### PR TITLE
docs: restructure documentation into docs/, add CONTRIBUTING and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer responsible for enforcement,
+[@eiserv](https://github.com/eiserv).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ by participating you agree to abide by it.
 - **Bugs:** include your workflow step (redact secrets!), the action version,
   the runner OS and the relevant log output. A `dry-run: true` log is often
   enough to reproduce planning problems.
-- **Security vulnerabilities:** do **not** open a public issue — see
+- **Security vulnerabilities:** do **not** open a public issue, see
   [SECURITY.md](SECURITY.md).
 - **Features:** describe the use case, not just the solution. Issues labeled
   [`good first issue`](https://github.com/eiserv/easySFTP/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
@@ -22,7 +22,7 @@ by participating you agree to abide by it.
 
 ## Development setup
 
-You need [Go](https://go.dev/dl/) (version from [go.mod](go.mod)) — nothing
+You need [Go](https://go.dev/dl/) (version from [go.mod](go.mod)), nothing
 else. No Docker required for tests.
 
 ```console
@@ -48,8 +48,8 @@ docs/                    user documentation
 
 ### Running the binary locally
 
-The binary is configured entirely through `EASYSFTP_*` environment variables —
-see [action.yml](action.yml) for the mapping. Example against a local SFTP
+The binary is configured entirely through `EASYSFTP_*` environment variables.
+See [action.yml](action.yml) for the mapping. Example against a local SFTP
 server:
 
 ```console
@@ -78,7 +78,7 @@ $ EASYSFTP_SERVER=localhost EASYSFTP_PORT=2222 \
 ### PR title = Conventional Commit (required)
 
 PRs are **squash-merged**, so the PR title becomes the commit message and must
-be a [Conventional Commit](https://www.conventionalcommits.org/) — CI enforces
+be a [Conventional Commit](https://www.conventionalcommits.org/). CI enforces
 this. The prefix decides the release bump
 (see [docs/RELEASING.md](docs/RELEASING.md)):
 
@@ -99,5 +99,5 @@ this. The prefix decides the release bump
 - Destructive-path changes (anything that deletes remote files) keep the
   [delete guards](docs/strategies.md#delete-guards) intact.
 
-Releases are fully automated — you never bump versions or edit the changelog
+Releases are fully automated: you never bump versions or edit the changelog
 by hand. Merged `feat:`/`fix:` PRs ship with the next release PR merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to easySFTP
+
+Thanks for your interest in contributing! Bug reports, documentation fixes and
+features are all welcome. This document tells you everything you need to get a
+change merged.
+
+Please note that this project has a [Code of Conduct](CODE_OF_CONDUCT.md);
+by participating you agree to abide by it.
+
+## Reporting bugs & requesting features
+
+- Search the [existing issues](https://github.com/eiserv/easySFTP/issues) first.
+- **Bugs:** include your workflow step (redact secrets!), the action version,
+  the runner OS and the relevant log output. A `dry-run: true` log is often
+  enough to reproduce planning problems.
+- **Security vulnerabilities:** do **not** open a public issue — see
+  [SECURITY.md](SECURITY.md).
+- **Features:** describe the use case, not just the solution. Issues labeled
+  [`good first issue`](https://github.com/eiserv/easySFTP/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+  are a great place to start; comment on an issue before starting bigger work
+  so nobody duplicates effort.
+
+## Development setup
+
+You need [Go](https://go.dev/dl/) (version from [go.mod](go.mod)) — nothing
+else. No Docker required for tests.
+
+```console
+$ git clone https://github.com/eiserv/easySFTP.git
+$ cd easySFTP
+$ go test ./...            # unit + end-to-end tests (in-process SFTP server)
+$ go vet ./...
+$ gofmt -l .               # must print nothing
+$ go build ./cmd/easysftp
+```
+
+### Repository layout
+
+```
+action.yml               the composite action: inputs → EASYSFTP_* env vars
+cmd/easysftp/            binary entry point
+internal/config/         env + YAML config parsing and validation
+internal/uploader/       SFTP connection, planning, strategies, transfers
+internal/gha/            GitHub Actions helpers (outputs, annotations, summary)
+schema/                  JSON Schema for the YAML config file
+docs/                    user documentation
+```
+
+### Running the binary locally
+
+The binary is configured entirely through `EASYSFTP_*` environment variables —
+see [action.yml](action.yml) for the mapping. Example against a local SFTP
+server:
+
+```console
+$ EASYSFTP_SERVER=localhost EASYSFTP_PORT=2222 \
+  EASYSFTP_USERNAME=demo EASYSFTP_PASSWORD=demopass \
+  EASYSFTP_UPLOADS="./dist/ => /upload/" EASYSFTP_DRY_RUN=true \
+  go run ./cmd/easysftp
+```
+
+### Tests
+
+- Unit and end-to-end tests run against an **in-process SFTP server**
+  ([internal/uploader/testserver_test.go](internal/uploader/testserver_test.go)),
+  so `go test ./...` needs no network and no Docker.
+- CI additionally runs the whole action against a real OpenSSH server
+  ([.github/workflows/ci.yml](.github/workflows/ci.yml)) on Linux and runs the
+  unit tests on Windows.
+- New behavior needs a test. Bug fixes need a test that fails without the fix.
+
+## Pull requests
+
+1. Fork, create a branch, make your change.
+2. Make sure `go test ./...`, `go vet ./...` and `gofmt -l .` are clean.
+3. Open a PR against `main`.
+
+### PR title = Conventional Commit (required)
+
+PRs are **squash-merged**, so the PR title becomes the commit message and must
+be a [Conventional Commit](https://www.conventionalcommits.org/) — CI enforces
+this. The prefix decides the release bump
+(see [docs/RELEASING.md](docs/RELEASING.md)):
+
+| Prefix | Effect | Example |
+|---|---|---|
+| `fix:` | patch release | `fix: retry on transient EOF` |
+| `feat:` | minor release | `feat: add keepalive support` |
+| `feat!:` / `BREAKING CHANGE:` | major release | `feat!: fail without host key` |
+| `docs:` `ci:` `chore:` `refactor:` `test:` `build:` `perf:` | no release | `docs: fix typo` |
+
+### Review checklist (what the maintainer looks for)
+
+- Behavior changes are covered by tests and documented (README / `docs/` /
+  `action.yml` input descriptions).
+- No new dependencies unless truly needed.
+- Errors are wrapped with context (`fmt.Errorf("...: %w", err)`), log output
+  goes through the `Logger`/`gha` helpers.
+- Destructive-path changes (anything that deletes remote files) keep the
+  [delete guards](docs/strategies.md#delete-guards) intact.
+
+Releases are fully automated — you never bump versions or edit the changelog
+by hand. Merged `feat:`/`fix:` PRs ship with the next release PR merge.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Fast, secure and simple SFTP uploads for GitHub Actions.**
 
-Deploy your build output to any SFTP server — from a three-line workflow step
+Deploy your build output to any SFTP server, from a three-line workflow step
 up to fully configured multi-target deployments.
 
 - ⚡ **Fast**: written in Go, files are transferred in parallel with concurrent
@@ -17,10 +17,11 @@ up to fully configured multi-target deployments.
   gitignore-style excludes, sync/clean strategies, delete guards, dry runs,
   retries and outputs for the complex ones.
 - 🖥️ **Cross-platform**: runs natively on `ubuntu-*`, `macos-*` and
-  `windows-*` runners — no Docker required.
+  `windows-*` runners, with no Docker required.
 
 ## Table of contents
 
+- [Why easySFTP?](#why-easysftp)
 - [Quick start](#quick-start)
 - [Inputs & outputs](#inputs--outputs)
 - [Strategies](#strategies)
@@ -28,9 +29,55 @@ up to fully configured multi-target deployments.
 - [Security](#security)
 - [Documentation](#documentation)
 - [Versioning](#versioning)
-- [Why another SFTP action?](#why-another-sftp-action)
 - [Contributing](#contributing)
 - [License](#license)
+
+## Why easySFTP?
+
+I needed an SFTP upload step for a GitHub Actions deploy, and none of the
+existing options really fit. They were either no longer actively maintained,
+not resource-friendly, hard or barely configurable, or they simply did not work
+reliably. So I built my own and made it available for everyone with the same
+problem: an action that stays out of your way for the simple case and still
+handles the complex ones.
+
+Here is how easySFTP compares to other open-source actions that tackle the same
+job:
+
+| Feature | easySFTP | [Dylan700/sftp&#8209;upload&#8209;action][dylan] | [SamKirkland/FTP&#8209;Deploy&#8209;Action][sam] | [wlixcc/SFTP&#8209;Deploy&#8209;Action][wlixcc] | [wangyucode/sftp&#8209;upload&#8209;action][wang] |
+|---|---|---|---|---|---|
+| Protocol | SFTP | SFTP | FTP / FTPS only | SFTP | SFTP |
+| Implementation | Go binary | Node.js | Node.js | Docker (rsync) | Python |
+| Linux / macOS / Windows | yes / yes / yes | yes / yes / yes | yes / yes / yes | Linux only (Docker) | needs Python on runner |
+| Host key verification | yes (pinned fingerprints) | no | n/a | not documented | not documented |
+| Atomic per-file upload | yes | no | no | rsync temp file | no |
+| Skip unchanged files | yes (SHA256 manifest) | no | yes (state file) | partial (rsync) | yes (MD5 hashes) |
+| Delete removed files | yes (tracked, via sync) | yes (full wipe) | yes | yes (full wipe) | yes (tracked) |
+| Delete safety guards | yes (root refusal, max_deletes) | no | no | no | no |
+| Multiple targets / strategies | yes (config file) | multiple mappings | single directory | single directory | single directory |
+| Dry run | yes | no | yes | no | no |
+| Actively maintained | yes | last release 2024 | yes | yes | yes |
+
+The matrix reflects each project's public documentation as of July 2026.
+"Not documented" means the feature was not found in that action's README, not
+that it is impossible. SamKirkland's FTP-Deploy-Action is by far the most
+popular deploy action, but it speaks FTP/FTPS rather than SFTP, so it is listed
+for context rather than as a direct SFTP alternative.
+
+easySFTP is a clean, from-scratch implementation in Go, inspired by the
+no-longer-maintained [Dylan700/sftp-upload-action][dylan]:
+
+- compiled static binary instead of a Node.js runtime (fast startup, parallel transfers)
+- works on Linux, macOS **and** Windows runners, with no Docker required
+- host key verification, atomic uploads, retries with backoff, structured
+  outputs and a job summary
+- end-to-end test suite against an in-process SFTP server, plus a CI self-test
+  against a real OpenSSH server
+
+[dylan]: https://github.com/Dylan700/sftp-upload-action
+[sam]: https://github.com/SamKirkland/FTP-Deploy-Action
+[wlixcc]: https://github.com/wlixcc/SFTP-Deploy-Action
+[wang]: https://github.com/wangyucode/sftp-upload-action
 
 ## Quick start
 
@@ -44,8 +91,8 @@ up to fully configured multi-target deployments.
     uploads: ./dist/ => /var/www/html/
 ```
 
-That's it. Everything else is optional. More recipes — key auth, multi-target
-deploys, PR previews, `.sftpignore` — live in [docs/examples.md](docs/examples.md).
+That's it. Everything else is optional. More recipes (key auth, multi-target
+deploys, PR previews, `.sftpignore`) live in [docs/examples.md](docs/examples.md).
 
 ## Inputs & outputs
 
@@ -53,17 +100,17 @@ The most used inputs:
 
 | Input | Default | Description |
 |---|---|---|
-| `server` / `port` / `username` | — / `22` / — | Where and as whom to connect. |
-| `password` / `private-key` / `passphrase` | — | Authentication — at least one of password/key. **Use secrets.** |
-| `host-key-fingerprint` | — | Pin the server's SHA256 host key(s). **Strongly recommended.** |
-| `uploads` | — | One `local => remote` mapping per line; directories are recursive. |
+| `server` / `port` / `username` | - / `22` / - | Where and as whom to connect. |
+| `password` / `private-key` / `passphrase` | - | Authentication, at least one of password/key. **Use secrets.** |
+| `host-key-fingerprint` | - | Pin the server's SHA256 host key(s). **Strongly recommended.** |
+| `uploads` | - | One `local => remote` mapping per line; directories are recursive. |
 | `strategy` | `overlay` | How the remote side is reconciled: `overlay`, `sync` or `clean`. |
-| `ignore` / `ignore-from` | — | Gitignore-style excludes (inline / from a file). |
+| `ignore` / `ignore-from` | - | Gitignore-style excludes (inline / from a file). |
 | `dry-run` | `false` | Log what would happen, change nothing. |
 | `concurrency` / `retries` / `timeout` | `4` / `2` / `30` | Parallelism, per-file retries, connection timeout (s). |
 
 Outputs: `files-uploaded`, `files-deleted`, `files-skipped`, `bytes-uploaded`,
-`duration-ms` — plus a summary table in the job summary.
+`duration-ms`, plus a summary table in the job summary.
 
 ➡ Full reference with every input, output and rule:
 [docs/configuration.md](docs/configuration.md)
@@ -76,7 +123,7 @@ Outputs: `files-uploaded`, `files-deleted`, `files-skipped`, `bytes-uploaded`,
 | `sync` | new & changed files | files a previous sync uploaded but that are now gone locally | keeping a directory an exact mirror of your build, safely |
 | `clean` | all files | **everything** in the remote target first | a guaranteed-fresh deploy |
 
-`sync` is manifest-based — it only ever deletes files it uploaded itself, skips
+`sync` is manifest-based: it only ever deletes files it uploaded itself, skips
 unchanged files by content hash, and re-deploys only transfer what changed.
 Destructive strategies are protected by [delete guards](docs/strategies.md#delete-guards):
 the remote root is always refused, and `max_deletes` caps how much a single run
@@ -103,7 +150,7 @@ targets:
     strategy: clean
 ```
 
-A JSON Schema for editor autocomplete/validation is bundled — see
+A JSON Schema for editor autocomplete/validation is bundled. See
 [docs/configuration.md](docs/configuration.md#the-yaml-config-file) and the
 commented [example config](docs/easysftp.example.yml).
 
@@ -112,7 +159,7 @@ commented [example config](docs/easysftp.example.yml).
 Two rules cover most of it:
 
 1. **Pin the host key.** Without `host-key-fingerprint`, any server is
-   accepted — set it so a man-in-the-middle fails the deploy instead:
+   accepted. Set it so a man-in-the-middle fails the deploy instead:
 
    ```console
    $ ssh-keyscan sftp.example.com | ssh-keygen -lf -
@@ -139,25 +186,13 @@ Vulnerability reports: [SECURITY.md](SECURITY.md)
 easySFTP follows [Semantic Versioning](https://semver.org):
 
 ```yaml
-uses: eiserv/easySFTP@v1        # latest 1.x — recommended, gets fixes & features
+uses: eiserv/easySFTP@v1        # latest 1.x, recommended, gets fixes & features
 uses: eiserv/easySFTP@v1.2.3    # exact, immutable pin
 ```
 
 `v1`/`v1.2` are rolling tags; `v1.2.3` and commit SHAs never move. Releases and
-the changelog are generated automatically from Conventional Commits — see
+the changelog are generated automatically from Conventional Commits. See
 [docs/RELEASING.md](docs/RELEASING.md).
-
-## Why another SFTP action?
-
-This project is inspired by [Dylan700/sftp-upload-action](https://github.com/Dylan700/sftp-upload-action),
-which is no longer actively maintained. easySFTP is a clean reimplementation in Go:
-
-- compiled static binary instead of a Node.js runtime (fast startup, parallel transfers)
-- works on Linux, macOS **and** Windows runners (no Docker required)
-- host key verification, atomic uploads, retries with backoff, structured
-  outputs and a job summary
-- end-to-end test suite against an in-process SFTP server, plus a CI self-test
-  against a real OpenSSH server
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,32 @@
 
 **Fast, secure and simple SFTP uploads for GitHub Actions.**
 
-Deploy your build output to any SFTP server — from a three-line workflow step up to
-fully configured multi-target deployments.
+Deploy your build output to any SFTP server — from a three-line workflow step
+up to fully configured multi-target deployments.
 
 - ⚡ **Fast**: written in Go, files are transferred in parallel with concurrent
   SFTP write requests per file.
 - 🔒 **Secure**: optional host key pinning verifies the server's identity;
-  credentials are only ever read from environment variables.
-- 🧩 **Simple, but configurable**: sensible defaults for the simple case,
-  gitignore-style excludes, delete mode, dry runs, retries and outputs for the
-  complex ones.
-- 🖥️ **Cross-platform**: runs on `ubuntu-*`, `macos-*` and `windows-*` runners.
+  atomic per-file uploads never leave half-written files; credentials are only
+  ever read from environment variables.
+- 🧩 **Simple, but configurable**: sensible defaults for the simple case;
+  gitignore-style excludes, sync/clean strategies, delete guards, dry runs,
+  retries and outputs for the complex ones.
+- 🖥️ **Cross-platform**: runs natively on `ubuntu-*`, `macos-*` and
+  `windows-*` runners — no Docker required.
+
+## Table of contents
+
+- [Quick start](#quick-start)
+- [Inputs & outputs](#inputs--outputs)
+- [Strategies](#strategies)
+- [Config file for multiple targets](#config-file-for-multiple-targets)
+- [Security](#security)
+- [Documentation](#documentation)
+- [Versioning](#versioning)
+- [Why another SFTP action?](#why-another-sftp-action)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Quick start
 
@@ -29,144 +44,56 @@ fully configured multi-target deployments.
     uploads: ./dist/ => /var/www/html/
 ```
 
-That's it. Everything else is optional.
+That's it. Everything else is optional. More recipes — key auth, multi-target
+deploys, PR previews, `.sftpignore` — live in [docs/examples.md](docs/examples.md).
 
-## Full example
+## Inputs & outputs
 
-```yaml
-name: Deploy
+The most used inputs:
 
-on:
-  push:
-    branches: [main]
+| Input | Default | Description |
+|---|---|---|
+| `server` / `port` / `username` | — / `22` / — | Where and as whom to connect. |
+| `password` / `private-key` / `passphrase` | — | Authentication — at least one of password/key. **Use secrets.** |
+| `host-key-fingerprint` | — | Pin the server's SHA256 host key(s). **Strongly recommended.** |
+| `uploads` | — | One `local => remote` mapping per line; directories are recursive. |
+| `strategy` | `overlay` | How the remote side is reconciled: `overlay`, `sync` or `clean`. |
+| `ignore` / `ignore-from` | — | Gitignore-style excludes (inline / from a file). |
+| `dry-run` | `false` | Log what would happen, change nothing. |
+| `concurrency` / `retries` / `timeout` | `4` / `2` / `30` | Parallelism, per-file retries, connection timeout (s). |
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
+Outputs: `files-uploaded`, `files-deleted`, `files-skipped`, `bytes-uploaded`,
+`duration-ms` — plus a summary table in the job summary.
 
-      # ... build your project ...
-
-      - name: Deploy via SFTP
-        id: deploy
-        uses: eiserv/easySFTP@v1
-        with:
-          server: sftp.example.com
-          port: 22
-          username: ${{ secrets.SFTP_USERNAME }}
-          private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
-          passphrase: ${{ secrets.SFTP_PASSPHRASE }}
-          host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-          uploads: |
-            ./dist/ => /var/www/html/
-            ./docs/ => /var/www/docs/
-            ./robots.txt => /var/www/html/robots.txt
-          ignore: |
-            *.map
-            *.log
-            node_modules/
-          delete: true
-          concurrency: 8
-
-      - name: Report
-        run: echo "Uploaded ${{ steps.deploy.outputs.files-uploaded }} files (${{ steps.deploy.outputs.bytes-uploaded }} bytes) in ${{ steps.deploy.outputs.duration-ms }} ms"
-```
-
-## Inputs
-
-| Input | Required | Default | Description |
-|---|---|---|---|
-| `server` | ✅ | — | Hostname or IP of the SFTP server. |
-| `port` | | `22` | SSH port. |
-| `username` | ✅ | — | Username for authentication. |
-| `password` | ¹ | — | Password. **Use a secret.** |
-| `private-key` | ¹ | — | SSH private key (OpenSSH/PEM format). **Use a secret.** |
-| `passphrase` | | — | Passphrase of the private key, if encrypted. |
-| `host-key-fingerprint` | | — | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). **Strongly recommended**, see [Security](#security). |
-| `uploads` | ² | — | One `local => remote` mapping per line. Directories are uploaded recursively; single files are supported too. |
-| `config-file` | | — | Path to a [YAML config file](#config-file) with per-target strategies and delete guards. Replaces `uploads`/`strategy`/`delete`/`ignore`. |
-| `strategy` | | `overlay` | [Reconciliation strategy](#strategies): `overlay`, `sync` or `clean`. |
-| `ignore` | | — | Gitignore-style exclude patterns, one per line. `!` re-includes. |
-| `ignore-from` | | — | Path to a file with exclude patterns (e.g. `.sftpignore`). |
-| `delete` | | `false` | Legacy alias for `strategy: clean`. Prefer `strategy`. |
-| `dry-run` | | `false` | Connect and log what would happen, change nothing. |
-| `concurrency` | | `4` | Number of files uploaded in parallel. |
-| `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). |
-| `timeout` | | `30` | Connection timeout in seconds. |
-
-¹ At least one of `password` / `private-key` is required. If both are set, the key is tried first.
-² Required unless `config-file` is set.
-
-### The `uploads` mapping
-
-```yaml
-uploads: |
-  # directory => directory (recursive)
-  ./dist/ => /var/www/html/
-
-  # single file => exact remote path (rename on the fly)
-  ./config/prod.json => /etc/app/config.json
-
-  # single file => into a remote directory (note the trailing slash)
-  ./robots.txt => /var/www/html/
-```
-
-Remote directories are created automatically.
+➡ Full reference with every input, output and rule:
+[docs/configuration.md](docs/configuration.md)
 
 ## Strategies
 
-How each target's remote directory is reconciled with your local files:
-
 | Strategy | Uploads | Deletes | Use for |
 |---|---|---|---|
-| `overlay` (default) | new & changed files | nothing | adding/updating files, leaving everything else in place |
+| `overlay` (default) | all files | nothing | adding/updating files, leaving everything else in place |
 | `sync` | new & changed files | files a previous sync uploaded but that are now gone locally | keeping a directory an exact mirror of your build, safely |
 | `clean` | all files | **everything** in the remote target first | a guaranteed-fresh deploy |
 
-`sync` is **manifest-based**: it keeps a small `.easysftp-manifest.json` in each
-target listing what it uploaded, so it only ever deletes files it manages —
-files put on the server by anyone else are never touched. Unchanged files
-(compared by content hash) are skipped, so re-deploys only transfer what
-actually changed.
+`sync` is manifest-based — it only ever deletes files it uploaded itself, skips
+unchanged files by content hash, and re-deploys only transfer what changed.
+Destructive strategies are protected by [delete guards](docs/strategies.md#delete-guards):
+the remote root is always refused, and `max_deletes` caps how much a single run
+may delete. Preview anything with `dry-run: true`.
 
-Preview any strategy without touching the server with `dry-run: true` — the log
-shows exactly what would be uploaded, skipped and deleted.
+➡ Details, manifest semantics and guard rules: [docs/strategies.md](docs/strategies.md)
 
-### Delete guards
+## Config file for multiple targets
 
-Before `sync` or `clean` delete anything:
-
-- **Remote root is refused.** A target that resolves to `/` (or `.`) is rejected
-  outright — no strategy will ever wipe a server root.
-- **`max_deletes`** (config file only) aborts a run that would delete more files
-  than the limit, catching a misconfiguration before it does damage.
-
-## Config file
-
-For multiple targets with different strategies, point `config-file` at a YAML
-file instead of using the plain inputs (connection settings stay in inputs/secrets):
-
-```yaml
-- name: Deploy via SFTP
-  uses: eiserv/easySFTP@v1
-  with:
-    server: sftp.example.com
-    username: ${{ secrets.SFTP_USERNAME }}
-    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
-    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-    config-file: .github/easysftp.yml
-```
+Multiple targets with different strategies? Point `config-file` at a YAML file
+(connection settings stay in inputs/secrets):
 
 ```yaml
 # .github/easysftp.yml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/eiserv/easySFTP/main/schema/easysftp.schema.json
 version: 1
-strategy: overlay          # default for all targets
-ignore:
-  - "*.map"
 guards:
-  max_deletes: 200         # 0 = unlimited
+  max_deletes: 200
 targets:
   - local: ./dist/
     remote: /var/www/html/
@@ -176,72 +103,49 @@ targets:
     strategy: clean
 ```
 
-The `# yaml-language-server` modeline enables autocomplete and validation in
-editors from the bundled [JSON Schema](schema/easysftp.schema.json). See
-[docs/easysftp.example.yml](docs/easysftp.example.yml) for a fully commented
-example. `config-file` and the `uploads`/`strategy`/`delete`/`ignore` inputs are
-mutually exclusive.
-
-## Outputs
-
-| Output | Description |
-|---|---|
-| `files-uploaded` | Number of uploaded files (planned files in dry-run mode). |
-| `files-deleted` | Number of remote files removed by the `clean`/`sync` strategy. |
-| `files-skipped` | Number of unchanged files skipped by the `sync` strategy. |
-| `bytes-uploaded` | Total bytes transferred. |
-| `duration-ms` | Total runtime in milliseconds. |
-
-A summary table is also written to the job summary of every run.
-
-## Versioning
-
-easySFTP follows [Semantic Versioning](https://semver.org). Pick the pin that
-matches how much you want to move:
-
-```yaml
-uses: eiserv/easySFTP@v1        # latest 1.x — recommended, gets fixes & features
-uses: eiserv/easySFTP@v1.2      # latest 1.2.x patch
-uses: eiserv/easySFTP@v1.2.3    # exact, immutable pin
-```
-
-`v1` and `v1.2` are rolling tags that advance with each release; `v1.2.3` (and
-the commit SHA) never move. Releases, tags and the changelog are generated
-automatically from [Conventional Commits](https://www.conventionalcommits.org/) —
-see [docs/RELEASING.md](docs/RELEASING.md).
+A JSON Schema for editor autocomplete/validation is bundled — see
+[docs/configuration.md](docs/configuration.md#the-yaml-config-file) and the
+commented [example config](docs/easysftp.example.yml).
 
 ## Security
 
-### Pin the host key (recommended)
+Two rules cover most of it:
 
-Without `host-key-fingerprint`, easySFTP prints a warning and accepts any host
-key — convenient, but vulnerable to man-in-the-middle attacks. Pin your
-server's keys once:
+1. **Pin the host key.** Without `host-key-fingerprint`, any server is
+   accepted — set it so a man-in-the-middle fails the deploy instead:
 
-```console
-$ ssh-keyscan sftp.example.com | ssh-keygen -lf -
-256  SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8 sftp.example.com (ED25519)
-256  SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM sftp.example.com (ECDSA)
-3072 SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s sftp.example.com (RSA)
-```
+   ```console
+   $ ssh-keyscan sftp.example.com | ssh-keygen -lf -
+   ```
 
-Store the `SHA256:...` values as a secret (one per line) and pass them as
-`host-key-fingerprint` — the connection is accepted if the server presents a
-key matching any of them:
+2. **Keep credentials in encrypted secrets**, prefer key-based auth, and use a
+   least-privilege deploy account.
+
+➡ Full guide (key setup, chroot, SHA pinning): [docs/security.md](docs/security.md) ·
+Vulnerability reports: [SECURITY.md](SECURITY.md)
+
+## Documentation
+
+| | |
+|---|---|
+| [Configuration reference](docs/configuration.md) | All inputs, outputs, mappings, ignore rules, config file. |
+| [Strategies](docs/strategies.md) | `overlay`/`sync`/`clean`, manifest, delete guards, dry runs. |
+| [Examples & use cases](docs/examples.md) | Copy-paste recipes for common deployments. |
+| [Security guide](docs/security.md) | Host key pinning, credentials, supply chain. |
+| [Troubleshooting & FAQ](docs/troubleshooting.md) | Common errors and fixes. |
+
+## Versioning
+
+easySFTP follows [Semantic Versioning](https://semver.org):
 
 ```yaml
-host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINTS }}
+uses: eiserv/easySFTP@v1        # latest 1.x — recommended, gets fixes & features
+uses: eiserv/easySFTP@v1.2.3    # exact, immutable pin
 ```
 
-If the server's keys ever change unexpectedly, the deploy fails instead of
-talking to an impostor.
-
-### Credentials
-
-Always store `password`, `private-key` and `passphrase` as
-[encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
-— never hardcode them in the workflow. easySFTP receives them via environment
-variables and never prints them.
+`v1`/`v1.2` are rolling tags; `v1.2.3` and commit SHAs never move. Releases and
+the changelog are generated automatically from Conventional Commits — see
+[docs/RELEASING.md](docs/RELEASING.md).
 
 ## Why another SFTP action?
 
@@ -250,21 +154,18 @@ which is no longer actively maintained. easySFTP is a clean reimplementation in 
 
 - compiled static binary instead of a Node.js runtime (fast startup, parallel transfers)
 - works on Linux, macOS **and** Windows runners (no Docker required)
-- host key verification, retries with backoff, structured outputs and a job summary
-- end-to-end test suite that runs against a real in-process SFTP server
-  plus a CI self-test against a real OpenSSH server
+- host key verification, atomic uploads, retries with backoff, structured
+  outputs and a job summary
+- end-to-end test suite against an in-process SFTP server, plus a CI self-test
+  against a real OpenSSH server
 
-## Development
+## Contributing
 
-```console
-$ go test ./...   # unit + end-to-end tests (in-process SFTP server, no Docker needed)
-$ go vet ./...
-$ go build ./cmd/easysftp
-```
-
-The binary is configured entirely through `EASYSFTP_*` environment variables —
-see [action.yml](action.yml) for the mapping. CI additionally runs the action
-against a real OpenSSH SFTP server (see [.github/workflows/ci.yml](.github/workflows/ci.yml)).
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev
+setup, test suite and PR conventions, and the
+[good first issues](https://github.com/eiserv/easySFTP/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+for places to start. This project follows a
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   config-file:
     description: >-
       Path to an optional YAML config file describing the deployment targets,
-      their strategy and delete guards (see docs/CONFIG.md). When set, it
+      their strategy and delete guards (see docs/configuration.md). When set, it
       replaces the uploads/strategy/delete/ignore inputs. Connection settings
       always come from the inputs above.
     required: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# easySFTP documentation
+
+| Document | What's in it |
+|---|---|
+| [Configuration reference](configuration.md) | Every input, output, the `uploads` mapping, ignore patterns and the YAML config file. |
+| [Strategies](strategies.md) | `overlay` vs. `sync` vs. `clean`, the sync manifest, delete guards, dry runs. |
+| [Examples & use cases](examples.md) | Copy-paste recipes: static sites, mirroring, multi-target deploys, PR previews, outputs. |
+| [Security guide](security.md) | Host key pinning, credential handling, least privilege, supply-chain safety. |
+| [Troubleshooting & FAQ](troubleshooting.md) | Common errors and what to do about them. |
+| [Releasing](RELEASING.md) | How releases, tags and the changelog are automated (maintainers). |
+| [easysftp.example.yml](easysftp.example.yml) | Fully commented example config file. |
+
+New here? Start with the [README](../README.md) quick start, then the
+[examples](examples.md).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -71,7 +71,7 @@ targeting `main`:
   - `Validate Conventional Commit title`
 - ✅ Require branches to be up to date before merging.
 - ✅ Block force pushes.
-- ✅ (Recommended) Require a linear history — matches the squash-merge model.
+- ✅ (Recommended) Require a linear history, matches the squash-merge model.
 
 > Do **not** require signed commits or a second approving review on a
 > single-maintainer repo unless you are prepared to review Release Please and
@@ -83,7 +83,7 @@ targeting `main`:
 
 - **Target tags** by pattern (fnmatch): `v*.*.*`
   This matches exact three-part tags like `v1.2.3` **but not** `v1` or `v1.2`.
-- ✅ **Restrict updates** and ✅ **Restrict deletions** — makes `vX.Y.Z`
+- ✅ **Restrict updates** and ✅ **Restrict deletions**, making `vX.Y.Z`
   immutable once published.
 - Leave `v1` and `v1.*` **unprotected** so the `update-major-tags` job can
   force-move them. (If you add a second ruleset for those, it must allow the
@@ -98,4 +98,4 @@ exact tags than the ruleset alone.
 [Dependabot](../.github/dependabot.yml) opens weekly grouped PRs for Go modules
 (`build(deps): ...`) and pinned GitHub Actions (`ci(deps): ...`). Both prefixes
 are Conventional Commits, so they pass the PR-title check and are hidden from the
-changelog. Review, let CI pass, and merge — no release is cut for them alone.
+changelog. Review, let CI pass, and merge. No release is cut for them alone.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,13 +14,13 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `server` | ✅ | — | Hostname or IP of the SFTP server. |
+| `server` | ✅ | - | Hostname or IP of the SFTP server. |
 | `port` | | `22` | SSH port. |
-| `username` | ✅ | — | Username for authentication. |
-| `password` | ¹ | — | Password. **Use a secret.** |
-| `private-key` | ¹ | — | SSH private key (OpenSSH/PEM format). **Use a secret.** |
-| `passphrase` | | — | Passphrase of the private key, if encrypted. |
-| `host-key-fingerprint` | | — | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). **Strongly recommended** — see [Security](security.md). |
+| `username` | ✅ | - | Username for authentication. |
+| `password` | ¹ | - | Password. **Use a secret.** |
+| `private-key` | ¹ | - | SSH private key (OpenSSH/PEM format). **Use a secret.** |
+| `passphrase` | | - | Passphrase of the private key, if encrypted. |
+| `host-key-fingerprint` | | - | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). **Strongly recommended**, see [Security](security.md). |
 | `timeout` | | `30` | Connection timeout in seconds. |
 
 ¹ At least one of `password` / `private-key` is required. If both are set, the key is tried first.
@@ -29,11 +29,11 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `uploads` | ² | — | One `local => remote` mapping per line. Directories are uploaded recursively; single files are supported too. |
-| `config-file` | | — | Path to a [YAML config file](#the-yaml-config-file) with per-target strategies and delete guards. Mutually exclusive with `uploads`/`strategy`/`delete`/`ignore`/`ignore-from`. |
+| `uploads` | ² | - | One `local => remote` mapping per line. Directories are uploaded recursively; single files are supported too. |
+| `config-file` | | - | Path to a [YAML config file](#the-yaml-config-file) with per-target strategies and delete guards. Mutually exclusive with `uploads`/`strategy`/`delete`/`ignore`/`ignore-from`. |
 | `strategy` | | `overlay` | [Reconciliation strategy](strategies.md): `overlay`, `sync` or `clean`. |
-| `ignore` | | — | Gitignore-style exclude patterns, one per line. `!` re-includes. |
-| `ignore-from` | | — | Path to a file with exclude patterns (e.g. `.sftpignore`). |
+| `ignore` | | - | Gitignore-style exclude patterns, one per line. `!` re-includes. |
+| `ignore-from` | | - | Path to a file with exclude patterns (e.g. `.sftpignore`). |
 | `delete` | | `false` | Legacy alias for `strategy: clean`. Prefer `strategy`. |
 
 ² Required unless `config-file` is set.
@@ -78,7 +78,7 @@ uploads: |
 Rules:
 
 - **Directories** are uploaded recursively. Remote directories are created automatically.
-- **Single files** map onto the exact remote path — unless the remote side ends
+- **Single files** map onto the exact remote path, unless the remote side ends
   with `/`, which means "into this directory" keeping the original file name.
 - Single files only support the `overlay` strategy (`sync`/`clean` reconcile a
   directory tree and are rejected for single-file targets).
@@ -106,7 +106,7 @@ ignore: |
 
 For multiple targets with different strategies, point `config-file` at a YAML
 file. Connection settings (server, credentials, host key) always stay in the
-action inputs — **never put credentials in this file**.
+action inputs. **Never put credentials in this file**.
 
 ```yaml
 - uses: eiserv/easySFTP@v1
@@ -140,15 +140,15 @@ targets:
 
 | Field | Required | Default | Description |
 |---|---|---|---|
-| `version` | ✅ | — | Config format version. Must be `1`. |
+| `version` | ✅ | - | Config format version. Must be `1`. |
 | `strategy` | | `overlay` | Default strategy for all targets. |
-| `ignore` | | — | Global gitignore-style excludes, applied to every target. |
+| `ignore` | | - | Global gitignore-style excludes, applied to every target. |
 | `guards.max_deletes` | | `0` | Abort a run that would delete more files than this (0 = unlimited). See [delete guards](strategies.md#delete-guards). |
-| `targets` | ✅ | — | List of upload targets (at least one). |
-| `targets[].local` | ✅ | — | Local file or directory. |
-| `targets[].remote` | ✅ | — | Remote path. |
+| `targets` | ✅ | - | List of upload targets (at least one). |
+| `targets[].local` | ✅ | - | Local file or directory. |
+| `targets[].remote` | ✅ | - | Remote path. |
 | `targets[].strategy` | | global | Per-target strategy override. |
-| `targets[].ignore` | | — | Per-target excludes, additive to the global list. |
+| `targets[].ignore` | | - | Per-target excludes, additive to the global list. |
 
 Unknown keys are rejected with an error (they are never silently ignored), and
 `config-file` cannot be combined with the `uploads`, `strategy`, `delete`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,162 @@
+# Configuration reference
+
+Everything easySFTP accepts: action inputs, outputs and the YAML config file.
+
+- [Inputs](#inputs)
+- [Outputs](#outputs)
+- [The `uploads` mapping](#the-uploads-mapping)
+- [Ignore patterns](#ignore-patterns)
+- [The YAML config file](#the-yaml-config-file)
+
+## Inputs
+
+### Connection
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `server` | ✅ | — | Hostname or IP of the SFTP server. |
+| `port` | | `22` | SSH port. |
+| `username` | ✅ | — | Username for authentication. |
+| `password` | ¹ | — | Password. **Use a secret.** |
+| `private-key` | ¹ | — | SSH private key (OpenSSH/PEM format). **Use a secret.** |
+| `passphrase` | | — | Passphrase of the private key, if encrypted. |
+| `host-key-fingerprint` | | — | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). **Strongly recommended** — see [Security](security.md). |
+| `timeout` | | `30` | Connection timeout in seconds. |
+
+¹ At least one of `password` / `private-key` is required. If both are set, the key is tried first.
+
+### What to upload
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `uploads` | ² | — | One `local => remote` mapping per line. Directories are uploaded recursively; single files are supported too. |
+| `config-file` | | — | Path to a [YAML config file](#the-yaml-config-file) with per-target strategies and delete guards. Mutually exclusive with `uploads`/`strategy`/`delete`/`ignore`/`ignore-from`. |
+| `strategy` | | `overlay` | [Reconciliation strategy](strategies.md): `overlay`, `sync` or `clean`. |
+| `ignore` | | — | Gitignore-style exclude patterns, one per line. `!` re-includes. |
+| `ignore-from` | | — | Path to a file with exclude patterns (e.g. `.sftpignore`). |
+| `delete` | | `false` | Legacy alias for `strategy: clean`. Prefer `strategy`. |
+
+² Required unless `config-file` is set.
+
+### Behavior
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `dry-run` | | `false` | Connect and log what would happen, change nothing. |
+| `concurrency` | | `4` | Number of files uploaded in parallel. |
+| `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `files-uploaded` | Number of uploaded files (planned files in dry-run mode). |
+| `files-deleted` | Number of remote files removed by the `clean`/`sync` strategy. |
+| `files-skipped` | Number of unchanged files skipped by the `sync` strategy. |
+| `bytes-uploaded` | Total bytes transferred. |
+| `duration-ms` | Total runtime in milliseconds. |
+
+A summary table is also written to the job summary of every run. See
+[examples](examples.md#using-the-outputs) for how to consume outputs in later steps.
+
+## The `uploads` mapping
+
+One mapping per line, `local => remote`. Lines starting with `#` are ignored.
+
+```yaml
+uploads: |
+  # directory => directory (recursive)
+  ./dist/ => /var/www/html/
+
+  # single file => exact remote path (rename on the fly)
+  ./config/prod.json => /etc/app/config.json
+
+  # single file => into a remote directory (note the trailing slash)
+  ./robots.txt => /var/www/html/
+```
+
+Rules:
+
+- **Directories** are uploaded recursively. Remote directories are created automatically.
+- **Single files** map onto the exact remote path — unless the remote side ends
+  with `/`, which means "into this directory" keeping the original file name.
+- Single files only support the `overlay` strategy (`sync`/`clean` reconcile a
+  directory tree and are rejected for single-file targets).
+- Symlinks, sockets and other non-regular files are skipped.
+
+## Ignore patterns
+
+`ignore` (inline) and `ignore-from` (a file, e.g. `.sftpignore`) use
+[gitignore syntax](https://git-scm.com/docs/gitignore):
+
+```yaml
+ignore: |
+  *.map
+  *.log
+  node_modules/
+  !important.log
+```
+
+- Patterns are matched against the path **relative to the local root** of each target.
+- `!pattern` re-includes files excluded by an earlier pattern.
+- `ignore` and `ignore-from` are additive; in the config file, per-target
+  `ignore` lists add to the global one.
+
+## The YAML config file
+
+For multiple targets with different strategies, point `config-file` at a YAML
+file. Connection settings (server, credentials, host key) always stay in the
+action inputs — **never put credentials in this file**.
+
+```yaml
+- uses: eiserv/easySFTP@v1
+  with:
+    server: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
+    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+    config-file: .github/easysftp.yml
+```
+
+```yaml
+# .github/easysftp.yml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/eiserv/easySFTP/main/schema/easysftp.schema.json
+version: 1
+strategy: overlay          # default for all targets
+ignore:
+  - "*.map"
+guards:
+  max_deletes: 200         # 0 = unlimited
+targets:
+  - local: ./dist/
+    remote: /var/www/html/
+    strategy: sync
+  - local: ./docs/
+    remote: /var/www/docs/
+    strategy: clean
+```
+
+### Fields
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `version` | ✅ | — | Config format version. Must be `1`. |
+| `strategy` | | `overlay` | Default strategy for all targets. |
+| `ignore` | | — | Global gitignore-style excludes, applied to every target. |
+| `guards.max_deletes` | | `0` | Abort a run that would delete more files than this (0 = unlimited). See [delete guards](strategies.md#delete-guards). |
+| `targets` | ✅ | — | List of upload targets (at least one). |
+| `targets[].local` | ✅ | — | Local file or directory. |
+| `targets[].remote` | ✅ | — | Remote path. |
+| `targets[].strategy` | | global | Per-target strategy override. |
+| `targets[].ignore` | | — | Per-target excludes, additive to the global list. |
+
+Unknown keys are rejected with an error (they are never silently ignored), and
+`config-file` cannot be combined with the `uploads`, `strategy`, `delete`,
+`ignore` or `ignore-from` inputs.
+
+### Editor support
+
+The `# yaml-language-server` modeline at the top of the file enables
+autocomplete and validation in editors from the bundled
+[JSON Schema](../schema/easysftp.schema.json). A fully commented example lives
+at [easysftp.example.yml](easysftp.example.yml).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -15,7 +15,7 @@ stored as [encrypted secrets](https://docs.github.com/en/actions/security-guides
 
 ## Deploy a static site
 
-The minimal setup — build, then upload the output on top of what's there:
+The minimal setup: build, then upload the output on top of what's there:
 
 ```yaml
 name: Deploy
@@ -43,7 +43,7 @@ jobs:
 ## Mirror a build with sync
 
 `sync` keeps the remote directory an exact mirror of your build output:
-unchanged files are skipped, files removed locally are deleted remotely — but
+unchanged files are skipped, files removed locally are deleted remotely, but
 only files easySFTP itself uploaded ([manifest-based](strategies.md#sync), so
 user uploads and server-generated files survive):
 
@@ -95,7 +95,7 @@ Full field reference: [configuration.md](configuration.md#the-yaml-config-file).
 
 ## Key-based authentication
 
-Preferred over passwords — see the [security guide](security.md#credentials):
+Preferred over passwords, see the [security guide](security.md#credentials):
 
 ```yaml
 - uses: eiserv/easySFTP@v1
@@ -110,7 +110,7 @@ Preferred over passwords — see the [security guide](security.md#credentials):
 
 ## Upload a single file (with rename)
 
-A single file maps onto the exact remote path — so you can rename on the fly.
+A single file maps onto the exact remote path, so you can rename on the fly.
 A trailing `/` on the remote side means "into this directory" instead:
 
 ```yaml
@@ -179,7 +179,7 @@ Keep the exclude list out of the workflow file:
 ```
 
 ```gitignore
-# .sftpignore — gitignore syntax
+# .sftpignore, gitignore syntax
 *.map
 *.log
 node_modules/
@@ -188,7 +188,7 @@ node_modules/
 
 ## Windows and macOS runners
 
-Nothing changes — easySFTP is a compiled Go binary and runs natively on
+Nothing changes: easySFTP is a compiled Go binary and runs natively on
 `ubuntu-*`, `macos-*` and `windows-*` runners (no Docker required):
 
 ```yaml

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,207 @@
+# Examples & use cases
+
+Copy-paste recipes for common deployments. All of them assume credentials are
+stored as [encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+
+- [Deploy a static site](#deploy-a-static-site)
+- [Mirror a build with sync](#mirror-a-build-with-sync)
+- [Multiple targets with a config file](#multiple-targets-with-a-config-file)
+- [Key-based authentication](#key-based-authentication)
+- [Upload a single file (with rename)](#upload-a-single-file-with-rename)
+- [Preview a deploy in pull requests](#preview-a-deploy-in-pull-requests)
+- [Using the outputs](#using-the-outputs)
+- [Excludes via .sftpignore](#excludes-via-sftpignore)
+- [Windows and macOS runners](#windows-and-macos-runners)
+
+## Deploy a static site
+
+The minimal setup — build, then upload the output on top of what's there:
+
+```yaml
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: npm ci && npm run build
+
+      - name: Deploy via SFTP
+        uses: eiserv/easySFTP@v1
+        with:
+          server: sftp.example.com
+          username: ${{ secrets.SFTP_USERNAME }}
+          password: ${{ secrets.SFTP_PASSWORD }}
+          host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+          uploads: ./dist/ => /var/www/html/
+```
+
+## Mirror a build with sync
+
+`sync` keeps the remote directory an exact mirror of your build output:
+unchanged files are skipped, files removed locally are deleted remotely — but
+only files easySFTP itself uploaded ([manifest-based](strategies.md#sync), so
+user uploads and server-generated files survive):
+
+```yaml
+- uses: eiserv/easySFTP@v1
+  with:
+    server: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    password: ${{ secrets.SFTP_PASSWORD }}
+    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+    uploads: ./dist/ => /var/www/html/
+    strategy: sync
+```
+
+## Multiple targets with a config file
+
+Different directories, different strategies, one connection:
+
+```yaml
+- uses: eiserv/easySFTP@v1
+  with:
+    server: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
+    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+    config-file: .github/easysftp.yml
+```
+
+```yaml
+# .github/easysftp.yml
+version: 1
+strategy: overlay
+ignore:
+  - "*.map"
+guards:
+  max_deletes: 200
+targets:
+  - local: ./dist/
+    remote: /var/www/html/
+    strategy: sync
+  - local: ./docs/
+    remote: /var/www/docs/
+    strategy: clean
+  - local: ./robots.txt
+    remote: /var/www/html/robots.txt
+```
+
+Full field reference: [configuration.md](configuration.md#the-yaml-config-file).
+
+## Key-based authentication
+
+Preferred over passwords — see the [security guide](security.md#credentials):
+
+```yaml
+- uses: eiserv/easySFTP@v1
+  with:
+    server: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
+    passphrase: ${{ secrets.SFTP_PASSPHRASE }}   # only if the key is encrypted
+    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+    uploads: ./dist/ => /var/www/html/
+```
+
+## Upload a single file (with rename)
+
+A single file maps onto the exact remote path — so you can rename on the fly.
+A trailing `/` on the remote side means "into this directory" instead:
+
+```yaml
+uploads: |
+  ./config/prod.json => /etc/app/config.json
+  ./robots.txt => /var/www/html/
+```
+
+## Preview a deploy in pull requests
+
+Run the real plan against the real server without changing anything, and post
+the numbers to the job summary:
+
+```yaml
+name: Deploy preview
+on: pull_request
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: npm ci && npm run build
+
+      - name: What would deploy?
+        uses: eiserv/easySFTP@v1
+        with:
+          server: sftp.example.com
+          username: ${{ secrets.SFTP_USERNAME }}
+          password: ${{ secrets.SFTP_PASSWORD }}
+          host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+          uploads: ./dist/ => /var/www/html/
+          strategy: sync
+          dry-run: true
+```
+
+## Using the outputs
+
+Give the step an `id` and read the outputs in later steps:
+
+```yaml
+- name: Deploy via SFTP
+  id: deploy
+  uses: eiserv/easySFTP@v1
+  with:
+    # ...
+
+- name: Report
+  run: |
+    echo "Uploaded ${{ steps.deploy.outputs.files-uploaded }} files"
+    echo "Deleted  ${{ steps.deploy.outputs.files-deleted }} files"
+    echo "Skipped  ${{ steps.deploy.outputs.files-skipped }} unchanged"
+    echo "${{ steps.deploy.outputs.bytes-uploaded }} bytes in ${{ steps.deploy.outputs.duration-ms }} ms"
+```
+
+## Excludes via .sftpignore
+
+Keep the exclude list out of the workflow file:
+
+```yaml
+- uses: eiserv/easySFTP@v1
+  with:
+    # ...
+    uploads: ./dist/ => /var/www/html/
+    ignore-from: .sftpignore
+```
+
+```gitignore
+# .sftpignore — gitignore syntax
+*.map
+*.log
+node_modules/
+!keep-this.log
+```
+
+## Windows and macOS runners
+
+Nothing changes — easySFTP is a compiled Go binary and runs natively on
+`ubuntu-*`, `macos-*` and `windows-*` runners (no Docker required):
+
+```yaml
+jobs:
+  deploy:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: eiserv/easySFTP@v1
+        with:
+          server: sftp.example.com
+          username: ${{ secrets.SFTP_USERNAME }}
+          password: ${{ secrets.SFTP_PASSWORD }}
+          host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+          uploads: .\build\ => /var/www/html/
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,7 +6,7 @@ How to run easySFTP safely. See also the project's
 ## Pin the host key (strongly recommended)
 
 Without `host-key-fingerprint`, easySFTP prints a warning and accepts **any**
-host key — convenient for a first test, but vulnerable to man-in-the-middle
+host key. Convenient for a first test, but vulnerable to man-in-the-middle
 attacks. Pin your server's keys once:
 
 ```console
@@ -17,7 +17,7 @@ $ ssh-keyscan sftp.example.com | ssh-keygen -lf -
 ```
 
 Store the `SHA256:...` values as a secret (one per line) and pass them as
-`host-key-fingerprint` — the connection is accepted if the server presents a
+`host-key-fingerprint`. The connection is accepted if the server presents a
 key matching **any** of them, so you can simply pin all of your server's keys:
 
 ```yaml
@@ -32,7 +32,7 @@ new fingerprints.
 
 - Always store `password`, `private-key` and `passphrase` as
   [encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
-  — never hardcode them in a workflow file.
+  and never hardcode them in a workflow file.
 - easySFTP receives credentials via environment variables and never prints them.
 - **Prefer key-based authentication** over passwords. Generate a dedicated
   deploy key and restrict what its account can do on the server:
@@ -61,6 +61,6 @@ new fingerprints.
   ```
 
 - Exact version tags (`v1.2.3`) are immutable once published; `v1` and `v1.2`
-  are rolling tags — see [RELEASING.md](RELEASING.md#tag-policy).
+  are rolling tags, see [RELEASING.md](RELEASING.md#tag-policy).
 - Grant the deploy job only the permissions it needs
   (`permissions: contents: read` is enough for easySFTP itself).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,66 @@
+# Security guide
+
+How to run easySFTP safely. See also the project's
+[security policy](../SECURITY.md) for reporting vulnerabilities.
+
+## Pin the host key (strongly recommended)
+
+Without `host-key-fingerprint`, easySFTP prints a warning and accepts **any**
+host key — convenient for a first test, but vulnerable to man-in-the-middle
+attacks. Pin your server's keys once:
+
+```console
+$ ssh-keyscan sftp.example.com | ssh-keygen -lf -
+256  SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8 sftp.example.com (ED25519)
+256  SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM sftp.example.com (ECDSA)
+3072 SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s sftp.example.com (RSA)
+```
+
+Store the `SHA256:...` values as a secret (one per line) and pass them as
+`host-key-fingerprint` — the connection is accepted if the server presents a
+key matching **any** of them, so you can simply pin all of your server's keys:
+
+```yaml
+host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINTS }}
+```
+
+If the server's keys ever change unexpectedly, the deploy fails instead of
+talking to an impostor. When you migrate servers, update the secret with the
+new fingerprints.
+
+## Credentials
+
+- Always store `password`, `private-key` and `passphrase` as
+  [encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+  — never hardcode them in a workflow file.
+- easySFTP receives credentials via environment variables and never prints them.
+- **Prefer key-based authentication** over passwords. Generate a dedicated
+  deploy key and restrict what its account can do on the server:
+
+  ```console
+  $ ssh-keygen -t ed25519 -f deploy_key -N "" -C "gh-actions deploy"
+  ```
+
+  Put the private key into a secret, the public key into the server's
+  `authorized_keys`.
+
+## Least privilege on the server
+
+- Use a dedicated deploy user that can only write to the deployment target,
+  not a personal or root account.
+- Consider a chrooted SFTP-only account (`ForceCommand internal-sftp` in
+  `sshd_config`) so the deploy credentials cannot open a shell.
+
+## Supply-chain safety
+
+- Pin the action to a major tag for convenience (`eiserv/easySFTP@v1`) or to a
+  full commit SHA for maximum supply-chain safety:
+
+  ```yaml
+  uses: eiserv/easySFTP@<commit-sha>
+  ```
+
+- Exact version tags (`v1.2.3`) are immutable once published; `v1` and `v1.2`
+  are rolling tags — see [RELEASING.md](RELEASING.md#tag-policy).
+- Grant the deploy job only the permissions it needs
+  (`permissions: contents: read` is enough for easySFTP itself).

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -19,7 +19,7 @@ is ever deleted. This is the default and the backwards-compatible behavior.
 
 Uploads are **atomic per file**: content is streamed to a temporary sibling
 file (`<name>.easysftp-tmp`) and renamed over the target only once the transfer
-fully succeeded — a broken connection never leaves a half-written file where
+fully succeeded. A broken connection never leaves a half-written file where
 the live one was.
 
 ## `sync`
@@ -31,7 +31,7 @@ changed.
 
 `sync` is **manifest-based**: it keeps a small `.easysftp-manifest.json` in
 each target directory listing the relative path and content hash of every file
-it uploaded. Only files listed in the manifest are ever deleted — files put on
+it uploaded. Only files listed in the manifest are ever deleted. Files put on
 the server by anyone else (uploads from other tools, server-generated files,
 user content) are never touched.
 
@@ -56,7 +56,7 @@ The `delete: true` input is a legacy alias for `strategy: clean`.
 
 Two safety nets apply before `sync` or `clean` delete anything:
 
-- **Remote root is refused — always.** A target that resolves to `/` (or `.`)
+- **Remote root is always refused.** A target that resolves to `/` (or `.`)
   is rejected outright. No strategy will ever wipe a server root.
 - **`guards.max_deletes`** ([config file](configuration.md#fields) only) aborts
   a run that would delete more files than the limit, catching a
@@ -71,6 +71,6 @@ dry-run: true
 ```
 
 easySFTP connects, plans everything and logs exactly what would be uploaded,
-skipped and deleted — but changes nothing. The `files-uploaded` /
+skipped and deleted, but changes nothing. The `files-uploaded` /
 `files-deleted` outputs report the *planned* counts, so you can use a dry run
 in a pull request to preview a deploy.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,76 @@
+# Strategies
+
+A *strategy* decides how each target's remote directory is reconciled with
+your local files.
+
+| Strategy | Uploads | Deletes | Use for |
+|---|---|---|---|
+| `overlay` (default) | all files | nothing | adding/updating files, leaving everything else in place |
+| `sync` | new & changed files | files a previous sync uploaded but that are now gone locally | keeping a directory an exact mirror of your build, safely |
+| `clean` | all files | **everything** in the remote target first | a guaranteed-fresh deploy |
+
+Set the strategy globally with the `strategy` input, or per target in the
+[config file](configuration.md#the-yaml-config-file).
+
+## `overlay`
+
+Uploads every local file on top of whatever is already on the server. Nothing
+is ever deleted. This is the default and the backwards-compatible behavior.
+
+Uploads are **atomic per file**: content is streamed to a temporary sibling
+file (`<name>.easysftp-tmp`) and renamed over the target only once the transfer
+fully succeeded — a broken connection never leaves a half-written file where
+the live one was.
+
+## `sync`
+
+Uploads new and changed files, and deletes remote files that a previous sync
+uploaded but that no longer exist locally. Unchanged files (compared by SHA256
+content hash) are skipped entirely, so re-deploys only transfer what actually
+changed.
+
+`sync` is **manifest-based**: it keeps a small `.easysftp-manifest.json` in
+each target directory listing the relative path and content hash of every file
+it uploaded. Only files listed in the manifest are ever deleted — files put on
+the server by anyone else (uploads from other tools, server-generated files,
+user content) are never touched.
+
+Notes:
+
+- The first sync into a directory uploads everything and creates the manifest.
+- A missing or corrupt manifest degrades safely to "upload everything, delete
+  nothing" (with a warning).
+- The manifest trusts itself: a file changed *on the server* out of band is not
+  re-detected until its local content changes. Run `clean` once to reset.
+- Directories left empty by deletions are pruned automatically.
+
+## `clean`
+
+Deletes **everything** inside the remote target directory first, then uploads
+all local files. Use it when you want a guaranteed-fresh deploy and nothing in
+the target directory needs to survive.
+
+The `delete: true` input is a legacy alias for `strategy: clean`.
+
+## Delete guards
+
+Two safety nets apply before `sync` or `clean` delete anything:
+
+- **Remote root is refused — always.** A target that resolves to `/` (or `.`)
+  is rejected outright. No strategy will ever wipe a server root.
+- **`guards.max_deletes`** ([config file](configuration.md#fields) only) aborts
+  a run that would delete more files than the limit, catching a
+  misconfiguration before it does damage. `0` means unlimited.
+
+## Dry runs
+
+Preview any strategy without touching the server:
+
+```yaml
+dry-run: true
+```
+
+easySFTP connects, plans everything and logs exactly what would be uploaded,
+skipped and deleted — but changes nothing. The `files-uploaded` /
+`files-deleted` outputs report the *planned* counts, so you can use a dry run
+in a pull request to preview a deploy.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,126 @@
+# Troubleshooting & FAQ
+
+Common errors, what they mean and how to fix them. If your problem is not
+listed, [open an issue](https://github.com/eiserv/easySFTP/issues) — ideally
+with the log of a `dry-run: true` run.
+
+## Connection problems
+
+### `connecting to <host>:22: dial tcp ...: i/o timeout`
+
+The runner cannot reach the server.
+
+- Check `server` and `port`.
+- Many hosters firewall SSH to allowlisted IPs — GitHub-hosted runners use
+  [changing IP ranges](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#ip-addresses),
+  so an IP allowlist usually requires a self-hosted runner or a relaxed rule.
+- Raise `timeout` (default 30 s) if the server is just slow to accept
+  connections.
+
+### `connecting to <host>:22: ssh: handshake failed: ... unable to authenticate`
+
+The server rejected the credentials.
+
+- Verify the secret names in your workflow match the configured secrets
+  (a missing secret silently expands to an empty string).
+- Password auth: some servers disable it entirely (`PasswordAuthentication no`)
+  — use a key instead.
+- Key auth: the key must be in OpenSSH or PEM format. If it is encrypted, set
+  `passphrase`. Check that the *public* key is in the server's
+  `authorized_keys`.
+
+### `host key mismatch for <host>: got SHA256:..., want one of: ...`
+
+The server presented a key that matches none of your pinned fingerprints.
+
+- If the server was migrated or its keys rotated, re-run
+  `ssh-keyscan <server> | ssh-keygen -lf -` and update the secret.
+- If you did **not** expect a key change, stop and investigate — this is
+  exactly the man-in-the-middle situation pinning exists for.
+- You can pin multiple fingerprints (one per line); the connection is accepted
+  if any matches.
+
+### `host-key-fingerprint must be a SHA256 fingerprint like 'SHA256:...'`
+
+Pass the fingerprint (`SHA256:nThbg...`), not the raw `ssh-keyscan` line and
+not an MD5 fingerprint. Get the right format with:
+
+```console
+ssh-keyscan sftp.example.com | ssh-keygen -lf -
+```
+
+## Upload problems
+
+### `permission denied` while uploading
+
+The SFTP user cannot write to the target directory. Check ownership and
+permissions on the server. With chrooted SFTP setups remember that paths are
+relative to the chroot — `/upload/...`, not `/home/user/upload/...`.
+
+### `replacing "<path>": ...` or leftover `.easysftp-tmp` files
+
+easySFTP uploads to a temporary sibling file and renames it over the target
+(atomic on servers supporting the `posix-rename@openssh.com` extension, with a
+remove+rename fallback otherwise). A hard crash mid-upload can leave a
+`*.easysftp-tmp` file behind; it is safe to delete and will be cleaned up by
+the next successful upload of the same file.
+
+### Ignored files are uploaded anyway / patterns don't match
+
+- Patterns match against the path **relative to the local root of each
+  target**, not the repository root.
+- Directory patterns need a trailing slash (`node_modules/`), just like
+  gitignore.
+- Test your patterns cheaply with `dry-run: true`.
+
+### Symlinks are missing on the server
+
+Symlinks, sockets and other non-regular files are skipped by design — SFTP
+uploads regular file content. If your build output contains symlinks (e.g.
+pnpm's `node_modules`), upload a bundled/dereferenced build instead.
+
+## Strategy questions
+
+### `sync` did not delete a file I removed locally
+
+`sync` only deletes files listed in its manifest — files it uploaded itself.
+Files that were already on the server before your first sync are never
+touched. Run `strategy: clean` once for a fresh start, then continue with
+`sync`. See [strategies](strategies.md#sync).
+
+### What is `.easysftp-manifest.json` on my server?
+
+The [sync manifest](strategies.md#sync): the list of files (with content
+hashes) the last sync uploaded. Leave it in place — without it, the next sync
+re-uploads everything and deletes nothing. It is excluded from uploads and
+never deleted by `sync` itself.
+
+### `refusing a destructive strategy on remote root`
+
+`sync` and `clean` refuse to operate on `/` (or `.`) as the remote target —
+always. Deploy into a specific subdirectory instead. This guard cannot be
+disabled; see [delete guards](strategies.md#delete-guards).
+
+### `refusing to delete N files: exceeds guards.max_deletes`
+
+Your run would delete more files than `guards.max_deletes` allows. Inspect the
+plan with `dry-run: true`; if the deletions are intended, raise (or remove)
+the limit in the config file.
+
+## Configuration errors
+
+### `when 'config-file' is set, put targets/strategy/ignore/guards in the file`
+
+`config-file` replaces the `uploads`, `strategy`, `delete`, `ignore` and
+`ignore-from` inputs — remove them from the step. Connection inputs stay.
+
+### `strategy "sync" requires a directory, but local path ... is a single file`
+
+`sync` and `clean` reconcile a directory tree; for single files use `overlay`
+(the default).
+
+### `config-file "..." is not valid: field <x> not found`
+
+The config file rejects unknown keys instead of silently ignoring them —
+usually a typo. Enable [editor validation](configuration.md#editor-support)
+via the JSON Schema to catch these while typing.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,7 +1,7 @@
 # Troubleshooting & FAQ
 
 Common errors, what they mean and how to fix them. If your problem is not
-listed, [open an issue](https://github.com/eiserv/easySFTP/issues) — ideally
+listed, [open an issue](https://github.com/eiserv/easySFTP/issues), ideally
 with the log of a `dry-run: true` run.
 
 ## Connection problems
@@ -11,7 +11,7 @@ with the log of a `dry-run: true` run.
 The runner cannot reach the server.
 
 - Check `server` and `port`.
-- Many hosters firewall SSH to allowlisted IPs — GitHub-hosted runners use
+- Many hosters firewall SSH to allowlisted IPs. GitHub-hosted runners use
   [changing IP ranges](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#ip-addresses),
   so an IP allowlist usually requires a self-hosted runner or a relaxed rule.
 - Raise `timeout` (default 30 s) if the server is just slow to accept
@@ -24,7 +24,7 @@ The server rejected the credentials.
 - Verify the secret names in your workflow match the configured secrets
   (a missing secret silently expands to an empty string).
 - Password auth: some servers disable it entirely (`PasswordAuthentication no`)
-  — use a key instead.
+  use a key instead.
 - Key auth: the key must be in OpenSSH or PEM format. If it is encrypted, set
   `passphrase`. Check that the *public* key is in the server's
   `authorized_keys`.
@@ -35,7 +35,7 @@ The server presented a key that matches none of your pinned fingerprints.
 
 - If the server was migrated or its keys rotated, re-run
   `ssh-keyscan <server> | ssh-keygen -lf -` and update the secret.
-- If you did **not** expect a key change, stop and investigate — this is
+- If you did **not** expect a key change, stop and investigate. This is
   exactly the man-in-the-middle situation pinning exists for.
 - You can pin multiple fingerprints (one per line); the connection is accepted
   if any matches.
@@ -55,7 +55,7 @@ ssh-keyscan sftp.example.com | ssh-keygen -lf -
 
 The SFTP user cannot write to the target directory. Check ownership and
 permissions on the server. With chrooted SFTP setups remember that paths are
-relative to the chroot — `/upload/...`, not `/home/user/upload/...`.
+relative to the chroot: `/upload/...`, not `/home/user/upload/...`.
 
 ### `replacing "<path>": ...` or leftover `.easysftp-tmp` files
 
@@ -75,7 +75,7 @@ the next successful upload of the same file.
 
 ### Symlinks are missing on the server
 
-Symlinks, sockets and other non-regular files are skipped by design — SFTP
+Symlinks, sockets and other non-regular files are skipped by design. SFTP
 uploads regular file content. If your build output contains symlinks (e.g.
 pnpm's `node_modules`), upload a bundled/dereferenced build instead.
 
@@ -83,7 +83,7 @@ pnpm's `node_modules`), upload a bundled/dereferenced build instead.
 
 ### `sync` did not delete a file I removed locally
 
-`sync` only deletes files listed in its manifest — files it uploaded itself.
+`sync` only deletes files listed in its manifest: files it uploaded itself.
 Files that were already on the server before your first sync are never
 touched. Run `strategy: clean` once for a fresh start, then continue with
 `sync`. See [strategies](strategies.md#sync).
@@ -91,13 +91,13 @@ touched. Run `strategy: clean` once for a fresh start, then continue with
 ### What is `.easysftp-manifest.json` on my server?
 
 The [sync manifest](strategies.md#sync): the list of files (with content
-hashes) the last sync uploaded. Leave it in place — without it, the next sync
+hashes) the last sync uploaded. Leave it in place. Without it, the next sync
 re-uploads everything and deletes nothing. It is excluded from uploads and
 never deleted by `sync` itself.
 
 ### `refusing a destructive strategy on remote root`
 
-`sync` and `clean` refuse to operate on `/` (or `.`) as the remote target —
+`sync` and `clean` refuse to operate on `/` (or `.`) as the remote target,
 always. Deploy into a specific subdirectory instead. This guard cannot be
 disabled; see [delete guards](strategies.md#delete-guards).
 
@@ -112,7 +112,7 @@ the limit in the config file.
 ### `when 'config-file' is set, put targets/strategy/ignore/guards in the file`
 
 `config-file` replaces the `uploads`, `strategy`, `delete`, `ignore` and
-`ignore-from` inputs — remove them from the step. Connection inputs stay.
+`ignore-from` inputs. Remove them from the step. Connection inputs stay.
 
 ### `strategy "sync" requires a directory, but local path ... is a single file`
 
@@ -121,6 +121,6 @@ the limit in the config file.
 
 ### `config-file "..." is not valid: field <x> not found`
 
-The config file rejects unknown keys instead of silently ignoring them —
+The config file rejects unknown keys instead of silently ignoring them,
 usually a typo. Enable [editor validation](configuration.md#editor-support)
 via the JSON Schema to catch these while typing.


### PR DESCRIPTION
## What

- **README**: much shorter, with a table of contents. Deep detail moved out; the README now covers quick start, a compact input overview, strategies at a glance, security in two rules, and links into `docs/`.
- **New `docs/` pages**:
  - [`docs/README.md`](docs/README.md) — index
  - [`docs/configuration.md`](docs/configuration.md) — full input/output reference, `uploads` mapping rules, ignore patterns, YAML config file reference
  - [`docs/strategies.md`](docs/strategies.md) — overlay/sync/clean, manifest semantics, delete guards, dry runs
  - [`docs/examples.md`](docs/examples.md) — copy-paste recipes (static site, sync mirror, multi-target, key auth, single-file rename, PR previews, outputs, .sftpignore, Windows runners)
  - [`docs/security.md`](docs/security.md) — host key pinning, credentials, least privilege, supply chain
  - [`docs/troubleshooting.md`](docs/troubleshooting.md) — FAQ for common errors
- **CONTRIBUTING.md** — dev setup, repo layout, test expectations, squash-merge/Conventional-Commit PR-title rule, review checklist
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (enforcement contact: @eiserv)
- **Fix**: `action.yml` referenced a non-existent `docs/CONFIG.md` → now points at `docs/configuration.md`

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)