### PR TITLE
fix(ci): derive the prebuilt test ref from .easysftp-version

### DIFF
--- a/scripts/test-action.sh
+++ b/scripts/test-action.sh
@@ -47,6 +47,9 @@ trap 'rm -rf "$tmp"' EXIT
 
 mkdir -p "$tmp/action" "$tmp/assets" "$tmp/bin" "$tmp/runner"
 cp "$repo_root/.easysftp-version" "$tmp/action/.easysftp-version"
+# The prebuilt launcher rejects a ref that disagrees with .easysftp-version, so the
+# ref has to follow the release-please bump instead of being pinned to one release.
+release_version=$(read_release_version "$repo_root/.easysftp-version")
 printf '#!/usr/bin/env bash\necho prebuilt-ok\n' > "$tmp/assets/easysftp_linux_x64"
 chmod +x "$tmp/assets/easysftp_linux_x64"
 hash=$(sha256_file "$tmp/assets/easysftp_linux_x64")
@@ -99,7 +102,7 @@ PATH="$tmp/bin:$PATH" \
 MOCK_ASSET_DIR="$tmp/assets" \
 INPUT_BUILD_MODE=prebuilt \
 ACTION_PATH="$tmp/action" \
-ACTION_REF=v1.1.0 \
+ACTION_REF="$release_version" \
 RUNNER_OS=Linux \
 RUNNER_ARCH=X64 \
 RUNNER_TEMP="$tmp/runner" \


### PR DESCRIPTION
## Was war kaputt

Nach dem 1.2.0-Release schlug `Action launcher and metadata` auf `main` fehl (Ubuntu + Windows):

```
easySFTP action: action ref 'v1.1.0' does not match version 'v1.2.0' from .easysftp-version
```

`scripts/test-action.sh` hat `ACTION_REF=v1.1.0` fest verdrahtet, dem Launcher aber die **echte** `.easysftp-version` des Repos untergeschoben. Release Please hat diese Datei auf `v1.2.0` gehoben — `validate_release_ref` hat den veralteten Ref daraufhin völlig korrekt abgelehnt. Der Launcher ist in Ordnung, der Test war es nicht.

Auf der ursprünglichen PR fiel das nicht auf, weil dort beide Werte noch `v1.1.0` waren. In dieser Form wäre der Test nach **jedem** Release erneut gebrochen.

## Fix

Der Ref wird jetzt aus `.easysftp-version` gelesen, statt gepinnt zu werden. Damit folgt der Test jedem künftigen Bump von allein. Das Kopieren der echten Version-Datei bleibt erhalten — es ist die Absicherung, dass Format und Zeilenenden der Datei stimmen.

## Verifikation

- `scripts/test-action.sh` läuft auf dem Stand von `main` (also mit `v1.2.0`) im Linux- und im Windows-Pfad grün.
- Zusätzlich der echte Prebuilt-Pfad gegen das veröffentlichte v1.2.0-Release geprüft: Download, SHA-256-Verifikation und Ausführung des Binaries funktionieren, sowohl über `@v1.2.0` als auch über den Rolling-Tag `@v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)