### PR TITLE
fix: log build version and revision at startup

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -116,10 +116,11 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           ASSET: ${{ matrix.asset }}
+          TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
           mkdir dist
-          go build -trimpath -ldflags="-s -w" -o "dist/$ASSET" ./cmd/easysftp
+          go build -trimpath -ldflags="-s -w -X main.buildVersion=$TAG" -o "dist/$ASSET" ./cmd/easysftp
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/eiserv/easySFTP/internal/config"
@@ -38,6 +39,8 @@ func helpRequested(args []string) bool {
 }
 
 func run() error {
+	logBuildInfo()
+
 	cfg, err := config.Load()
 	if err != nil {
 		return err
@@ -58,6 +61,40 @@ func run() error {
 
 	reportStats(stats, mode, runErr)
 	return runErr
+}
+
+func logBuildInfo() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if line := buildInfoLine(info); line != "" {
+		gha.Infof("%s", line)
+	}
+}
+
+func buildInfoLine(info *debug.BuildInfo) string {
+	if info == nil {
+		return ""
+	}
+
+	for _, setting := range info.Settings {
+		if setting.Key != "vcs.revision" || setting.Value == "" {
+			continue
+		}
+
+		revision := setting.Value
+		if len(revision) > 12 {
+			revision = revision[:12]
+		}
+		version := info.Main.Version
+		if version == "" {
+			version = "(devel)"
+		}
+		return fmt.Sprintf("easySFTP %s (%s)", version, revision)
+	}
+
+	return ""
 }
 
 func reportStats(stats *uploader.Stats, mode string, runErr error) {

--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -18,6 +18,8 @@ import (
 
 type ghaLogger struct{}
 
+var buildVersion string
+
 func (ghaLogger) Infof(format string, args ...any)    { gha.Infof(format, args...) }
 func (ghaLogger) Warningf(format string, args ...any) { gha.Warningf(format, args...) }
 func (ghaLogger) Group(name string)                   { gha.Group(name) }
@@ -68,12 +70,12 @@ func logBuildInfo() {
 	if !ok {
 		return
 	}
-	if line := buildInfoLine(info); line != "" {
+	if line := buildInfoLine(info, buildVersion); line != "" {
 		gha.Infof("%s", line)
 	}
 }
 
-func buildInfoLine(info *debug.BuildInfo) string {
+func buildInfoLine(info *debug.BuildInfo, version string) string {
 	if info == nil {
 		return ""
 	}
@@ -87,7 +89,9 @@ func buildInfoLine(info *debug.BuildInfo) string {
 		if len(revision) > 12 {
 			revision = revision[:12]
 		}
-		version := info.Main.Version
+		if version == "" {
+			version = info.Main.Version
+		}
 		if version == "" {
 			version = "(devel)"
 		}

--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +28,51 @@ func TestHelpRequested(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := helpRequested(tt.args); got != tt.want {
 				t.Fatalf("helpRequested(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildInfoLine(t *testing.T) {
+	tests := []struct {
+		name string
+		info *debug.BuildInfo
+		want string
+	}{
+		{
+			name: "version and revision",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "v1.2.3"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "0123456789abcdef0123456789abcdef01234567"},
+				},
+			},
+			want: "easySFTP v1.2.3 (0123456789ab)",
+		},
+		{
+			name: "short revision and unknown version",
+			info: &debug.BuildInfo{
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "abc123"},
+				},
+			},
+			want: "easySFTP (devel) (abc123)",
+		},
+		{
+			name: "missing revision",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "v1.2.3"},
+			},
+		},
+		{
+			name: "build info unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildInfoLine(tt.info); got != tt.want {
+				t.Fatalf("buildInfoLine() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -35,9 +35,10 @@ func TestHelpRequested(t *testing.T) {
 
 func TestBuildInfoLine(t *testing.T) {
 	tests := []struct {
-		name string
-		info *debug.BuildInfo
-		want string
+		name    string
+		info    *debug.BuildInfo
+		version string
+		want    string
 	}{
 		{
 			name: "version and revision",
@@ -48,6 +49,17 @@ func TestBuildInfoLine(t *testing.T) {
 				},
 			},
 			want: "easySFTP v1.2.3 (0123456789ab)",
+		},
+		{
+			name: "injected release version",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "0123456789abcdef"},
+				},
+			},
+			version: "v1.2.3",
+			want:    "easySFTP v1.2.3 (0123456789ab)",
 		},
 		{
 			name: "short revision and unknown version",
@@ -71,7 +83,7 @@ func TestBuildInfoLine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := buildInfoLine(tt.info); got != tt.want {
+			if got := buildInfoLine(tt.info, tt.version); got != tt.want {
 				t.Fatalf("buildInfoLine() = %q, want %q", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Summary

Fixes #20.

- Log the easySFTP module version and shortened VCS revision at startup.
- Gracefully skip the log when build information is unavailable.
- Safely handle short revisions and unknown versions.
- Add unit tests for the build information formatting.

## Testing

- `go test ./...`
- `go vet ./...`
- Action launcher tests
- Verified with the action’s production build flags