### PR TITLE
feat!: remove the 'delete' input in favor of 'strategy: clean'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Plant stale remote file
         run: docker exec sftp sh -c 'echo stale > /home/demo/upload/stale.html && chown demo /home/demo/upload/stale.html'
 
-      - name: Upload with delete mode
+      - name: Upload with clean strategy
         id: clean-upload
         uses: ./
         with:
@@ -161,12 +161,12 @@ jobs:
           host-key-fingerprint: ${{ steps.hostkey.outputs.fingerprints }}
           uploads: ./site/ => /upload/
           ignore: "*.log"
-          delete: true
+          strategy: clean
 
-      - name: Verify delete mode
+      - name: Verify clean strategy
         run: |
           if docker exec sftp test -e /home/demo/upload/stale.html; then
-            echo "::error::stale file survived delete mode"
+            echo "::error::stale file survived the clean strategy"
             exit 1
           fi
           docker exec sftp test -f /home/demo/upload/index.html

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ inputs:
     description: >-
       Path to an optional YAML config file describing the deployment targets,
       their strategy and delete guards (see docs/configuration.md). When set, it
-      replaces the uploads/strategy/delete/ignore inputs. Connection settings
+      replaces the uploads/strategy/ignore inputs. Connection settings
       always come from the inputs above.
     required: false
   strategy:
@@ -64,7 +64,7 @@ inputs:
       Reconciliation strategy for every target: "overlay" (upload only, never
       delete — the default), "sync" (upload changed files and delete files no
       longer present locally, tracked via a manifest) or "clean" (wipe the
-      remote target directory, then upload). Mutually exclusive with delete.
+      remote target directory, then upload).
     required: false
   ignore:
     description: >-
@@ -76,8 +76,9 @@ inputs:
     required: false
   delete:
     description: >-
-      Legacy alias for strategy "clean": if "true", delete all existing files
-      inside each remote target directory before uploading. Prefer "strategy".
+      Removed in v2 — use "strategy: clean" instead. Still declared so that a
+      workflow passing it fails loudly rather than silently degrading to the
+      "overlay" default. Will be deleted in v3.
     required: false
     default: "false"
   dry-run:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,13 +30,16 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `uploads` | ² | - | One `local => remote` mapping per line. Directories are uploaded recursively; single files are supported too. |
