### PR TITLE
perf: use prebuilt binaries by default

### DIFF
--- a/.easysftp-version
+++ b/.easysftp-version
@@ -1,0 +1,3 @@
+# x-release-please-start-version
+v1.1.0
+# x-release-please-end

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,6 @@ go.sum text eol=lf
 *.yaml text eol=lf
 *.md text eol=lf
 LICENSE text eol=lf
+# Bash reads these verbatim; CRLF would break the version parser on Windows runners.
+*.sh text eol=lf
+.easysftp-version text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,32 @@ permissions:
   contents: read
 
 jobs:
+  action-tests:
+    name: Action launcher and metadata (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Lint shell scripts
+        if: runner.os == 'Linux'
+        run: shellcheck scripts/*.sh
+
+      - name: Test action launcher modes and validation
+        shell: bash
+        run: bash scripts/test-action.sh
+
+      - name: Validate action metadata
+        run: go test ./internal/actionmeta
+
   test:
     name: Unit tests (${{ matrix.os }})
     strategy:
@@ -79,6 +105,7 @@ jobs:
       - name: Dry run
         uses: ./
         with:
+          build-mode: source
           server: localhost
           port: 2222
           username: demo
@@ -99,6 +126,7 @@ jobs:
         id: upload
         uses: ./
         with:
+          build-mode: source
           server: localhost
           port: 2222
           username: demo
@@ -125,6 +153,7 @@ jobs:
         id: clean-upload
         uses: ./
         with:
+          build-mode: source
           server: localhost
           port: 2222
           username: demo
@@ -148,6 +177,7 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
+          build-mode: source
           server: localhost
           port: 2222
           username: demo

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,269 @@
+name: Release binaries
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing exact release tag to build and publish.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate exact trusted release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Verify tag, version, release, and ancestry
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Repair/build tag must be an exact vMAJOR.MINOR.PATCH tag"
+            exit 1
+          fi
+          git show-ref --verify --quiet "refs/tags/$TAG"
+          commit=$(git rev-parse "$TAG^{}")
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$commit" origin/main; then
+            echo "::error::Release tag $TAG is not reachable from main"
+            exit 1
+          fi
+          source scripts/action-lib.sh
+          version=$(read_release_version .easysftp-version)
+          if [[ "$version" != "$TAG" ]]; then
+            echo "::error::.easysftp-version contains $version, expected $TAG"
+            exit 1
+          fi
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+  unit-tests:
+    name: Test exact release source
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.validate.outputs.commit }}
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - run: go test -race ./...
+
+  build:
+    name: Build ${{ matrix.asset }}
+    needs: [validate, unit-tests]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            asset: easysftp_linux_x64
+          - goos: linux
+            goarch: arm64
+            asset: easysftp_linux_arm64
+          - goos: darwin
+            goarch: amd64
+            asset: easysftp_macos_x64
+          - goos: darwin
+            goarch: arm64
+            asset: easysftp_macos_arm64
+          - goos: windows
+            goarch: amd64
+            asset: easysftp_windows_x64.exe
+          - goos: windows
+            goarch: arm64
+            asset: easysftp_windows_arm64.exe
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.validate.outputs.commit }}
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Cross-compile static binary
+        shell: bash
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          ASSET: ${{ matrix.asset }}
+        run: |
+          set -euo pipefail
+          mkdir dist
+          go build -trimpath -ldflags="-s -w" -o "dist/$ASSET" ./cmd/easysftp
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-${{ matrix.asset }}
+          path: dist/${{ matrix.asset }}
+          if-no-files-found: error
+          retention-days: 1
+
+  smoke-test:
+    name: Smoke test ${{ matrix.asset }}
+    needs: build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            asset: easysftp_linux_x64
+            windows: false
+          - runner: ubuntu-24.04-arm
+            asset: easysftp_linux_arm64
+            windows: false
+          - runner: macos-15-intel
+            asset: easysftp_macos_x64
+            windows: false
+          - runner: macos-15
+            asset: easysftp_macos_arm64
+            windows: false
+          - runner: windows-latest
+            asset: easysftp_windows_x64.exe
+            windows: true
+          - runner: windows-11-arm
+            asset: easysftp_windows_arm64.exe
+            windows: true
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-${{ matrix.asset }}
+
+      - name: Run network-free help smoke test
+        if: matrix.windows == false
+        shell: bash
+        env:
+          ASSET: ${{ matrix.asset }}
+        run: |
+          set -euo pipefail
+          chmod +x "$ASSET"
+          "./$ASSET" --help
+
+      - name: Run network-free help smoke test
+        if: matrix.windows == true
+        shell: pwsh
+        env:
+          ASSET: ${{ matrix.asset }}
+        run: '& (Join-Path $PWD $env:ASSET) --help'
+
+  upload:
+    name: Upload assets and checksums
+    needs: [validate, build, smoke-test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.validate.outputs.commit }}
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: release-*
+          path: release
+          merge-multiple: true
+
+      - name: Verify asset set and generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected=(
+            easysftp_linux_x64
+            easysftp_linux_arm64
+            easysftp_macos_x64
+            easysftp_macos_arm64
+            easysftp_windows_x64.exe
+            easysftp_windows_arm64.exe
+          )
+          for asset in "${expected[@]}"; do
+            test -f "release/$asset"
+          done
+          count=$(find release -maxdepth 1 -type f | wc -l)
+          if [[ "$count" -ne "${#expected[@]}" ]]; then
+            echo "::error::Expected ${#expected[@]} release binaries, found $count files"
+            exit 1
+          fi
+          (
+            cd release
+            sha256sum "${expected[@]}" > checksums.txt
+          )
+
+      - name: Upload or replace release assets
+        shell: bash
+        env:
+          EXPECTED_COMMIT: ${{ needs.validate.outputs.commit }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"
+          actual_commit=$(git rev-parse "$TAG^{}")
+          if [[ "$actual_commit" != "$EXPECTED_COMMIT" ]]; then
+            echo "::error::Exact release tag $TAG moved during this run"
+            exit 1
+          fi
+          gh release upload "$TAG" release/* --clobber --repo "$GITHUB_REPOSITORY"
+
+  rolling-tags:
+    name: Update rolling major and minor tags
+    needs: [validate, upload]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.validate.outputs.commit }}
+          fetch-depth: 0
+
+      - name: Move rolling tags after successful publication
+        shell: bash
+        env:
+          COMMIT: ${{ needs.validate.outputs.commit }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+            echo "::error::Invalid exact release tag: $TAG"
+            exit 1
+          fi
+          major=${BASH_REMATCH[1]}
+          minor=${BASH_REMATCH[2]}
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f "v$major" "$COMMIT"
+          git tag -f "v$major.$minor" "$COMMIT"
+          git push --force origin "v$major" "v$major.$minor"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,8 +17,6 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-      major: ${{ steps.release.outputs.major }}
-      minor: ${{ steps.release.outputs.minor }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
@@ -26,30 +24,15 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  update-major-tags:
-    name: Update moving major/minor tags
+  release-binaries:
+    name: Build, test, and publish release binaries
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.release-please.outputs.release_created == 'true'
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Force the moving major and minor tags onto ${{ needs.release-please.outputs.tag_name }}
-        env:
-          MAJOR: ${{ needs.release-please.outputs.major }}
-          MINOR: ${{ needs.release-please.outputs.minor }}
-          TAG: ${{ needs.release-please.outputs.tag_name }}
-        # The exact tag (e.g. v1.2.3) is created by release-please and is never
-        # touched again. Only the rolling v1 and v1.2 pointers are force-moved so
-        # `uses: eiserv/easySFTP@v1` follows the latest 1.x release.
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -f "v${MAJOR}" "${TAG}^{}"
-          git tag -f "v${MAJOR}.${MINOR}" "${TAG}^{}"
-          git push --force origin "v${MAJOR}" "v${MAJOR}.${MINOR}"
+    uses: ./.github/workflows/release-binaries.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/repair-release.yml
+++ b/.github/workflows/repair-release.yml
@@ -1,0 +1,21 @@
+name: Repair release binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing exact release tag (vMAJOR.MINOR.PATCH) to rebuild.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  repair:
+    name: Rebuild an existing exact release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-binaries.yml
+    with:
+      tag: ${{ inputs.tag }}

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@
 Deploy your build output to any SFTP server, from a three-line workflow step
 up to fully configured multi-target deployments.
 
-- ⚡ **Fast**: written in Go, files are transferred in parallel with concurrent
-  SFTP write requests per file.
+- ⚡ **Fast**: release tags use a prebuilt, checksum-verified Go binary by
+  default, and files are transferred in parallel with concurrent SFTP write
+  requests per file.
 - 🔒 **Secure**: optional host key pinning verifies the server's identity;
   atomic per-file uploads never leave half-written files; credentials are only
   ever read from environment variables.
 - 🧩 **Simple, but configurable**: sensible defaults for the simple case;
   gitignore-style excludes, sync/clean strategies, delete guards, dry runs,
   retries and outputs for the complex ones.
-- 🖥️ **Cross-platform**: runs natively on `ubuntu-*`, `macos-*` and
-  `windows-*` runners, with no Docker required.
+- 🖥️ **Cross-platform**: native amd64 and arm64 binaries for Linux, macOS and
+  Windows, with no Docker required.
 
 ## Table of contents
 
@@ -100,6 +101,7 @@ The most used inputs:
 
 | Input | Default | Description |
 |---|---|---|
+| `build-mode` | `prebuilt` | `prebuilt` downloads and verifies the release binary; `source` installs Go and compiles this checkout. |
 | `server` / `port` / `username` | - / `22` / - | Where and as whom to connect. |
 | `password` / `private-key` / `passphrase` | - | Authentication, at least one of password/key. **Use secrets.** |
 | `host-key-fingerprint` | - | Pin the server's SHA256 host key(s). **Strongly recommended.** |
@@ -190,8 +192,27 @@ uses: eiserv/easySFTP@v1        # latest 1.x, recommended, gets fixes & features
 uses: eiserv/easySFTP@v1.2.3    # exact, immutable pin
 ```
 
-`v1`/`v1.2` are rolling tags; `v1.2.3` and commit SHAs never move. Releases and
-the changelog are generated automatically from Conventional Commits. See
+`v1`, `v1.2` and `v1.2.3` use the exact version recorded in
+`.easysftp-version` and download the corresponding asset only from this
+repository's GitHub Release. The asset's SHA-256 digest is checked against
+`checksums.txt` before it is executed. `v1`/`v1.2` are rolling tags; exact tags
+never move.
+
+An exact release-commit SHA is accepted after it is matched against the exact
+tag recorded in `.easysftp-version`. Development refs such as `@main`, local
+`uses: ./`, and commit SHAs that do not match that release do not silently reuse
+the last binary. Select the source fallback explicitly for those checkouts:
+
+```yaml
+- uses: eiserv/easySFTP@<commit-sha>
+  with:
+    build-mode: source
+    # connection and upload inputs...
+```
+
+Source mode installs the Go version from `go.mod` and builds that exact
+checkout with `CGO_ENABLED=0`, `-trimpath`, and stripped symbols. Releases and
+the changelog remain managed by Release Please and Conventional Commits. See
 [docs/RELEASING.md](docs/RELEASING.md).
 
 ## Contributing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,5 @@ or contact the maintainer directly. You will receive a response as soon as possi
 - Always set the `host-key-fingerprint` input so the server's identity is verified
 - Store all credentials (`password`, `private-key`, `passphrase`) as encrypted GitHub Actions secrets
 - Prefer key-based authentication over passwords
-- Pin this action to a full commit SHA in your workflows if you require maximum supply-chain safety
+- Release refs download only this repository's platform binary and verify it against the release's `checksums.txt`
+- Prebuilt mode accepts a commit SHA only if it matches the exact release tag in `.easysftp-version`; use `build-mode: source` for all other SHAs

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,12 @@ branding:
   color: blue
 
 inputs:
+  build-mode:
+    description: >-
+      How to obtain easySFTP: "prebuilt" downloads and verifies the matching
+      release binary (default); "source" installs Go and builds this checkout.
+    required: false
+    default: prebuilt
   server:
     description: Hostname or IP address of the SFTP server (e.g. sftp.example.com).
     required: true
@@ -113,37 +119,40 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Resolve action path
-      id: paths
+    - name: Prepare easySFTP
+      id: prepare
       shell: bash
-      # github.action_path may contain "\" or "/./" segments (e.g. when the
-      # action is used locally via "uses: ./"), which setup-go's cache glob
-      # rejects — normalize to a clean absolute path.
       run: |
-        p='${{ github.action_path }}'
-        p="${p//\\//}"
-        while [[ "$p" == *"/./"* ]]; do p="${p//\/.\//\/}"; done
-        p="${p%/.}"
-        p="${p%/}"
-        echo "dir=$p" >> "$GITHUB_OUTPUT"
+        action_path="${ACTION_PATH//\\//}"
+        bash "$action_path/scripts/prepare-action.sh"
+      env:
+        INPUT_BUILD_MODE: ${{ inputs.build-mode }}
+        ACTION_PATH: ${{ github.action_path }}
+        ACTION_REF: ${{ github.action_ref }}
 
     - name: Set up Go
+      if: steps.prepare.outputs.build-mode == 'source'
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
-        go-version-file: ${{ steps.paths.outputs.dir }}/go.mod
+        go-version-file: ${{ steps.prepare.outputs.action-dir }}/go.mod
         cache: true
-        cache-dependency-path: ${{ steps.paths.outputs.dir }}/go.sum
+        cache-dependency-path: ${{ steps.prepare.outputs.action-dir }}/go.sum
 
     - name: Build easySFTP
+      if: steps.prepare.outputs.build-mode == 'source'
       shell: bash
-      working-directory: ${{ steps.paths.outputs.dir }}
-      run: go build -trimpath -ldflags="-s -w" -o "$RUNNER_TEMP/easysftp$(go env GOEXE)" ./cmd/easysftp
+      working-directory: ${{ steps.prepare.outputs.action-dir }}
+      run: go build -trimpath -ldflags="-s -w" -o "$BINARY" ./cmd/easysftp
+      env:
+        BINARY: ${{ steps.prepare.outputs.binary }}
+        CGO_ENABLED: "0"
 
     - name: Upload via SFTP
       id: easysftp
       shell: bash
-      run: '"$RUNNER_TEMP/easysftp$(go env GOEXE)"'
+      run: '"$BINARY"'
       env:
+        BINARY: ${{ steps.prepare.outputs.binary }}
         EASYSFTP_SERVER: ${{ inputs.server }}
         EASYSFTP_PORT: ${{ inputs.port }}
         EASYSFTP_USERNAME: ${{ inputs.username }}

--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -23,10 +23,18 @@ func (ghaLogger) Group(name string)                   { gha.Group(name) }
 func (ghaLogger) EndGroup()                           { gha.EndGroup() }
 
 func main() {
+	if helpRequested(os.Args[1:]) {
+		fmt.Print("easySFTP uploads files to an SFTP server using EASYSFTP_* environment variables.\n\nUsage:\n  easysftp\n  easysftp --help\n")
+		return
+	}
 	if err := run(); err != nil {
 		gha.Errorf("%v", err)
 		os.Exit(1)
 	}
+}
+
+func helpRequested(args []string) bool {
+	return len(args) == 1 && (args[0] == "--help" || args[0] == "-h")
 }
 
 func run() error {

--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestHelpRequested(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "long", args: []string{"--help"}, want: true},
+		{name: "short", args: []string{"-h"}, want: true},
+		{name: "none", args: nil, want: false},
+		{name: "extra", args: []string{"--help", "unexpected"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := helpRequested(tt.args); got != tt.want {
+				t.Fatalf("helpRequested(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,101 +1,124 @@
 # Releasing easySFTP
 
-Releases are fully automated with [Release Please](https://github.com/googleapis/release-please)
-driven by [Conventional Commits](https://www.conventionalcommits.org/). You never
-tag or draft a release by hand.
+Releases use [Release Please](https://github.com/googleapis/release-please) and
+[Conventional Commits](https://www.conventionalcommits.org/). Do not create
+version tags or releases by hand.
 
-## How a release happens
+## Release flow
 
-1. **Land Conventional Commits on `main`.** PRs are squash-merged, so the **PR
-   title** becomes the commit subject and must be a Conventional Commit. The
-   [`PR Title`](../.github/workflows/pr-title.yml) workflow enforces this.
+1. Land Conventional Commits on `main`. PRs are squash-merged, so the PR title
+   becomes the commit subject and is checked by the `PR Title` workflow.
 
-   | Prefix              | Version bump | Example                              |
-   | ------------------- | ------------ | ------------------------------------ |
-   | `fix:`              | patch        | `fix: retry on transient EOF`        |
-   | `feat:`             | minor        | `feat: add proxy-jump support`       |
-   | `feat!:` / `BREAKING CHANGE:` | major | `feat!: drop password auth`  |
-   | `docs:` `ci:` `chore:` `refactor:` `test:` `build:` `perf:` | none* | `docs: fix typo` |
+   | Prefix | Version bump | Example |
+   |---|---|---|
+   | `fix:` | patch | `fix: retry on transient EOF` |
+   | `feat:` | minor | `feat: add proxy-jump support` |
+   | `feat!:` / `BREAKING CHANGE:` | major | `feat!: drop password auth` |
+   | `docs:` `ci:` `chore:` `refactor:` `test:` `build:` `perf:` | none* | `perf: reduce startup time` |
 
-   \* `perf:` shows in the changelog but does not force a bump on its own.
+   \* `perf:` appears in the changelog but does not force a bump by itself.
 
-2. **Release Please opens/updates a release PR.** The
-   [`Release`](../.github/workflows/release-please.yml) workflow runs on every
-   push to `main`. It maintains a single "chore(main): release x.y.z" PR that
-   accumulates the changelog and the next version in
-   [`.release-please-manifest.json`](../.release-please-manifest.json).
+2. The `Release` workflow runs on pushes to `main`. Release Please maintains a
+   release PR containing `CHANGELOG.md`, `.release-please-manifest.json`, and
+   the exact `vMAJOR.MINOR.PATCH` value in `.easysftp-version`.
 
-3. **Merge the release PR.** On merge, Release Please:
-   - updates [`CHANGELOG.md`](../CHANGELOG.md),
-   - creates the **immutable** exact tag `vX.Y.Z`,
-   - publishes the GitHub Release.
+3. Merging the release PR makes Release Please create the immutable exact tag
+   and GitHub Release. Only when that release was created in the current
+   `push` run does the binary pipeline start.
 
-4. **Moving tags follow automatically.** The `update-major-tags` job force-moves
-   the rolling `vX` and `vX.Y` tags onto the new release commit, so
-   `uses: eiserv/easySFTP@v1` always points at the latest 1.x.
+4. The binary pipeline validates that the exact tag exists, is reachable from
+   `main`, matches `.easysftp-version`, and already has a GitHub Release. It
+   tests the exact tagged source and cross-compiles six binaries with
+   `CGO_ENABLED=0`, `-trimpath`, and `-ldflags="-s -w"`:
+
+   - Linux amd64 / arm64
+   - macOS amd64 / arm64
+   - Windows amd64 / arm64
+
+5. Each produced artifact is run on its native hosted runner with the
+   network-free `easysftp --help` smoke test. Build and test jobs have only
+   `contents: read`.
+
+6. After every smoke test passes, the upload job generates `checksums.txt` and
+   uploads (or deliberately replaces) the complete asset set on the exact
+   release. Only this job has release-upload write access.
+
+7. Only after upload succeeds are rolling `vX` and `vX.Y` tags force-moved to
+   the exact release commit. A failed build, test, or upload leaves rolling
+   tags unchanged. The exact `vX.Y.Z` tag is never moved.
+
+## Stable asset names
+
+```text
+easysftp_linux_x64
+easysftp_linux_arm64
+easysftp_macos_x64
+easysftp_macos_arm64
+easysftp_windows_x64.exe
+easysftp_windows_arm64.exe
+checksums.txt
+```
+
+## Repairing a failed binary publication
+
+Use `Actions → Repair release binaries → Run workflow` and enter an existing
+exact tag such as `v1.2.3`. The workflow never creates or chooses a version. It
+fails unless the tag is an exact SemVer release reachable from `main`, the
+GitHub Release already exists, and `.easysftp-version` matches it.
+
+The repair rebuilds and tests the binaries from the exact tagged commit,
+replaces the known assets with `gh release upload --clobber`, regenerates
+checksums, and moves rolling tags only after success. Do not use PR artifacts
+or locally built files to repair a release.
 
 ## Tag policy
 
-| Tag       | Mutable? | Purpose                                             |
-| --------- | -------- | --------------------------------------------------- |
-| `v1.2.3`  | **No**   | Exact, reproducible pin. Created once, never moved. |
-| `v1.2`    | Yes      | Latest patch within 1.2.                            |
-| `v1`      | Yes      | Latest release within major version 1.              |
-
-Consumers who want a byte-exact pin can also reference the commit SHA directly.
+| Tag | Mutable? | Purpose |
+|---|---|---|
+| `v1.2.3` | **No** | Exact source/release identity, created once by Release Please. |
+| `v1.2` | Yes | Latest fully published patch within 1.2. |
+| `v1` | Yes | Latest fully published release within major version 1. |
 
 ## Required repository settings
 
-The automation assumes these are configured once in the GitHub UI. They are not
-in version control, so they are documented here.
+### GitHub Actions
 
-### 1. Allow GitHub Actions to create pull requests
+In `Settings → Actions → General → Workflow permissions`, enable **Allow GitHub
+Actions to create and approve pull requests**. Global read/write permission is
+not needed because workflows declare job-level scopes.
 
-`Settings → Actions → General → Workflow permissions`:
+The repository must allow the official GitHub-hosted arm64 labels used by the
+smoke matrix (`ubuntu-24.04-arm`, `macos-15`, and `windows-11-arm`) as well as
+their x64 counterparts. If GitHub changes label availability for the repository
+plan, update only the runner labels; do not replace native smoke tests with
+cross-platform emulation.
 
-- Read and write permissions is **not** required globally (the workflows request
-  their own scopes), **but**
-- ✅ **Allow GitHub Actions to create and approve pull requests** must be on, or
-  Release Please cannot open its release PR.
+### Branch protection for `main`
 
-### 2. Branch protection for `main`
+Require pull requests, up-to-date branches, and these CI checks:
 
-`Settings → Branches → Add branch ruleset` (or classic branch protection),
-targeting `main`:
+- `Action launcher and metadata (ubuntu-latest)`
+- `Action launcher and metadata (windows-latest)`
+- `Unit tests (ubuntu-latest)`
+- `Unit tests (windows-latest)`
+- `Self-test against a real SFTP server`
+- `Validate Conventional Commit title`
 
-- ✅ Require a pull request before merging.
-- ✅ Require status checks to pass:
-  - `Unit tests (ubuntu-latest)`
-  - `Unit tests (windows-latest)`
-  - `Self-test against a real SFTP server`
-  - `Validate Conventional Commit title`
-- ✅ Require branches to be up to date before merging.
-- ✅ Block force pushes.
-- ✅ (Recommended) Require a linear history, matches the squash-merge model.
+Block force pushes to `main`. A linear squash-merge history is recommended.
 
-> Do **not** require signed commits or a second approving review on a
-> single-maintainer repo unless you are prepared to review Release Please and
-> Dependabot PRs yourself; both bots push under `github-actions[bot]`.
+### Tag and release settings
 
-### 3. Tag protection ruleset (keeps exact tags immutable)
+Create a tag ruleset matching `v*.*.*` that restricts updates and deletions.
+Leave `vX` and `vX.Y` updateable by `github-actions[bot]` so the post-upload job
+can move them.
 
-`Settings → Rules → Rulesets → New tag ruleset`:
-
-- **Target tags** by pattern (fnmatch): `v*.*.*`
-  This matches exact three-part tags like `v1.2.3` **but not** `v1` or `v1.2`.
-- ✅ **Restrict updates** and ✅ **Restrict deletions**, making `vX.Y.Z`
-  immutable once published.
-- Leave `v1` and `v1.*` **unprotected** so the `update-major-tags` job can
-  force-move them. (If you add a second ruleset for those, it must allow the
-  `github-actions[bot]` actor to update them.)
-
-If your plan supports it, enabling **immutable releases**
-(`Settings → General → ... → Immutable releases`) is a stronger guarantee for the
-exact tags than the ruleset alone.
+Do **not** enable GitHub's immutable-releases setting with this flow: Release
+Please creates the Release before the trusted binary jobs attach assets, and
+the controlled repair path must be able to replace those assets. Exact tag
+immutability is enforced by the tag ruleset instead.
 
 ## Dependencies
 
-[Dependabot](../.github/dependabot.yml) opens weekly grouped PRs for Go modules
-(`build(deps): ...`) and pinned GitHub Actions (`ci(deps): ...`). Both prefixes
-are Conventional Commits, so they pass the PR-title check and are hidden from the
-changelog. Review, let CI pass, and merge. No release is cut for them alone.
+Dependabot opens grouped updates for Go modules and pinned GitHub Actions. All
+external actions in CI and release workflows must remain pinned to full commit
+SHAs. Review and merge those PRs only after CI passes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,9 +42,18 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 
 | Input | Required | Default | Description |
 |---|---|---|---|
+| `build-mode` | | `prebuilt` | `prebuilt` downloads the platform-specific release binary and verifies its SHA-256 digest. `source` installs Go and compiles the selected action checkout. |
 | `dry-run` | | `false` | Connect and log what would happen, change nothing. |
 | `concurrency` | | `4` | Number of files uploaded in parallel. |
 | `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). |
+
+Prebuilt binaries support Linux, macOS, and Windows on both x64 and arm64
+GitHub-hosted runners. Release refs `@vX`, `@vX.Y`, and `@vX.Y.Z` resolve via
+the exact version in `.easysftp-version`. A commit SHA is accepted in prebuilt
+mode only when it is the commit behind that exact release tag. Development
+refs (`@main`, other commit SHAs, and local `uses: ./`) require
+`build-mode: source`; prebuilt mode fails clearly instead of running an older
+release.
 
 ## Outputs
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -53,14 +53,28 @@ new fingerprints.
 
 ## Supply-chain safety
 
-- Pin the action to a major tag for convenience (`eiserv/easySFTP@v1`) or to a
-  full commit SHA for maximum supply-chain safety:
+- Release refs use `build-mode: prebuilt` by default. The launcher validates
+  `.easysftp-version`, maps only the supported OS/architecture pairs, downloads
+  only the matching binary and `checksums.txt` from
+  `eiserv/easySFTP`'s exact GitHub Release, and verifies SHA-256 before
+  execution. Release downloads may follow GitHub's HTTPS redirect to its own
+  release-asset CDN; no third-party download source is configured.
+- Pin the action to a major tag for convenience (`eiserv/easySFTP@v1`) or to
+  the full commit SHA of an exact release. Prebuilt mode verifies that a SHA is
+  the commit behind the version file's release tag. For any development SHA,
+  explicitly build that checkout from source so a stale release binary can
+  never be substituted:
 
   ```yaml
-  uses: eiserv/easySFTP@<commit-sha>
+  - uses: eiserv/easySFTP@<commit-sha>
+    with:
+      build-mode: source
   ```
 
 - Exact version tags (`v1.2.3`) are immutable once published; `v1` and `v1.2`
   are rolling tags, see [RELEASING.md](RELEASING.md#tag-policy).
+- `build-mode: source` installs Go and compiles the selected action checkout.
+  Use it for `@main`, local actions, non-release commit SHAs, or source-level
+  debugging.
 - Grant the deploy job only the permissions it needs
   (`permissions: contents: read` is enough for easySFTP itself).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,21 @@ Common errors, what they mean and how to fix them. If your problem is not
 listed, [open an issue](https://github.com/eiserv/easySFTP/issues), ideally
 with the log of a `dry-run: true` run.
 
+## Action startup problems
+
+### `prebuilt mode requires a release tag ref ... Use build-mode: source`
+
+Prebuilt mode accepts `@vX`, `@vX.Y`, `@vX.Y.Z`, or the full commit SHA behind
+that exact release. For `@main`, other commit SHAs, or local `uses: ./`, add
+`build-mode: source`. This avoids silently running the last published binary
+for newer source code.
+
+### `SHA-256 mismatch` or `checksums.txt has no SHA-256 entry`
+
+The release is incomplete or an asset does not match its published checksum.
+The binary is not executed. Retry after the maintainer repairs the exact
+release; do not bypass checksum verification.
+
 ## Connection problems
 
 ### `connecting to <host>:22: dial tcp ...: i/o timeout`

--- a/internal/actionmeta/actionmeta_test.go
+++ b/internal/actionmeta/actionmeta_test.go
@@ -1,0 +1,90 @@
+package actionmeta_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type metadata struct {
+	Name    string                 `yaml:"name"`
+	Inputs  map[string]actionInput `yaml:"inputs"`
+	Outputs map[string]any         `yaml:"outputs"`
+	Runs    struct {
+		Using string       `yaml:"using"`
+		Steps []actionStep `yaml:"steps"`
+	} `yaml:"runs"`
+}
+
+type actionInput struct {
+	Default string `yaml:"default"`
+}
+
+type actionStep struct {
+	Name string `yaml:"name"`
+	If   string `yaml:"if"`
+	Uses string `yaml:"uses"`
+}
+
+func TestActionMetadata(t *testing.T) {
+	path := filepath.Join("..", "..", "action.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var action metadata
+	if err := yaml.Unmarshal(data, &action); err != nil {
+		t.Fatalf("parse action.yml: %v", err)
+	}
+	if action.Name != "easySFTP" {
+		t.Errorf("name = %q, want easySFTP", action.Name)
+	}
+	if action.Runs.Using != "composite" {
+		t.Errorf("runs.using = %q, want composite", action.Runs.Using)
+	}
+	if len(action.Runs.Steps) == 0 {
+		t.Fatal("action has no steps")
+	}
+	input, ok := action.Inputs["build-mode"]
+	if !ok {
+		t.Fatal("build-mode input is missing")
+	}
+	if input.Default != "prebuilt" {
+		t.Errorf("build-mode default = %q, want prebuilt", input.Default)
+	}
+
+	wantInputs := []string{
+		"build-mode", "server", "port", "username", "password", "private-key",
+		"passphrase", "host-key-fingerprint", "uploads", "config-file", "strategy",
+		"ignore", "ignore-from", "delete", "dry-run", "concurrency", "retries", "timeout",
+	}
+	for _, name := range wantInputs {
+		if _, ok := action.Inputs[name]; !ok {
+			t.Errorf("input %q is missing", name)
+		}
+	}
+	for _, name := range []string{"files-uploaded", "files-deleted", "files-skipped", "bytes-uploaded", "duration-ms"} {
+		if _, ok := action.Outputs[name]; !ok {
+			t.Errorf("output %q is missing", name)
+		}
+	}
+
+	conditions := map[string]string{
+		"Set up Go":      "steps.prepare.outputs.build-mode == 'source'",
+		"Build easySFTP": "steps.prepare.outputs.build-mode == 'source'",
+	}
+	for _, step := range action.Runs.Steps {
+		if want, ok := conditions[step.Name]; ok {
+			if step.If != want {
+				t.Errorf("%s condition = %q, want %q", step.Name, step.If, want)
+			}
+			delete(conditions, step.Name)
+		}
+	}
+	for name := range conditions {
+		t.Errorf("step %q is missing", name)
+	}
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,12 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": ".easysftp-version"
+        }
+      ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },

--- a/scripts/action-lib.sh
+++ b/scripts/action-lib.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+easysftp_error() {
+  local message=$*
+  message=${message//$'\r'/ }
+  message=${message//$'\n'/ }
+  printf '::error::easySFTP action: %s\n' "$message" >&2
+  return 1
+}
+
+validate_build_mode() {
+  case "${1:-}" in
+    prebuilt | source)
+      printf '%s\n' "$1"
+      ;;
+    *)
+      easysftp_error "invalid build-mode '${1:-}'; supported values are 'prebuilt' and 'source'"
+      ;;
+  esac
+}
+
+read_release_version() {
+  local version_file=$1
+  local -a lines=()
+
+  if [[ ! -f "$version_file" ]]; then
+    easysftp_error "version file '$version_file' is missing"
+    return 1
+  fi
+
+  mapfile -t lines < "$version_file"
+  if (( ${#lines[@]} != 3 )) ||
+    [[ "${lines[0]}" != '# x-release-please-start-version' ]] ||
+    [[ "${lines[2]}" != '# x-release-please-end' ]]; then
+    easysftp_error "version file '$version_file' has an invalid format"
+    return 1
+  fi
+
+  if [[ ! "${lines[1]}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    easysftp_error "version '${lines[1]}' is invalid; expected vMAJOR.MINOR.PATCH"
+    return 1
+  fi
+
+  printf '%s\n' "${lines[1]}"
+}
+
+validate_release_ref() {
+  local action_ref=$1
+  local version=$2
+  local release_commit=${3:-}
+  local major minor patch
+
+  IFS=. read -r major minor patch <<< "${version#v}"
+  case "$action_ref" in
+    "v$major" | "v$major.$minor" | "v$major.$minor.$patch")
+      ;;
+    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
+      if [[ ! "$action_ref" =~ ^[0-9a-f]{40}$ ]] || [[ "$action_ref" != "$release_commit" ]]; then
+        easysftp_error "commit ref '$action_ref' does not match the published $version release commit. Use build-mode: source"
+      fi
+      ;;
+    v[0-9]*)
+      easysftp_error "action ref '$action_ref' does not match version '$version' from .easysftp-version"
+      ;;
+    *)
+      easysftp_error "prebuilt mode requires a release tag ref (@vX, @vX.Y, or @vX.Y.Z) or its matching full commit SHA; '$action_ref' is a development ref. Use build-mode: source"
+      ;;
+  esac
+}
+
+resolve_release_commit() {
+  local version=$1
+  local sha ref direct='' peeled=''
+
+  while IFS=$'\t' read -r sha ref; do
+    case "$ref" in
+      "refs/tags/$version") direct=$sha ;;
+      "refs/tags/$version^{}") peeled=$sha ;;
+    esac
+  done < <(git ls-remote --exit-code \
+    'https://github.com/eiserv/easySFTP.git' \
+    "refs/tags/$version" \
+    "refs/tags/$version^{}")
+
+  sha=${peeled:-$direct}
+  if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+    easysftp_error "could not resolve the exact $version release commit from eiserv/easySFTP"
+    return 1
+  fi
+  printf '%s\n' "$sha"
+}
+
+resolve_release_asset() {
+  case "${1:-}/${2:-}" in
+    Linux/X64) printf '%s\n' 'easysftp_linux_x64' ;;
+    Linux/ARM64) printf '%s\n' 'easysftp_linux_arm64' ;;
+    macOS/X64) printf '%s\n' 'easysftp_macos_x64' ;;
+    macOS/ARM64) printf '%s\n' 'easysftp_macos_arm64' ;;
+    Windows/X64) printf '%s\n' 'easysftp_windows_x64.exe' ;;
+    Windows/ARM64) printf '%s\n' 'easysftp_windows_arm64.exe' ;;
+    *)
+      easysftp_error "unsupported runner platform '${1:-}/${2:-}'; supported OS values are Linux, macOS, and Windows with X64 or ARM64"
+      ;;
+  esac
+}
+
+sha256_file() {
+  local path=$1
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print tolower($1)}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print tolower($1)}'
+  else
+    easysftp_error "no SHA-256 implementation found (sha256sum or shasum is required)"
+  fi
+}
+
+verify_release_checksum() {
+  local binary=$1
+  local checksums=$2
+  local asset=$3
+  local line hash filename expected='' matches=0 actual
+
+  if [[ ! -f "$checksums" ]]; then
+    easysftp_error "checksums.txt is missing"
+    return 1
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" =~ ^([0-9A-Fa-f]{64})[[:space:]]+([^[:space:]]+)$ ]]; then
+      hash=${BASH_REMATCH[1],,}
+      filename=${BASH_REMATCH[2]}
+      filename=${filename#\*}
+      if [[ "$filename" == "$asset" ]]; then
+        expected=$hash
+        matches=$((matches + 1))
+      fi
+    fi
+  done < "$checksums"
+
+  if (( matches == 0 )); then
+    easysftp_error "checksums.txt has no SHA-256 entry for '$asset'"
+    return 1
+  fi
+  if (( matches != 1 )); then
+    easysftp_error "checksums.txt contains multiple SHA-256 entries for '$asset'"
+    return 1
+  fi
+
+  actual=$(sha256_file "$binary")
+  if [[ "$actual" != "$expected" ]]; then
+    easysftp_error "SHA-256 mismatch for '$asset' (expected $expected, got $actual)"
+    return 1
+  fi
+}
+
+download_release_file() {
+  local version=$1
+  local asset=$2
+  local output=$3
+  local max_size=$4
+  local url="https://github.com/eiserv/easySFTP/releases/download/${version}/${asset}"
+
+  curl \
+    --proto '=https' \
+    --proto-redir '=https' \
+    --location \
+    --max-redirs 5 \
+    --fail \
+    --silent \
+    --show-error \
+    --retry 3 \
+    --retry-all-errors \
+    --max-filesize "$max_size" \
+    --output "$output" \
+    "$url"
+}

--- a/scripts/prepare-action.sh
+++ b/scripts/prepare-action.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+# shellcheck source=scripts/action-lib.sh
+source "$script_dir/action-lib.sh"
+
+mode=$(validate_build_mode "${INPUT_BUILD_MODE:-}")
+action_path=${ACTION_PATH:?ACTION_PATH is required}
+action_path=${action_path//\\//}
+while [[ "$action_path" == *'/./'* ]]; do
+  action_path=${action_path//\/\.\//\/}
+done
+action_path=${action_path%/.}
+action_path=${action_path%/}
+temp_root=${RUNNER_TEMP:?RUNNER_TEMP is required}
+temp_root=${temp_root//\\//}
+output_file=${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}
+output_file=${output_file//\\//}
+work_dir=$(mktemp -d "$temp_root/easysftp-action.XXXXXX")
+
+if [[ "${RUNNER_OS:-}" == 'Windows' ]]; then
+  binary="$work_dir/easysftp.exe"
+else
+  binary="$work_dir/easysftp"
+fi
+
+if [[ "$mode" == 'prebuilt' ]]; then
+  version=$(read_release_version "$action_path/.easysftp-version")
+  release_commit=''
+  if [[ "${ACTION_REF:-}" =~ ^[0-9a-f]{40}$ ]]; then
+    release_commit=$(resolve_release_commit "$version")
+  fi
+  validate_release_ref "${ACTION_REF:-}" "$version" "$release_commit"
+  asset=$(resolve_release_asset "${RUNNER_OS:-}" "${RUNNER_ARCH:-}")
+  checksums="$work_dir/checksums.txt"
+
+  download_release_file "$version" 'checksums.txt' "$checksums" 1048576
+  download_release_file "$version" "$asset" "$binary" 104857600
+  verify_release_checksum "$binary" "$checksums" "$asset"
+  chmod +x "$binary"
+  echo "Using verified easySFTP $version release asset $asset"
+fi
+
+{
+  echo "build-mode=$mode"
+  echo "binary=$binary"
+  echo "action-dir=$action_path"
+} >> "$output_file"

--- a/scripts/test-action.sh
+++ b/scripts/test-action.sh
@@ -104,7 +104,7 @@ RUNNER_OS=Linux \
 RUNNER_ARCH=X64 \
 RUNNER_TEMP="$tmp/runner" \
 GITHUB_OUTPUT="$output_file" \
-  "$repo_root/scripts/prepare-action.sh"
+  bash "$repo_root/scripts/prepare-action.sh"
 prepared_binary=$(sed -n 's/^binary=//p' "$output_file")
 prebuilt_result=$("$prepared_binary")
 expect_equal 'prebuilt execution' 'prebuilt-ok' "$prebuilt_result"
@@ -127,7 +127,7 @@ RUNNER_OS="$source_runner_os" \
 RUNNER_ARCH=X64 \
 RUNNER_TEMP="$source_runner_temp" \
 GITHUB_OUTPUT="$source_github_output" \
-  "$repo_root/scripts/prepare-action.sh"
+  bash "$repo_root/scripts/prepare-action.sh"
 expect_equal 'source preparation' 'source' "$(sed -n 's/^build-mode=//p' "$source_output")"
 
 printf '%s\n' '# x-release-please-start-version' '1.2.3' '# x-release-please-end' > "$tmp/bad-version"

--- a/scripts/test-action.sh
+++ b/scripts/test-action.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+# shellcheck source=scripts/action-lib.sh
+source "$repo_root/scripts/action-lib.sh"
+
+failures=0
+
+expect_failure() {
+  local description=$1
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "FAIL: $description unexpectedly succeeded" >&2
+    failures=$((failures + 1))
+  else
+    echo "PASS: $description"
+  fi
+}
+
+expect_equal() {
+  local description=$1 expected=$2 actual=$3
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: $description: expected '$expected', got '$actual'" >&2
+    failures=$((failures + 1))
+  else
+    echo "PASS: $description"
+  fi
+}
+
+expect_equal 'prebuilt mode' 'prebuilt' "$(validate_build_mode prebuilt)"
+expect_equal 'source mode' 'source' "$(validate_build_mode source)"
+expect_failure 'invalid build mode' validate_build_mode archive
+
+expect_equal 'Linux x64 mapping' 'easysftp_linux_x64' "$(resolve_release_asset Linux X64)"
+expect_equal 'Linux arm64 mapping' 'easysftp_linux_arm64' "$(resolve_release_asset Linux ARM64)"
+expect_equal 'macOS x64 mapping' 'easysftp_macos_x64' "$(resolve_release_asset macOS X64)"
+expect_equal 'macOS arm64 mapping' 'easysftp_macos_arm64' "$(resolve_release_asset macOS ARM64)"
+expect_equal 'Windows x64 mapping' 'easysftp_windows_x64.exe' "$(resolve_release_asset Windows X64)"
+expect_equal 'Windows arm64 mapping' 'easysftp_windows_arm64.exe' "$(resolve_release_asset Windows ARM64)"
+expect_failure 'unsupported OS' resolve_release_asset FreeBSD X64
+expect_failure 'unsupported architecture' resolve_release_asset Linux RISCV64
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/action" "$tmp/assets" "$tmp/bin" "$tmp/runner"
+cp "$repo_root/.easysftp-version" "$tmp/action/.easysftp-version"
+printf '#!/usr/bin/env bash\necho prebuilt-ok\n' > "$tmp/assets/easysftp_linux_x64"
+chmod +x "$tmp/assets/easysftp_linux_x64"
+hash=$(sha256_file "$tmp/assets/easysftp_linux_x64")
+printf '%s  %s\n' "$hash" 'easysftp_linux_x64' > "$tmp/assets/checksums.txt"
+
+cat > "$tmp/bin/curl" <<'MOCK_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+output=''
+url=''
+while (( $# )); do
+  case "$1" in
+    --output)
+      output=$2
+      shift 2
+      ;;
+    --max-redirs | --retry | --max-filesize)
+      shift 2
+      ;;
+    --proto | --proto-redir)
+      shift 2
+      ;;
+    --location | --fail | --silent | --show-error | --retry-all-errors)
+      shift
+      ;;
+    *)
+      url=$1
+      shift
+      ;;
+  esac
+done
+cp "$MOCK_ASSET_DIR/${url##*/}" "$output"
+MOCK_CURL
+chmod +x "$tmp/bin/curl"
+
+cat > "$tmp/bin/git" <<'MOCK_GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" != 'ls-remote' ]]; then
+  exit 2
+fi
+printf '%s\t%s\n' \
+  '1111111111111111111111111111111111111111' 'refs/tags/v1.2.3' \
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' 'refs/tags/v1.2.3^{}'
+MOCK_GIT
+chmod +x "$tmp/bin/git"
+
+output_file="$tmp/prebuilt-output"
+PATH="$tmp/bin:$PATH" \
+MOCK_ASSET_DIR="$tmp/assets" \
+INPUT_BUILD_MODE=prebuilt \
+ACTION_PATH="$tmp/action" \
+ACTION_REF=v1.1.0 \
+RUNNER_OS=Linux \
+RUNNER_ARCH=X64 \
+RUNNER_TEMP="$tmp/runner" \
+GITHUB_OUTPUT="$output_file" \
+  "$repo_root/scripts/prepare-action.sh"
+prepared_binary=$(sed -n 's/^binary=//p' "$output_file")
+prebuilt_result=$("$prepared_binary")
+expect_equal 'prebuilt execution' 'prebuilt-ok' "$prebuilt_result"
+
+source_output="$tmp/source-output"
+source_action_path="$tmp/action"
+source_runner_temp="$tmp/runner"
+source_github_output="$source_output"
+source_runner_os=Linux
+if [[ "${RUNNER_OS:-}" == 'Windows' ]] && command -v cygpath >/dev/null 2>&1; then
+  source_action_path=$(cygpath -w "$source_action_path")
+  source_runner_temp=$(cygpath -w "$source_runner_temp")
+  source_github_output=$(cygpath -w "$source_github_output")
+  source_runner_os=Windows
+fi
+INPUT_BUILD_MODE=source \
+ACTION_PATH="$source_action_path" \
+ACTION_REF=main \
+RUNNER_OS="$source_runner_os" \
+RUNNER_ARCH=X64 \
+RUNNER_TEMP="$source_runner_temp" \
+GITHUB_OUTPUT="$source_github_output" \
+  "$repo_root/scripts/prepare-action.sh"
+expect_equal 'source preparation' 'source' "$(sed -n 's/^build-mode=//p' "$source_output")"
+
+printf '%s\n' '# x-release-please-start-version' '1.2.3' '# x-release-please-end' > "$tmp/bad-version"
+expect_failure 'invalid version file' read_release_version "$tmp/bad-version"
+expect_failure 'development ref in prebuilt mode' validate_release_ref main v1.2.3
+expect_failure 'mismatched rolling tag' validate_release_ref v2 v1.2.3
+release_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+expect_equal 'annotated release commit resolution' "$release_sha" "$(PATH="$tmp/bin:$PATH" resolve_release_commit v1.2.3)"
+expect_equal 'matching release commit ref' '' "$(validate_release_ref "$release_sha" v1.2.3 "$release_sha")"
+expect_failure 'unpublished commit ref' validate_release_ref bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb v1.2.3 "$release_sha"
+
+: > "$tmp/missing-checksum"
+expect_failure 'missing checksum entry' verify_release_checksum "$tmp/assets/easysftp_linux_x64" "$tmp/missing-checksum" 'easysftp_linux_x64'
+printf '%064d  easysftp_linux_x64\n' 0 > "$tmp/wrong-checksum"
+expect_failure 'wrong checksum' verify_release_checksum "$tmp/assets/easysftp_linux_x64" "$tmp/wrong-checksum" 'easysftp_linux_x64'
+
+if (( failures != 0 )); then
+  echo "$failures action test(s) failed" >&2
+  exit 1
+fi
+
+echo 'All action launcher tests passed.'


### PR DESCRIPTION
- Introduced `build-mode` input to specify between `prebuilt` and `source` modes.
- Updated documentation to clarify the behavior of prebuilt binaries and source builds.
- Added troubleshooting guidance for common startup issues related to build modes.
- Implemented a new version file to manage release versions.
- Created GitHub workflows for releasing binaries and repairing existing releases.
- Added tests for action metadata and action launcher functionality.
- Implemented action library scripts for better error handling and validation.