### PR TITLE
perf: hash sync files through a bounded worker pool

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,9 @@ inputs:
     required: false
     default: "false"
   concurrency:
-    description: Number of files uploaded in parallel.
+    description: >-
+      Number of files uploaded in parallel. Also bounds the worker pool that
+      hashes local files for the sync strategy.
     required: false
     default: "4"
   retries:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 |---|---|---|---|
 | `build-mode` | | `prebuilt` | `prebuilt` downloads the platform-specific release binary and verifies its SHA-256 digest. `source` installs Go and compiles the selected action checkout. |
 | `dry-run` | | `false` | Connect and log what would happen, change nothing. |
-| `concurrency` | | `4` | Number of files uploaded in parallel. |
+| `concurrency` | | `4` | Number of files uploaded in parallel. Also bounds the worker pool that hashes local files for the `sync` strategy. |
 | `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). |
 
 Prebuilt binaries support Linux, macOS, and Windows on both x64 and arm64

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -43,6 +43,8 @@ Notes:
 - The manifest trusts itself: a file changed *on the server* out of band is not
   re-detected until its local content changes. Run `clean` once to reset.
 - Directories left empty by deletions are pruned automatically.
+- Local files are hashed in parallel through a worker pool bounded by
+  `concurrency`, so planning a large tree uses the available runner CPU.
 
 ## `clean`
 

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -2,6 +2,7 @@ package uploader
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -147,6 +148,47 @@ func TestSyncSingleFileRejected(t *testing.T) {
 	_, err := Run(context.Background(), cfg, testLogger{t})
 	if err == nil || !strings.Contains(err.Error(), "requires a directory") {
 		t.Fatalf("expected single-file rejection, got %v", err)
+	}
+}
+
+// hashPlanFiles hashes files concurrently; its result must be identical to
+// hashing each file sequentially with hashFile.
+func TestHashPlanFilesMatchesSequentialHash(t *testing.T) {
+	dir := t.TempDir()
+	files := make([]fileItem, 64)
+	for i := range files {
+		p := filepath.Join(dir, fmt.Sprintf("f%02d.txt", i))
+		if err := os.WriteFile(p, []byte(fmt.Sprintf("content-%d", i)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		files[i] = fileItem{localPath: p}
+	}
+
+	if err := hashPlanFiles(context.Background(), files, 8); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range files {
+		want, err := hashFile(files[i].localPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if files[i].hash == "" {
+			t.Errorf("file %d: hash was not set", i)
+		}
+		if files[i].hash != want {
+			t.Errorf("file %d: hash = %q, want %q", i, files[i].hash, want)
+		}
+	}
+}
+
+// A read error on any file must surface from the pool rather than being lost.
+func TestHashPlanFilesPropagatesError(t *testing.T) {
+	files := []fileItem{
+		{localPath: filepath.Join(t.TempDir(), "does-not-exist")},
+	}
+	if err := hashPlanFiles(context.Background(), files, 4); err == nil {
+		t.Fatal("expected an error hashing a missing file, got nil")
 	}
 }
 

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -73,7 +73,7 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		st := effectiveStrategy(cfg, pair)
 		lines := append(append([]string{}, cfg.IgnoreLines...), pair.Ignore...)
 		matcher := ignore.CompileIgnoreLines(lines...)
-		p, err := buildPlan(pair, st, matcher)
+		p, err := buildPlan(ctx, pair, st, matcher, cfg.Concurrency)
 		if err != nil {
 			return stats, err
 		}
@@ -101,8 +101,10 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 
 // buildPlan walks the local side of an upload pair and computes the remote
 // file and directory layout, honoring the ignore patterns. For the sync
-// strategy it also hashes each file so changed files can be detected.
-func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore.GitIgnore) (plan, error) {
+// strategy it also hashes each file so changed files can be detected; the
+// hashing runs through a bounded worker pool so a large tree uses the
+// available runner CPU instead of being read one file at a time.
+func buildPlan(ctx context.Context, pair config.UploadPair, strategy config.Strategy, matcher *ignore.GitIgnore, concurrency int) (plan, error) {
 	p := plan{pair: pair, strategy: strategy}
 	remoteBase := normalizeRemote(pair.Remote)
 
@@ -169,11 +171,6 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore
 			size:       fi.Size(),
 			mode:       fi.Mode(),
 		}
-		if strategy == config.StrategySync {
-			if item.hash, err = hashFile(fpath); err != nil {
-				return err
-			}
-		}
 		p.files = append(p.files, item)
 		for _, dir := range parentDirs(item.remotePath) {
 			dirSet[dir] = struct{}{}
@@ -184,12 +181,44 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore
 		return p, fmt.Errorf("walking local path %q: %w", pair.Local, err)
 	}
 
+	// The sync strategy needs a content hash per file to detect changes.
+	// Hashing is the slow part of planning a large tree, so run it through a
+	// bounded worker pool instead of reading each file sequentially.
+	if strategy == config.StrategySync {
+		if err := hashPlanFiles(ctx, p.files, concurrency); err != nil {
+			return p, fmt.Errorf("hashing local files under %q: %w", pair.Local, err)
+		}
+	}
+
 	for dir := range dirSet {
 		p.remoteDirs = append(p.remoteDirs, dir)
 	}
 	// Parents sort before their children, so creation order is safe.
 	sort.Strings(p.remoteDirs)
 	return p, nil
+}
+
+// hashPlanFiles fills in each file's sha256 content hash, hashing through a
+// worker pool bounded to concurrency workers so a large tree uses the runner's
+// CPU instead of being read and hashed one file at a time. It is used only by
+// the sync strategy, whose changed-file detection compares content hashes.
+func hashPlanFiles(ctx context.Context, files []fileItem, concurrency int) error {
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+	for i := range files {
+		g.Go(func() error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			hash, err := hashFile(files[i].localPath)
+			if err != nil {
+				return err
+			}
+			files[i].hash = hash
+			return nil
+		})
+	}
+	return g.Wait()
 }
 
 // executePlan performs (or previews) one plan according to its strategy.


### PR DESCRIPTION
Closes #30.

## Problem

The `sync` strategy computed a SHA-256 hash for every local file **sequentially**, inline in the `filepath.WalkDir` callback in `buildPlan`. Planning a large tree therefore read and hashed all content on a single goroutine before the action even connected to the server, leaving most of the runner's CPU idle.

## Chosen optimization

The issue proposed one or both of:

1. Hash files through a bounded worker pool.
2. A size/mtime metadata fast path in the manifest.

This PR implements **option 1 (bounded worker pool)**. It is a pure performance change with no consistency tradeoff, no manifest format change, and no new configuration surface — it reuses the existing `errgroup` + `SetLimit` pattern already used for parallel uploads and the existing `concurrency` input. Option 2 was deliberately left out: its metadata fast path needs the (remote) manifest during local planning, which would require restructuring the "plan locally → connect → reconcile" flow and carries a documented consistency tradeoff.

## Changes

- `internal/uploader/uploader.go`: hashing is moved out of the walk callback into a new `hashPlanFiles` helper that hashes the planned files concurrently, bounded by `concurrency`. `buildPlan` now takes a `context.Context` (for cancellation of a long hashing phase) and the concurrency limit.
- `internal/uploader/sync_test.go`: adds `TestHashPlanFilesMatchesSequentialHash` (concurrent hashes equal the sequential `hashFile` result) and `TestHashPlanFilesPropagatesError` (a read error surfaces from the pool). Existing sync tests continue to cover end-to-end change detection.
- Docs: `action.yml`, `docs/configuration.md` and `docs/strategies.md` note that `concurrency` now also bounds the sync hashing pool.

## Behavior

Unchanged. The same content hashes are computed for the same files; they are just computed in parallel instead of one at a time. No manifest format change, so existing manifests and re-deploys are unaffected.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- `go test -race ./...` — all packages pass (race detector confirms the concurrent hashing is data-race free; each worker writes only its own slice element)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3RTPrgJqyhfHwaNDx2o3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3RTPrgJqyhfHwaNDx2o3D)_