-| `config-file` | | - | Path to a [YAML config file](#the-yaml-config-file) with per-target strategies and delete guards. Mutually exclusive with `uploads`/`strategy`/`delete`/`ignore`/`ignore-from`. |
+| `config-file` | | - | Path to a [YAML config file](#the-yaml-config-file) with per-target strategies and delete guards. Mutually exclusive with `uploads`/`strategy`/`ignore`/`ignore-from`. |
 | `strategy` | | `overlay` | [Reconciliation strategy](strategies.md): `overlay`, `sync` or `clean`. |
 | `ignore` | | - | Gitignore-style exclude patterns, one per line. `!` re-includes. |
 | `ignore-from` | | - | Path to a file with exclude patterns (e.g. `.sftpignore`). |
-| `delete` | | `false` | Legacy alias for `strategy: clean`. Prefer `strategy`. |
 
 ² Required unless `config-file` is set.
+
+> **Removed in v2:** the `delete` input is gone — use `strategy: clean`.
+> Passing `delete: true` now fails the run with a migration hint instead of
+> silently falling back to `overlay`. The declaration disappears in v3.
 
 ### Behavior
 
@@ -164,8 +167,8 @@ targets:
 | `targets[].ignore` | | - | Per-target excludes, additive to the global list. |
 
 Unknown keys are rejected with an error (they are never silently ignored), and
-`config-file` cannot be combined with the `uploads`, `strategy`, `delete`,
-`ignore` or `ignore-from` inputs.
+`config-file` cannot be combined with the `uploads`, `strategy`, `ignore` or
+`ignore-from` inputs.
 
 ### Editor support
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -52,7 +52,7 @@ Deletes **everything** inside the remote target directory first, then uploads
 all local files. Use it when you want a guaranteed-fresh deploy and nothing in
 the target directory needs to survive.
 
-The `delete: true` input is a legacy alias for `strategy: clean`.
+The `delete: true` input was removed in v2; `strategy: clean` replaces it.
 
 ## Delete guards
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -126,8 +126,14 @@ the limit in the config file.
 
 ### `when 'config-file' is set, put targets/strategy/ignore/guards in the file`
 
-`config-file` replaces the `uploads`, `strategy`, `delete`, `ignore` and
-`ignore-from` inputs. Remove them from the step. Connection inputs stay.
+`config-file` replaces the `uploads`, `strategy`, `ignore` and `ignore-from`
+inputs. Remove them from the step. Connection inputs stay.
+
+### `the 'delete' input was removed in v2 — use 'strategy: clean' instead`
+
+Replace `delete: true` with `strategy: clean` in your step. The inputs are
+equivalent; `delete` only remains declared so that this error fires instead of
+the run silently degrading to the `overlay` default.
 
 ### `strategy "sync" requires a directory, but local path ... is a single file`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,7 +62,6 @@ type Config struct {
 	IgnoreLines []string
 	Guards      Guards
 
-	Delete      bool // legacy input; mapped to the clean strategy
 	DryRun      bool
 	Concurrency int
 	Retries     int
@@ -96,8 +95,12 @@ func Load() (*Config, error) {
 	if cfg.Retries, err = parseInt(get("RETRIES"), 2); err != nil {
 		return nil, fmt.Errorf("invalid retries: %w", err)
 	}
-	if cfg.Delete, err = parseBool(get("DELETE"), false); err != nil {
+	// Tombstone: 'delete' is still declared in action.yml so that a workflow
+	// passing it fails loudly here instead of silently falling back to overlay.
+	if deleted, err := parseBool(get("DELETE"), false); err != nil {
 		return nil, fmt.Errorf("invalid delete: %w", err)
+	} else if deleted {
+		return nil, fmt.Errorf("the 'delete' input was removed in v2 — use 'strategy: clean' instead")
 	}
 	if cfg.DryRun, err = parseBool(get("DRY_RUN"), false); err != nil {
 		return nil, fmt.Errorf("invalid dry-run: %w", err)
@@ -118,16 +121,16 @@ func Load() (*Config, error) {
 	ignoreFrom := get("IGNORE_FROM")
 
 	if configFile != "" {
-		if strings.TrimSpace(uploadsInput) != "" || strategyInput != "" || cfg.Delete ||
+		if strings.TrimSpace(uploadsInput) != "" || strategyInput != "" ||
 			strings.TrimSpace(ignoreInput) != "" || ignoreFrom != "" {
 			return nil, fmt.Errorf("when 'config-file' is set, put targets/strategy/ignore/guards " +
-				"in the file — do not also set the uploads, strategy, delete, ignore or ignore-from inputs")
+				"in the file — do not also set the uploads, strategy, ignore or ignore-from inputs")
 		}
 		if err := loadConfigFile(cfg, configFile); err != nil {
 			return nil, err
 		}
 	} else {
-		strategy, err := resolveStrategy(strategyInput, cfg.Delete)
+		strategy, err := resolveStrategy(strategyInput)
 		if err != nil {
 			return nil, err
 		}
@@ -153,23 +156,16 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
-// resolveStrategy maps the strategy input (and the legacy delete flag) to a
-// concrete strategy, rejecting an ambiguous combination of both.
-func resolveStrategy(input string, delete bool) (Strategy, error) {
-	if input != "" {
-		if delete {
-			return "", fmt.Errorf("set either 'strategy' or 'delete', not both")
-		}
-		s := Strategy(input)
-		if !s.valid() {
-			return "", fmt.Errorf("input 'strategy' must be overlay, sync or clean, got %q", input)
-		}
-		return s, nil
+// resolveStrategy maps the strategy input to a concrete strategy.
+func resolveStrategy(input string) (Strategy, error) {
+	if input == "" {
+		return StrategyOverlay, nil
 	}
-	if delete {
-		return StrategyClean, nil
+	s := Strategy(input)
+	if !s.valid() {
+		return "", fmt.Errorf("input 'strategy' must be overlay, sync or clean, got %q", input)
 	}
-	return StrategyOverlay, nil
+	return s, nil
 }
 
 func (c *Config) validate() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,7 +56,7 @@ func TestLoadDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.Retries != 2 || cfg.Delete || cfg.DryRun {
+	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.Retries != 2 || cfg.DryRun {
 		t.Errorf("unexpected defaults: %+v", cfg)
 	}
 	if cfg.Timeout.Seconds() != 30 {

--- a/internal/config/configfile_test.go
+++ b/internal/config/configfile_test.go
@@ -107,23 +107,18 @@ func TestStrategyInput(t *testing.T) {
 	}
 }
 
-func TestStrategyInputConflictsWithDelete(t *testing.T) {
+func TestDeleteInputIsRejected(t *testing.T) {
 	setBaseEnv(t)
-	t.Setenv("EASYSFTP_STRATEGY", "clean")
 	t.Setenv("EASYSFTP_DELETE", "true")
-	if _, err := Load(); err == nil || !strings.Contains(err.Error(), "not both") {
-		t.Fatalf("expected strategy/delete conflict error, got %v", err)
+	if _, err := Load(); err == nil || !strings.Contains(err.Error(), "strategy: clean") {
+		t.Fatalf("expected the delete tombstone error, got %v", err)
 	}
 }
 
-func TestDeleteMapsToClean(t *testing.T) {
+func TestDeleteFalseIsAccepted(t *testing.T) {
 	setBaseEnv(t)
-	t.Setenv("EASYSFTP_DELETE", "true")
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Uploads[0].Strategy != StrategyClean {
-		t.Errorf("expected delete to map to clean, got %q", cfg.Uploads[0].Strategy)
+	t.Setenv("EASYSFTP_DELETE", "false")
+	if _, err := Load(); err != nil {
+		t.Fatalf("delete=false must stay accepted (it is the action.yml default): %v", err)
 	}
 }

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -70,7 +70,7 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	// we touch the network.
 	plans := make([]plan, 0, len(cfg.Uploads))
 	for _, pair := range cfg.Uploads {
-		st := effectiveStrategy(cfg, pair)
+		st := effectiveStrategy(pair)
 		lines := append(append([]string{}, cfg.IgnoreLines...), pair.Ignore...)
 		matcher := ignore.CompileIgnoreLines(lines...)
 		p, err := buildPlan(ctx, pair, st, matcher, cfg.Concurrency)
@@ -373,14 +373,11 @@ func planVerb(cfg *config.Config) string {
 	return ""
 }
 
-// effectiveStrategy resolves the strategy for a pair, falling back to the
-// legacy delete flag for callers that construct a Config directly.
-func effectiveStrategy(cfg *config.Config, pair config.UploadPair) config.Strategy {
+// effectiveStrategy resolves the strategy for a pair, defaulting to overlay for
+// callers that construct a Config directly.
+func effectiveStrategy(pair config.UploadPair) config.Strategy {
 	if pair.Strategy != "" {
 		return pair.Strategy
-	}
-	if cfg.Delete {
-		return config.StrategyClean
 	}
 	return config.StrategyOverlay
 }

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -150,7 +150,7 @@ func TestUploadSingleFile(t *testing.T) {
 	}
 }
 
-func TestDeleteMode(t *testing.T) {
+func TestCleanStrategy(t *testing.T) {
 	srv := startTestServer(t)
 
 	// Pre-populate the remote target with stale content.
@@ -173,8 +173,7 @@ func TestDeleteMode(t *testing.T) {
 	writeTree(t, local, map[string]string{"index.html": "fresh"})
 
 	cfg := baseConfig(srv)
-	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
-	cfg.Delete = true
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategyClean}}
 
 	stats, err := Run(context.Background(), cfg, testLogger{t})
 	if err != nil {


### PR DESCRIPTION
Closes #50

`delete: true` and `strategy: clean` were not similar — they were identical, and `resolveStrategy` did nothing but map one onto the other. This removes the alias, so `strategy` is the only way to select reconciliation behavior.

## The tombstone

`delete` stays **declared** in `action.yml`. GitHub Actions only prints a warning for unknown inputs and continues, so removing the declaration outright would make a workflow that still passes `delete: true` fall through to the `overlay` default and *silently stop deleting* — green checkmark, stale files piling up forever. Instead, `Load()` now fails the run:

```
the 'delete' input was removed in v2 — use 'strategy: clean' instead
```

`delete: false` stays accepted, since that is the declared default and every run sets it. The declaration goes away in v3.

## Changes

- `action.yml` — `delete` description replaced with the removal notice; dropped the stale `delete` mentions from the `config-file` and `strategy` descriptions.
- `internal/config/config.go` — dropped `Config.Delete`, the `|| cfg.Delete ||` exclusion condition and the `resolveStrategy` delete parameter (with its `not both` error); added the tombstone check in `Load()`.
- `internal/uploader/uploader.go` — `effectiveStrategy` collapses to "pair strategy, else overlay" and no longer needs the `cfg` argument.
- `.github/workflows/ci.yml` — the delete-mode self-test now uses `strategy: clean`; assertions unchanged.
- Tests — the conflict and alias tests are replaced by one asserting the tombstone error fires and one pinning that `delete: false` still loads.
- Docs — `configuration.md`, `strategies.md`, `troubleshooting.md` (new entry for the error).

CHANGELOG is release-please generated; the `feat!:` commit carries the breaking change and the one-line migration.

## Verification

`go build`, `go vet` and `go test ./...` all pass locally. The end-to-end clean-strategy self-test against the dockerised SFTP server runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
