### PR TITLE
fix: report partial progress on failed runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ The most used inputs:
 | `concurrency` / `retries` / `timeout` | `4` / `2` / `30` | Parallelism, per-file retries, connection timeout (s). |
 
 Outputs: `files-uploaded`, `files-deleted`, `files-skipped`, `bytes-uploaded`,
-`duration-ms`, plus a summary table in the job summary.
+`duration-ms`, plus a summary table in the job summary. If a transfer fails
+partway, the outputs contain the progress completed before the failure and the
+summary is marked as failed.
 
 ➡ Full reference with every input, output and rule:
 [docs/configuration.md](docs/configuration.md)

--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -46,17 +46,25 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	stats, err := uploader.Run(ctx, cfg, ghaLogger{})
-	if err != nil {
-		return err
-	}
-
+	stats, runErr := uploader.Run(ctx, cfg, ghaLogger{})
 	mode := "uploaded"
 	if cfg.DryRun {
 		mode = "would upload (dry-run)"
 	}
-	gha.Infof("done: %s %d file(s), %d byte(s), deleted %d file(s), skipped %d unchanged, took %s",
-		mode, stats.FilesUploaded, stats.BytesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.Duration.Round(1e6))
+	if runErr == nil {
+		gha.Infof("done: %s %d file(s), %d byte(s), deleted %d file(s), skipped %d unchanged, took %s",
+			mode, stats.FilesUploaded, stats.BytesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.Duration.Round(1e6))
+	}
+
+	reportStats(stats, mode, runErr)
+	return runErr
+}
+
+func reportStats(stats *uploader.Stats, mode string, runErr error) {
+	status := "✅ Succeeded"
+	if runErr != nil {
+		status = fmt.Sprintf("❌ Failed after %d file(s), %d byte(s)", stats.FilesUploaded, stats.BytesUploaded)
+	}
 
 	gha.SetOutput("files-uploaded", fmt.Sprintf("%d", stats.FilesUploaded))
 	gha.SetOutput("files-deleted", fmt.Sprintf("%d", stats.FilesDeleted))
@@ -65,8 +73,6 @@ func run() error {
 	gha.SetOutput("duration-ms", fmt.Sprintf("%d", stats.Duration.Milliseconds()))
 
 	gha.AppendSummary(fmt.Sprintf(
-		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Files %s | %d |\n| Files deleted | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %d |\n| Duration | %s |\n",
-		mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.BytesUploaded, stats.Duration.Round(1e6)))
-
-	return nil
+		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %d |\n| Duration | %s |\n",
+		status, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.BytesUploaded, stats.Duration.Round(1e6)))
 }

