### PR TITLE
fix: fail fast on remote file directory conflicts

### DIFF
--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -248,8 +248,11 @@ func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, f
 		if cfg.DryRun {
 			continue
 		}
-		if _, err := client.Stat(dir); err == nil {
-			continue
+		if info, err := client.Stat(dir); err == nil {
+			if info.IsDir() {
+				continue
+			}
+			return fmt.Errorf("remote path %q exists but is not a directory", dir)
 		}
 		if err := client.MkdirAll(dir); err != nil {
 			return fmt.Errorf("creating remote directory %q: %w", dir, err)

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -96,6 +96,37 @@ func TestUploadDirectoryWithIgnore(t *testing.T) {
 	}
 }
 
+func TestUploadDirectoryFailsWhenRemoteDirIsFile(t *testing.T) {
+	srv := startTestServer(t)
+	client := srv.verifyClient(t)
+	f, err := client.Create("/www")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("not a directory")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"index.html": "fresh",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	_, err = Run(context.Background(), cfg, testLogger{t})
+	if err == nil {
+		t.Fatal("expected remote file conflict error")
+	}
+	if got, want := err.Error(), `remote path "/www" exists but is not a directory`; !strings.Contains(got, want) {
+		t.Fatalf("expected error containing %q, got %q", want, got)
+	}
+}
+
 func TestUploadSingleFile(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -122,7 +122,7 @@ func TestUploadDirectoryFailsWhenRemoteDirIsFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected remote file conflict error")
 	}
-	if got, want := err.Error(), `remote path "/www" exists but is not a directory`; !strings.Contains(got, want) {
+	if got, want := err.Error(), "remote path \"/www\" exists but is not a directory"; !strings.Contains(got, want) {
 		t.Fatalf("expected error containing %q, got %q", want, got)
 	}
 }

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -122,7 +122,7 @@ func TestUploadDirectoryFailsWhenRemoteDirIsFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected remote file conflict error")
 	}
-	if got, want := err.Error(), "remote path \"/www\" exists but is not a directory"; !strings.Contains(got, want) {
+	if got, want := err.Error(), `remote path "/www" exists but is not a directory`; !strings.Contains(got, want) {
 		t.Fatalf("expected error containing %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
Fixes #5

## Summary
- fail fast when a required remote directory path already exists as a file
- add a regression test covering the remote file-vs-directory conflict

## Validation
- `go test ./internal/uploader`
- `go test ./...`
