### PR TITLE
feat(sync): add opt-in sync-fast-path to skip re-hashing unchanged files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,19 @@ inputs:
       hashes local files for the sync strategy.
     required: false
     default: "4"
+  sync-fast-path:
+    description: >-
+      If "true", the sync strategy skips re-hashing a file whose size and
+      modification time still match its last-synced manifest entry, reusing
+      the stored hash instead. This is faster on large trees but, like
+      rsync's quick check, can miss a same-size edit made within the same
+      second as the previous one — see docs/strategies.md. Off by default,
+      since content-hash comparison is what "sync" advertises. Only helps
+      when local modification times are meaningful across runs (e.g. a
+      restored build cache); a fresh "actions/checkout" gives every file a
+      new modification time on every run, so this has no effect there.
+    required: false
+    default: "false"
   retries:
     description: How often a failed file upload is retried (with backoff).
     required: false
@@ -171,5 +184,6 @@ runs:
         EASYSFTP_DELETE: ${{ inputs.delete }}
         EASYSFTP_DRY_RUN: ${{ inputs.dry-run }}
         EASYSFTP_CONCURRENCY: ${{ inputs.concurrency }}
+        EASYSFTP_SYNC_FAST_PATH: ${{ inputs.sync-fast-path }}
         EASYSFTP_RETRIES: ${{ inputs.retries }}
         EASYSFTP_TIMEOUT: ${{ inputs.timeout }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,7 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 | `build-mode` | | `prebuilt` | `prebuilt` downloads the platform-specific release binary and verifies its SHA-256 digest. `source` installs Go and compiles the selected action checkout. |
 | `dry-run` | | `false` | Connect and log what would happen, change nothing. |
 | `concurrency` | | `4` | Number of files uploaded in parallel. Also bounds the worker pool that hashes local files for the `sync` strategy. |
+| `sync-fast-path` | | `false` | For the `sync` strategy, reuse a file's manifest hash instead of re-reading it when size and modification time still match. See [the sync-fast-path trade-off](strategies.md#sync-fast-path-skip-re-hashing-unchanged-files). |
 | `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). |
 
 Prebuilt binaries support Linux, macOS, and Windows on both x64 and arm64

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -46,6 +46,41 @@ Notes:
 - Local files are hashed in parallel through a worker pool bounded by
   `concurrency`, so planning a large tree uses the available runner CPU.
 
+### `sync-fast-path`: skip re-hashing unchanged files
+
+By default, `sync` re-reads and re-hashes **every** local file on every run to
+decide what changed — that's what makes its "unchanged" comparison exact. For
+a large tree where almost nothing changes, that's still a lot of local I/O.
+
+Setting `sync-fast-path: true` adds a cheaper check first: if a file's size
+and modification time still match what the manifest recorded for it last
+time, its stored hash is reused and the file is never re-read. This is the
+same trade rsync's "quick check" makes.
+
+**The trade-off, precisely:** a file whose content changed *without* its size
+or modification time changing is invisible to this check and will be missed
+— for example two edits that happen to produce the same file size within the
+same mtime second (mtimes have one-second resolution on most filesystems).
+Without `sync-fast-path`, `sync` never misses a content change, because it
+always compares actual content hashes; this is what you give up in exchange
+for skipping local reads.
+
+**When it actually helps:** local modification times need to be meaningful
+across runs for the check to ever hit. A fresh `actions/checkout` gives every
+file a brand-new modification time on every run — `sync-fast-path` has
+nothing to skip there and degrades gracefully to full hashing. It pays off
+when the local tree is a restored build cache (`actions/cache`, a persisted
+runner, `git restore-timestamps`, …) whose unchanged files keep their old
+modification times between runs.
+
+If you suspect a stale hash was reused for the wrong reason, delete the
+target's `.easysftp-manifest.json` (or run `strategy: clean` once) to force a
+full re-hash on the next sync.
+
+Manifests written before this option existed have no recorded modification
+time; the first sync after upgrading re-hashes everything once and then
+starts recording it.
+
 ## `clean`
 
 Deletes **everything** inside the remote target directory first, then uploads

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,10 +62,11 @@ type Config struct {
 	IgnoreLines []string
 	Guards      Guards
 
-	DryRun      bool
-	Concurrency int
-	Retries     int
-	Timeout     time.Duration
+	DryRun       bool
+	Concurrency  int
+	Retries      int
+	Timeout      time.Duration
+	SyncFastPath bool
 }
 
 const envPrefix = "EASYSFTP_"
@@ -104,6 +105,9 @@ func Load() (*Config, error) {
 	}
 	if cfg.DryRun, err = parseBool(get("DRY_RUN"), false); err != nil {
 		return nil, fmt.Errorf("invalid dry-run: %w", err)
+	}
+	if cfg.SyncFastPath, err = parseBool(get("SYNC_FAST_PATH"), false); err != nil {
+		return nil, fmt.Errorf("invalid sync-fast-path: %w", err)
 	}
 
 	timeoutSec, err := parseInt(get("TIMEOUT"), 30)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,7 +45,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("EASYSFTP_UPLOADS", "./dist/ => /www/")
 	for _, name := range []string{"PORT", "PRIVATE_KEY", "PASSPHRASE", "HOST_KEY_FINGERPRINT",
 		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "RETRIES", "TIMEOUT",
-		"CONFIG_FILE", "STRATEGY"} {
+		"SYNC_FAST_PATH", "CONFIG_FILE", "STRATEGY"} {
 		t.Setenv("EASYSFTP_"+name, "")
 	}
 }
@@ -56,7 +56,7 @@ func TestLoadDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.Retries != 2 || cfg.DryRun {
+	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.Retries != 2 || cfg.DryRun || cfg.SyncFastPath {
 		t.Errorf("unexpected defaults: %+v", cfg)
 	}
 	if cfg.Timeout.Seconds() != 30 {
@@ -76,6 +76,7 @@ func TestLoadValidation(t *testing.T) {
 		{"missing uploads", map[string]string{"EASYSFTP_UPLOADS": ""}, "'uploads' is required"},
 		{"bad port", map[string]string{"EASYSFTP_PORT": "99999"}, "'port' must be between"},
 		{"bad bool", map[string]string{"EASYSFTP_DRY_RUN": "yes-please"}, "invalid dry-run"},
+		{"bad sync-fast-path bool", map[string]string{"EASYSFTP_SYNC_FAST_PATH": "yes-please"}, "invalid sync-fast-path"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -112,5 +113,18 @@ func TestLoadIgnoreFrom(t *testing.T) {
 		if cfg.IgnoreLines[i] != want[i] {
 			t.Errorf("ignore line %d: expected %q, got %q", i, want[i], cfg.IgnoreLines[i])
 		}
+	}
+}
+
+func TestLoadSyncFastPath(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("EASYSFTP_SYNC_FAST_PATH", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.SyncFastPath {
+		t.Error("expected SyncFastPath to be true")
 	}
 }

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -22,10 +22,25 @@ import (
 // so files placed on the server by others are left untouched.
 const manifestName = ".easysftp-manifest.json"
 
-// manifest records the relative paths and content hashes of the last sync.
+// manifestVersion is written to every manifest this version of easySFTP
+// produces. v1 manifests (hash only, no size/mtime) are still read; see
+// readManifest.
+const manifestVersion = 2
+
+// manifestEntry records what is known about one file from the last sync.
+// Size and MTime enable the size+mtime fast path in hashPlanFiles: a v1
+// manifest entry has MTime 0, which never matches and always falls back to a
+// full re-hash.
+type manifestEntry struct {
+	Hash  string `json:"hash"`
+	Size  int64  `json:"size"`
+	MTime int64  `json:"mtime"` // local modification time at upload, unix seconds
+}
+
+// manifest records what the last sync uploaded, keyed by relative path.
 type manifest struct {
-	Version int               `json:"version"`
-	Files   map[string]string `json:"files"` // rel path => sha256 hex
+	Version int                      `json:"version"`
+	Files   map[string]manifestEntry `json:"files"`
 }
 
 // executeSync reconciles the remote target with the local tree using the
@@ -38,11 +53,23 @@ func executeSync(ctx context.Context, cfg *config.Config, client *sftp.Client, p
 
 	old := readManifest(client, base, log)
 
-	local := make(map[string]string, len(p.files))
+	// Hash after reading the manifest (not during buildPlan) so that, with
+	// sync-fast-path opted in, unchanged files whose size and mtime still
+	// match their manifest entry can reuse the stored hash instead of being
+	// re-read from disk. See hashPlanFiles.
+	var cached map[string]manifestEntry
+	if cfg.SyncFastPath {
+		cached = old.Files
+	}
+	if err := hashPlanFiles(ctx, p.files, cfg.Concurrency, cached); err != nil {
+		return fmt.Errorf("hashing local files under %q: %w", p.pair.Local, err)
+	}
+
+	local := make(map[string]manifestEntry, len(p.files))
 	var upload []fileItem
 	for _, f := range p.files {
-		local[f.rel] = f.hash
-		if h, ok := old.Files[f.rel]; !ok || h != f.hash {
+		local[f.rel] = manifestEntry{Hash: f.hash, Size: f.size, MTime: f.mtime}
+		if e, ok := old.Files[f.rel]; !ok || e.Hash != f.hash {
 			upload = append(upload, f)
 		}
 	}
@@ -55,7 +82,7 @@ func executeSync(ctx context.Context, cfg *config.Config, client *sftp.Client, p
 	}
 	sort.Strings(toDelete)
 
-	// ponytail: manifest is trusted — a file changed on the server out of band
+	// note: manifest is trusted — a file changed on the server out of band
 	// is not re-detected until its local content changes. Run clean to reset.
 	log.Infof("%ssync: %d to upload, %d to delete, %d unchanged",
 		verb, len(upload), len(toDelete), len(p.files)-len(upload))
@@ -89,7 +116,7 @@ func executeSync(ctx context.Context, cfg *config.Config, client *sftp.Client, p
 	}
 
 	pruneEmptyDirs(client, base, toDelete)
-	if err := writeManifest(client, base, manifest{Version: 1, Files: local}); err != nil {
+	if err := writeManifest(client, base, manifest{Version: manifestVersion, Files: local}); err != nil {
 		return fmt.Errorf("writing sync manifest in %q: %w", base, err)
 	}
 	return nil
@@ -98,8 +125,13 @@ func executeSync(ctx context.Context, cfg *config.Config, client *sftp.Client, p
 // readManifest loads the remote manifest. A missing manifest means a first
 // sync (empty). A corrupt one is treated the same, with a warning, so a bad
 // manifest degrades to "upload everything, delete nothing" instead of failing.
+//
+// Both the current (v2: hash+size+mtime) and old (v1: hash only) formats are
+// accepted; a v1 entry decodes with MTime 0, which never matches the fast
+// path in hashPlanFiles, so upgrading from a v1 manifest costs one full
+// re-hash and then writes v2 from then on.
 func readManifest(client *sftp.Client, dir string, log Logger) manifest {
-	empty := manifest{Version: 1, Files: map[string]string{}}
+	empty := manifest{Version: manifestVersion, Files: map[string]manifestEntry{}}
 	f, err := client.Open(path.Join(dir, manifestName))
 	if err != nil {
 		return empty
@@ -111,12 +143,26 @@ func readManifest(client *sftp.Client, dir string, log Logger) manifest {
 		log.Warningf("could not read sync manifest in %s (%v) — treating as first sync", dir, err)
 		return empty
 	}
-	var m manifest
-	if err := json.Unmarshal(data, &m); err != nil || m.Files == nil {
-		log.Warningf("sync manifest in %s is unreadable — treating as first sync", dir)
-		return empty
+
+	var v2 manifest
+	if err := json.Unmarshal(data, &v2); err == nil && v2.Files != nil {
+		return v2
 	}
-	return m
+
+	var v1 struct {
+		Version int               `json:"version"`
+		Files   map[string]string `json:"files"`
+	}
+	if err := json.Unmarshal(data, &v1); err == nil && v1.Files != nil {
+		files := make(map[string]manifestEntry, len(v1.Files))
+		for rel, hash := range v1.Files {
+			files[rel] = manifestEntry{Hash: hash}
+		}
+		return manifest{Version: v1.Version, Files: files}
+	}
+
+	log.Warningf("sync manifest in %s is unreadable — treating as first sync", dir)
+	return empty
 }
 
 // writeManifest atomically writes the manifest into dir.

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -2,11 +2,16 @@ package uploader
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
 
 	"github.com/eiserv/easySFTP/internal/config"
 )
@@ -164,7 +169,7 @@ func TestHashPlanFilesMatchesSequentialHash(t *testing.T) {
 		files[i] = fileItem{localPath: p}
 	}
 
-	if err := hashPlanFiles(context.Background(), files, 8); err != nil {
+	if err := hashPlanFiles(context.Background(), files, 8, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -187,9 +192,221 @@ func TestHashPlanFilesPropagatesError(t *testing.T) {
 	files := []fileItem{
 		{localPath: filepath.Join(t.TempDir(), "does-not-exist")},
 	}
-	if err := hashPlanFiles(context.Background(), files, 4); err == nil {
+	if err := hashPlanFiles(context.Background(), files, 4, nil); err == nil {
 		t.Fatal("expected an error hashing a missing file, got nil")
 	}
+}
+
+// When a file's size and mtime still match its manifest entry, hashPlanFiles
+// must reuse the stored hash instead of reading the file — proven here by
+// giving it a wrong-but-matching cached hash and checking it wins.
+func TestHashPlanFilesFastPathReusesCachedHash(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(p, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []fileItem{{localPath: p, rel: "a.txt", size: fi.Size(), mtime: fi.ModTime().Unix()}}
+	cached := map[string]manifestEntry{
+		"a.txt": {Hash: "stale-cached-hash", Size: fi.Size(), MTime: fi.ModTime().Unix()},
+	}
+
+	if err := hashPlanFiles(context.Background(), files, 4, cached); err != nil {
+		t.Fatal(err)
+	}
+	if files[0].hash != "stale-cached-hash" {
+		t.Errorf("fast path did not reuse the cached hash: got %q", files[0].hash)
+	}
+}
+
+// A manifest entry whose size or mtime differs must trigger a real re-hash,
+// not a false-positive fast-path hit.
+func TestHashPlanFilesFastPathMissOnMismatch(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(p, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := hashFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []manifestEntry{
+		{Hash: "stale", Size: fi.Size() + 1, MTime: fi.ModTime().Unix()}, // size mismatch
+		{Hash: "stale", Size: fi.Size(), MTime: fi.ModTime().Unix() + 1}, // mtime mismatch
+		{Hash: "stale", Size: fi.Size(), MTime: 0},                       // v1 upgrade: MTime unknown
+	}
+	for _, entry := range cases {
+		files := []fileItem{{localPath: p, rel: "a.txt", size: fi.Size(), mtime: fi.ModTime().Unix()}}
+		cached := map[string]manifestEntry{"a.txt": entry}
+		if err := hashPlanFiles(context.Background(), files, 4, cached); err != nil {
+			t.Fatal(err)
+		}
+		if files[0].hash != want {
+			t.Errorf("entry %+v: expected a real re-hash, got %q want %q", entry, files[0].hash, want)
+		}
+	}
+}
+
+// A manifest written by an older easySFTP version (v1: hash only, no
+// size/mtime) must still be read correctly — an upgrade re-hashes once, then
+// starts writing v2 manifests with the fast-path fields populated.
+// With sync-fast-path opted in, an unchanged file (same size, same mtime) is
+// skipped without a real re-hash — behavior stays identical to the default,
+// only the local I/O it takes to get there changes. A changed file with a
+// distinct size and a clearly later mtime is still detected and re-uploaded
+// (size or mtime differing is all the fast path needs).
+func TestSyncFastPathSkipsUnchangedFile(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1", "keep.txt": "keep"})
+
+	cfg := syncConfig(srv, local)
+	cfg.SyncFastPath = true
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(local, "a.txt"), []byte("twenty-two"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(filepath.Join(local, "a.txt"), future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 1 || stats.FilesSkipped != 1 {
+		t.Fatalf("up=%d skip=%d, want 1/1", stats.FilesUploaded, stats.FilesSkipped)
+	}
+	if got := readRemote(t, srv, "/www/a.txt"); got != "twenty-two" {
+		t.Errorf("changed file was not re-uploaded: %q", got)
+	}
+}
+
+// Documents the known limitation: with sync-fast-path on, a same-size edit
+// that lands within the same mtime second as the file it replaces is
+// invisible to the size+mtime check and is missed — exactly the tradeoff
+// action.yml and docs/strategies.md describe. This is not a "should" test;
+// it pins the documented behavior so a future change to the comparison
+// doesn't silently alter it either way.
+func TestSyncFastPathMissesSameSecondSameSizeEdit(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1"})
+
+	cfg := syncConfig(srv, local)
+	cfg.SyncFastPath = true
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	fi, err := os.Stat(filepath.Join(local, "a.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime := fi.ModTime()
+
+	// Same size ("1" -> "2"), mtime forced back to exactly what the manifest
+	// already recorded — simulating two same-size edits landing in the same
+	// mtime second, which second-granularity filesystem clocks make common.
+	writeTree(t, local, map[string]string{"a.txt": "2"})
+	if err := os.Chtimes(filepath.Join(local, "a.txt"), mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	if got := readRemote(t, srv, "/www/a.txt"); got != "1" {
+		t.Fatalf("expected the fast path to miss the edit and leave the old content, got %q", got)
+	}
+}
+
+func TestSyncUpgradesV1Manifest(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1", "keep.txt": "keep"})
+
+	hashA, err := hashFile(filepath.Join(local, "a.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashKeep, err := hashFile(filepath.Join(local, "keep.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/www"); err != nil {
+		t.Fatal(err)
+	}
+	v1 := fmt.Sprintf(`{"version":1,"files":{"a.txt":%q,"keep.txt":%q}}`, hashA, hashKeep)
+	f, err := client.Create("/www/" + manifestName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte(v1)); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	// The v1 manifest lists files that were never actually uploaded; put them
+	// on the server too so this looks like a real prior sync.
+	for name, content := range map[string]string{"a.txt": "1", "keep.txt": "keep"} {
+		wf, err := client.Create("/www/" + name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wf.Write([]byte(content))
+		wf.Close()
+	}
+
+	stats, err := Run(context.Background(), syncConfig(srv, local), testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 0 || stats.FilesDeleted != 0 || stats.FilesSkipped != 2 {
+		t.Fatalf("upgrading a v1 manifest: up=%d del=%d skip=%d, want 0/0/2", stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped)
+	}
+
+	data, err := io.ReadAll(mustOpen(t, client, "/www/"+manifestName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got manifest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("rewritten manifest is not valid v2 JSON: %v", err)
+	}
+	if got.Version != manifestVersion {
+		t.Errorf("manifest version = %d, want %d", got.Version, manifestVersion)
+	}
+	if e := got.Files["a.txt"]; e.Size == 0 || e.MTime == 0 {
+		t.Errorf("rewritten manifest entry missing size/mtime: %+v", e)
+	}
+}
+
+func mustOpen(t *testing.T, client *sftp.Client, path string) *sftp.File {
+	t.Helper()
+	f, err := client.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	return f
 }
 
 func TestSyncDryRunChangesNothing(t *testing.T) {

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -48,6 +48,7 @@ type fileItem struct {
 	remotePath string // slash-separated remote path
 	rel        string // slash path relative to the remote base (manifest key)
 	size       int64
+	mtime      int64 // local modification time, unix seconds
 	mode       fs.FileMode
 	hash       string // sha256 hex of the local content; only set for the sync strategy
 }
@@ -73,7 +74,7 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		st := effectiveStrategy(pair)
 		lines := append(append([]string{}, cfg.IgnoreLines...), pair.Ignore...)
 		matcher := ignore.CompileIgnoreLines(lines...)
-		p, err := buildPlan(ctx, pair, st, matcher, cfg.Concurrency)
+		p, err := buildPlan(pair, st, matcher)
 		if err != nil {
 			return stats, err
 		}
@@ -100,11 +101,11 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 }
 
 // buildPlan walks the local side of an upload pair and computes the remote
-// file and directory layout, honoring the ignore patterns. For the sync
-// strategy it also hashes each file so changed files can be detected; the
-// hashing runs through a bounded worker pool so a large tree uses the
-// available runner CPU instead of being read one file at a time.
-func buildPlan(ctx context.Context, pair config.UploadPair, strategy config.Strategy, matcher *ignore.GitIgnore, concurrency int) (plan, error) {
+// file and directory layout, honoring the ignore patterns. It does not touch
+// the network, so config/path errors surface before a connection is made.
+// Content hashing for the sync strategy happens later, once connected: see
+// executeSync.
+func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore.GitIgnore) (plan, error) {
 	p := plan{pair: pair, strategy: strategy}
 	remoteBase := normalizeRemote(pair.Remote)
 
@@ -134,6 +135,7 @@ func buildPlan(ctx context.Context, pair config.UploadPair, strategy config.Stra
 			remotePath: remotePath,
 			rel:        filepath.Base(pair.Local),
 			size:       info.Size(),
+			mtime:      info.ModTime().Unix(),
 			mode:       info.Mode(),
 		})
 		p.remoteDirs = parentDirs(remotePath)
@@ -169,6 +171,7 @@ func buildPlan(ctx context.Context, pair config.UploadPair, strategy config.Stra
 			remotePath: path.Join(remoteBase, rel),
 			rel:        rel,
 			size:       fi.Size(),
+			mtime:      fi.ModTime().Unix(),
 			mode:       fi.Mode(),
 		}
 		p.files = append(p.files, item)
@@ -179,15 +182,6 @@ func buildPlan(ctx context.Context, pair config.UploadPair, strategy config.Stra
 	})
 	if err != nil {
 		return p, fmt.Errorf("walking local path %q: %w", pair.Local, err)
-	}
-
-	// The sync strategy needs a content hash per file to detect changes.
-	// Hashing is the slow part of planning a large tree, so run it through a
-	// bounded worker pool instead of reading each file sequentially.
-	if strategy == config.StrategySync {
-		if err := hashPlanFiles(ctx, p.files, concurrency); err != nil {
-			return p, fmt.Errorf("hashing local files under %q: %w", pair.Local, err)
-		}
 	}
 
 	for dir := range dirSet {
@@ -202,13 +196,25 @@ func buildPlan(ctx context.Context, pair config.UploadPair, strategy config.Stra
 // worker pool bounded to concurrency workers so a large tree uses the runner's
 // CPU instead of being read and hashed one file at a time. It is used only by
 // the sync strategy, whose changed-file detection compares content hashes.
-func hashPlanFiles(ctx context.Context, files []fileItem, concurrency int) error {
+//
+// cached is the previous sync's manifest entries, keyed by relative path. When
+// a file's size and mtime still match its cached entry, its hash is reused
+// instead of re-reading the file (the same fast path rsync's "quick check"
+// uses). A cached entry with mtime 0 (a manifest written before this fast
+// path existed) never matches, so upgrading from an older manifest costs one
+// full re-hash and nothing more.
+func hashPlanFiles(ctx context.Context, files []fileItem, concurrency int, cached map[string]manifestEntry) error {
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(concurrency)
 	for i := range files {
 		g.Go(func() error {
 			if err := ctx.Err(); err != nil {
 				return err
+			}
+			if entry, ok := cached[files[i].rel]; ok && entry.MTime != 0 &&
+				entry.Size == files[i].size && entry.MTime == files[i].mtime {
+				files[i].hash = entry.Hash
+				return nil
 			}
 			hash, err := hashFile(files[i].localPath)
 			if err != nil {


### PR DESCRIPTION
Closes #10.

## Summary

Adds the size+mtime fast path to the `sync` manifest that #10 asked for, resolving the `needs-review` design question left in that issue's comment thread.

- Hashing now happens **after** the remote manifest is read (previously it ran during the network-free planning phase in `buildPlan`), so `hashPlanFiles` can consult the manifest's previous size/mtime for each file. When they still match, the stored hash is reused instead of re-reading the file from disk.
- **This is opt-in**, via a new `sync-fast-path` input (default `false`) — not the new default behavior. See "Design decision" below.
- The manifest format bumps to v2 (`{hash, size, mtime}` per file, was `{hash}` only). v1 manifests are still read and transparently upgrade to v2 on the next sync (costs one full re-hash, same as any other manifest miss).

## Design decision (the thing #10 flagged for review)

#10's own comment already surfaced the sharp edge: GitHub Actions checkouts get a fresh mtime on every run, so the fast path only helps when local mtimes are preserved across runs (a restored build cache, `git restore-timestamps`, etc.) — otherwise it degrades gracefully to full hashing.

While implementing it, I hit a second, more important edge while adapting the existing test suite: an edit that keeps the same file **size** and lands in the same mtime **second** as the previous write is invisible to a size+mtime check (mtimes have 1-second resolution on most filesystems) — this reused a stale hash for genuinely changed content in `TestSyncIncremental`. That's the same trade-off rsync's `--checksum`-less "quick check" makes, but it's a real, if narrow, correctness regression versus `sync`'s current guarantee, which always compares actual content hashes and therefore never misses a change.

Given this project's stated philosophy — safety/verification toggles (host-key pinning, delete guards) are explicit opt-ins so users choose their own risk level, never silent defaults — I made the same call here: `sync-fast-path` defaults to `false`, and the existing "unchanged files are compared by SHA256 content hash, full stop" guarantee is unchanged unless a user explicitly opts in and accepts the documented trade-off (`docs/strategies.md#sync-fast-path-skip-re-hashing-unchanged-files`).

New tests pin both sides of this explicitly:
- `TestSyncFastPathSkipsUnchangedFile` — a genuinely unchanged file is skipped, a changed one (distinct size + later mtime) is still caught.
- `TestSyncFastPathMissesSameSecondSameSizeEdit` — documents, deterministically, the exact miss case above.
- `TestHashPlanFilesFastPathReusesCachedHash` / `...MissOnMismatch` — unit-level coverage of the size/mtime comparison itself, including the v1-upgrade (`mtime: 0`) case.
- `TestSyncUpgradesV1Manifest` — a v1 manifest is read correctly and rewritten as v2 with size/mtime populated.

## Also fixed while in the area

- A stray `// ponytail:` typo in `sync.go` (clearly meant to say `// note:`) — one-word comment fix in a file already being touched.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `gofmt -l .` — clean
- [x] New unit + integration tests cover: fast-path hit, fast-path miss (size/mtime mismatch), the documented same-second/same-size miss, v1→v2 manifest upgrade, and config parsing of `sync-fast-path`/`EASYSFTP_SYNC_FAST_PATH`
- [x] Existing `sync` test suite (incremental sync, unmanaged files, max-deletes guard, dry-run) passes unchanged with the new default (`sync-fast-path: false`)

## Docs

- `docs/strategies.md`: new `sync-fast-path` subsection explaining the mechanism, the exact trade-off, and when it actually helps.
- `docs/configuration.md`: input row added.
- `action.yml`: input description covers the trade-off inline too.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xgku61ok58QAHmTHiTRAzN)_