--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -1,6 +1,15 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/uploader"
+)
 
 func TestHelpRequested(t *testing.T) {
 	tests := []struct {
@@ -20,5 +29,53 @@ func TestHelpRequested(t *testing.T) {
 				t.Fatalf("helpRequested(%q) = %v, want %v", tt.args, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReportStatsOnFailure(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "output")
+	summaryPath := filepath.Join(t.TempDir(), "summary")
+	t.Setenv("GITHUB_OUTPUT", outputPath)
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	stats := &uploader.Stats{
+		FilesUploaded: 3,
+		FilesDeleted:  1,
+		FilesSkipped:  4,
+		BytesUploaded: 2048,
+		Duration:      1500 * time.Millisecond,
+	}
+	reportStats(stats, "uploaded", errors.New("upload failed"))
+
+	output, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"files-uploaded=3",
+		"files-deleted=1",
+		"files-skipped=4",
+		"bytes-uploaded=2048",
+		"duration-ms=1500",
+	} {
+		if !strings.Contains(string(output), want) {
+			t.Errorf("output does not contain %q:\n%s", want, output)
+		}
+	}
+
+	summary, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"| Status | ❌ Failed after 3 file(s), 2048 byte(s) |",
+		"| Files uploaded | 3 |",
+		"| Files deleted | 1 |",
+		"| Files skipped (unchanged) | 4 |",
+		"| Bytes transferred | 2048 |",
+	} {
+		if !strings.Contains(string(summary), want) {
+			t.Errorf("summary does not contain %q:\n%s", want, summary)
+		}
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,8 +65,12 @@ release.
 | `bytes-uploaded` | Total bytes transferred. |
 | `duration-ms` | Total runtime in milliseconds. |
 
-A summary table is also written to the job summary of every run. See
-[examples](examples.md#using-the-outputs) for how to consume outputs in later steps.
+A summary table is also written to the job summary of every run. Outputs and
+the summary are populated even if a transfer fails partway: the values reflect
+the progress completed before the failure, and the summary is clearly marked
+as failed. Use `if: ${{ always() }}` when a later reporting or rollback step
+must consume these partial results. See [examples](examples.md#using-the-outputs)
+for how to consume outputs in later steps.
 
 ## The `uploads` mapping
 

--- a/internal/uploader/atomic_test.go
+++ b/internal/uploader/atomic_test.go
@@ -102,6 +102,36 @@ func TestConnectionDropFailsCleanly(t *testing.T) {
 	}
 }
 
+// TestFailedBatchReturnsPartialStats verifies successful files in a batch are
+// still reported when a later file fails.
+func TestFailedBatchReturnsPartialStats(t *testing.T) {
+	srv := startTestServer(t)
+
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/www/z.txt"); err != nil {
+		t.Fatal(err)
+	}
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "a", "z.txt": "z"})
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 1
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil {
+		t.Fatal("expected the second upload to fail")
+	}
+	if stats.FilesUploaded != 1 || stats.BytesUploaded != 1 {
+		t.Errorf("partial stats = %d file(s), %d byte(s); want 1 file, 1 byte",
+			stats.FilesUploaded, stats.BytesUploaded)
+	}
+	if stats.Duration <= 0 {
+		t.Errorf("partial duration = %s; want a positive duration", stats.Duration)
+	}
+}
+
 // TestAbortedDeploymentStops verifies that a cancelled context aborts the
 // deployment with the context error and uploads nothing.
 func TestAbortedDeploymentStops(t *testing.T) {

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -64,6 +64,7 @@ type plan struct {
 func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	start := time.Now()
 	stats := &Stats{}
+	defer func() { stats.Duration = time.Since(start) }()
 
 	// Build the full local plan first so config/path errors surface before
 	// we touch the network.
@@ -95,7 +96,6 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		}
 	}
 
-	stats.Duration = time.Since(start)
 	return stats, nil
 }
 
@@ -263,6 +263,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, f
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(cfg.Concurrency)
 	results := make([]int64, len(files))
+	completed := make([]bool, len(files))
 
 	for i, f := range files {
 		g.Go(func() error {
@@ -271,6 +272,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, f
 			}
 			log.Infof("%supload %s => %s (%s)", verb, f.localPath, f.remotePath, humanSize(f.size))
 			if cfg.DryRun {
+				completed[i] = true
 				return nil
 			}
 			n, err := uploadFileWithRetry(ctx, f, client, cfg.Retries, log)
@@ -278,18 +280,18 @@ func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, f
 				return err
 			}
 			results[i] = n
+			completed[i] = true
 			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
-		return err
+	runErr := g.Wait()
+	for i, n := range results {
+		if completed[i] {
+			stats.FilesUploaded++
+			stats.BytesUploaded += n
+		}
 	}
-
-	stats.FilesUploaded += len(files)
-	for _, n := range results {
-		stats.BytesUploaded += n
-	}
-	return nil
+	return runErr
 }
 
 // planVerb returns the log prefix that distinguishes a dry run from a real one.


### PR DESCRIPTION
## Summary

- write all action outputs and the job summary before returning an upload error
- mark failed summaries clearly while preserving the existing error annotation and exit behavior
- retain completed file and byte counts, plus elapsed duration, when a parallel upload batch fails partway
- document how partial outputs can be consumed from always-running follow-up steps

## Why

The action previously returned as soon as `uploader.Run` failed, dropping the available progress data. Successful files inside a failed batch were also only aggregated when the entire batch completed, so a partway failure could still report zero progress.

## Validation

- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `go build ./cmd/easysftp`
- `go test ./internal/uploader -run TestFailedBatchReturnsPartialStats -count=10`

The local Windows environment has CGO disabled, so `go test -race ./...` could not run locally; the repository's Linux CI job covers the race-enabled suite.

Closes #14