### PR TITLE
ci: harden PR title check and enforce CODEOWNERS review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for easySFTP.
+#
+# Every change requires review from the owner below. Combined with branch
+# protection ("Require review from Code Owners") this blocks unreviewed merges,
+# including changes to the CI workflows and the action itself from fork PRs.
+
+* @eiserv69

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,10 +5,15 @@ name: PR Title
 # parseable so versioning and the changelog stay correct.
 
 on:
-  pull_request_target:
+  # pull_request (never pull_request_target): validating the title needs no
+  # secrets and never checks out the PR's code, so it runs safely on fork PRs
+  # with the default read-only, secret-less token. This avoids the privilege-
+  # escalation surface that pull_request_target opens on untrusted contributions.
+  pull_request:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:


### PR DESCRIPTION
This pull request introduces improvements to repository security and workflow configuration. The most important changes are the addition of a `CODEOWNERS` file to enforce code review ownership, and a safer configuration for the pull request title workflow.

Repository ownership and security:

* Added a `.github/CODEOWNERS` file assigning repository ownership to `@eiserv69`, ensuring all changes require review from this user.

Workflow configuration and security:

* Updated `.github/workflows/pr-title.yml` to use the `pull_request` event instead of `pull_request_target`, reducing the risk of privilege escalation from forked pull requests. Also clarified permissions by explicitly setting `contents: read`.