### PR TITLE
perf: create only leaf remote directories to cut round-trips

### DIFF
--- a/internal/uploader/dirsetup_test.go
+++ b/internal/uploader/dirsetup_test.go
@@ -1,0 +1,119 @@
+package uploader
+
+import (
+	"context"
+	"reflect"
+	"sync/atomic"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// TestLeafDirs verifies the set of planned directories is reduced to just the
+// deepest members, since MkdirAll on those recreates every ancestor.
+func TestLeafDirs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty", nil, []string{}},
+		{"single", []string{"/www"}, []string{"/www"}},
+		{
+			name: "linear tree keeps only the deepest",
+			in:   []string{"a", "a/b", "a/b/c", "a/b/c/d"},
+			want: []string{"a/b/c/d"},
+		},
+		{
+			name: "branching tree keeps every branch tip",
+			in:   []string{"a", "a/b", "a/b/c", "a/b/c/d", "a/b/c/e"},
+			want: []string{"a/b/c/d", "a/b/c/e"},
+		},
+		{
+			// A sibling whose name sorts before '/' must not fool the leaf
+			// detection into treating its parent as a leaf.
+			name: "sibling sorting before the separator",
+			in:   []string{"x", "x/a", "x/a/c", "x/a.b"},
+			want: []string{"x/a.b", "x/a/c"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := leafDirs(c.in); !reflect.DeepEqual(got, c.want) {
+				t.Errorf("leafDirs(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestFreshTreeCreatesEachDirectoryOnce verifies a first deploy into an empty
+// remote creates every directory of a deep tree exactly once, with parents
+// created implicitly by MkdirAll on the leaves rather than pre-created level by
+// level.
+func TestFreshTreeCreatesEachDirectoryOnce(t *testing.T) {
+	var ops opCounter
+	srv := startTestServer(t, withOpCounter(&ops))
+
+	local := t.TempDir()
+	// Two leaf directories under a five-level-deep shared trunk.
+	writeTree(t, local, map[string]string{
+		"a/b/c/d/one.txt":   "1",
+		"a/b/c/d/two.txt":   "2",
+		"a/b/c/e/three.txt": "3",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 1
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	// /www + a + b + c + d + e, each created exactly once.
+	if got := atomic.LoadInt64(&ops.mkdir); got != 6 {
+		t.Errorf("first deploy issued %d Mkdir calls; want 6 (one per directory)", got)
+	}
+	if got := readRemote(t, srv, "/www/a/b/c/e/three.txt"); got != "3" {
+		t.Errorf("deep file not uploaded: %q", got)
+	}
+}
+
+// TestExistingTreeConfirmsOnlyLeaves verifies that when every remote directory
+// already exists, the uploader confirms just the leaf directories: it stats one
+// path per leaf and creates nothing, instead of stat'ing every ancestor of
+// every file as the old level-by-level setup did.
+func TestExistingTreeConfirmsOnlyLeaves(t *testing.T) {
+	var ops opCounter
+	srv := startTestServer(t, withOpCounter(&ops))
+
+	// Pre-create the full directory tree so the deploy finds it already present.
+	admin := srv.verifyClient(t)
+	for _, d := range []string{"/www/a/b/c/d", "/www/a/b/c/e"} {
+		if err := admin.MkdirAll(d); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"a/b/c/d/one.txt": "1",
+		"a/b/c/e/two.txt": "2",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 1
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	atomic.StoreInt64(&ops.stat, 0)
+	atomic.StoreInt64(&ops.mkdir, 0)
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt64(&ops.mkdir); got != 0 {
+		t.Errorf("deploy created %d directories; want 0 (all already exist)", got)
+	}
+	// One stat per leaf (/www/a/b/c/d and /www/a/b/c/e), not one per ancestor.
+	if got := atomic.LoadInt64(&ops.stat); got != 2 {
+		t.Errorf("deploy stat'd %d paths for directory setup; want 2 (one per leaf)", got)
+	}
+}

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -42,6 +42,41 @@ func withFailRename() serverOption { return func(s *testServer) { s.failRename =
 // client, simulating a mid-transfer connection drop.
 func withDropAfter(n int64) serverOption { return func(s *testServer) { s.dropAfter = n } }
 
+// withOpCounter wraps the in-memory handlers so the given counter tallies the
+// SFTP methods (Mkdir, Stat) a run issues, letting tests assert how many
+// directory round-trips it makes.
+func withOpCounter(c *opCounter) serverOption {
+	return func(s *testServer) {
+		c.cmd = s.handlers.FileCmd
+		c.list = s.handlers.FileList
+		s.handlers.FileCmd = c
+		s.handlers.FileList = c
+	}
+}
+
+// opCounter delegates to the real in-memory handlers while counting the
+// directory-related methods that flow through them.
+type opCounter struct {
+	cmd   sftp.FileCmder
+	list  sftp.FileLister
+	mkdir int64
+	stat  int64
+}
+
+func (c *opCounter) Filecmd(r *sftp.Request) error {
+	if r.Method == "Mkdir" {
+		atomic.AddInt64(&c.mkdir, 1)
+	}
+	return c.cmd.Filecmd(r)
+}
+
+func (c *opCounter) Filelist(r *sftp.Request) (sftp.ListerAt, error) {
+	if r.Method == "Stat" {
+		atomic.AddInt64(&c.stat, 1)
+	}
+	return c.list.Filelist(r)
+}
+
 const (
 	testUser     = "testuser"
 	testPassword = "testpass"

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -273,20 +273,10 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, client *sftp
 // uploadFiles creates the needed remote directories and uploads files in
 // parallel (or, in dry-run mode, only logs what it would do).
 func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, files []fileItem, dirs []string, stats *Stats, verb string, log Logger) error {
-	for _, dir := range dirs {
-		if cfg.DryRun {
-			continue
+	if !cfg.DryRun {
+		if err := createRemoteDirs(client, dirs, stats); err != nil {
+			return err
 		}
-		if info, err := client.Stat(dir); err == nil {
-			if info.IsDir() {
-				continue
-			}
-			return fmt.Errorf("remote path %q exists but is not a directory", dir)
-		}
-		if err := client.MkdirAll(dir); err != nil {
-			return fmt.Errorf("creating remote directory %q: %w", dir, err)
-		}
-		stats.DirsCreated++
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -321,6 +311,58 @@ func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, f
 		}
 	}
 	return runErr
+}
+
+// createRemoteDirs creates every remote directory the plan needs with as few
+// SFTP round-trips as possible. It calls MkdirAll only on the deepest (leaf)
+// directories: MkdirAll creates any missing parents in the same walk and
+// treats an already-existing directory as success, so ancestors are never
+// stat'd or created one level at a time. Only when a creation fails does it
+// look closer, to report a path that already exists as a file clearly.
+func createRemoteDirs(client *sftp.Client, dirs []string, stats *Stats) error {
+	for _, dir := range leafDirs(dirs) {
+		if err := client.MkdirAll(dir); err != nil {
+			if bad := nonDirConflict(client, dir); bad != "" {
+				return fmt.Errorf("remote path %q exists but is not a directory", bad)
+			}
+			return fmt.Errorf("creating remote directory %q: %w", dir, err)
+		}
+		stats.DirsCreated++
+	}
+	return nil
+}
+
+// leafDirs reduces a directory set to just the deepest members: those that are
+// not the parent of another directory in the set. The plan already lists every
+// ancestor of every file, so calling MkdirAll on the leaves alone still creates
+// the whole tree — but with far fewer calls on deep hierarchies, where each
+// leaf's parents would otherwise be created and checked one level at a time.
+func leafDirs(dirs []string) []string {
+	hasChild := make(map[string]struct{}, len(dirs))
+	for _, d := range dirs {
+		hasChild[path.Dir(d)] = struct{}{}
+	}
+	leaves := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if _, parent := hasChild[d]; !parent {
+			leaves = append(leaves, d)
+		}
+	}
+	sort.Strings(leaves)
+	return leaves
+}
+
+// nonDirConflict returns the shallowest ancestor of dir (dir itself included)
+// that exists on the server but is not a directory, or "" if there is none. It
+// is consulted only after MkdirAll fails, to turn a low-level error into a
+// clear message naming the offending path.
+func nonDirConflict(client *sftp.Client, dir string) string {
+	for _, d := range append(parentDirs(dir), dir) {
+		if info, err := client.Stat(d); err == nil && !info.IsDir() {
+			return d
+		}
+	}
+	return ""
 }
 
 // planVerb returns the log prefix that distinguishes a dry run from a real one.


### PR DESCRIPTION
Closes #31.

## Problem

Before an upload, `uploadFiles` stat'd **every** planned remote directory
(every ancestor of every file) and then called `MkdirAll` on each one. On a
deep or wide tree this walked the hierarchy one level at a time, and `MkdirAll`
re-stat'd along the way — many redundant SFTP round-trips, which hurt most on
high-latency connections.

## Change

- Reduce the planned directory set to its **leaves** — the deepest directories,
  i.e. those that are not the parent of any other planned directory — and call
  `MkdirAll` only on those. Because the plan already contains every ancestor of
  every file, `MkdirAll` on the leaves alone still creates the whole tree, while
  creating each ancestor implicitly and exactly once.
- Drop the per-directory pre-`Stat`. `MkdirAll` already treats an
  already-existing directory as success, so an existing tree is the normal fast
  path (one stat per leaf instead of one per ancestor).
- Preserve the clear `remote path %q exists but is not a directory` error by
  inspecting the path **only** when a creation actually fails, so the happy path
  stays cheap.

### Effect (5-level tree, two leaf dirs)

| Scenario | Before | After |
|---|---|---|
| Directory stats on re-deploy (tree exists) | one per directory | one per leaf |
| `Mkdir` calls on first deploy | one per directory | one per directory (unchanged) |

## Tests

- `TestLeafDirs` — unit test for the leaf reduction, including a sibling name
  that sorts before the path separator.
- `TestFreshTreeCreatesEachDirectoryOnce` — a first deploy `Mkdir`s each
  directory exactly once (parents created implicitly).
- `TestExistingTreeConfirmsOnlyLeaves` — when the tree already exists, setup
  creates nothing and stats only the leaves, not every ancestor. Backed by a new
  op-counting test-server wrapper.

Full suite passes (`go test -race ./...`), `gofmt` and `go vet` clean.

No user-facing behaviour changes: remote directories are still created
automatically and existing directories are still the normal success case, so no
documentation update was needed. The changelog is left to release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VreP1rKkY4dGQiYrp3G8jZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VreP1rKkY4dGQiYrp3G8jZ)_