### PR TITLE
feat: add max-deletes input for the delete safety guard

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,14 @@ inputs:
   ignore-from:
     description: Path to a file containing gitignore-style exclude patterns.
     required: false
+  max-deletes:
+    description: >-
+      Refuse the run if the "sync" or "clean" strategy would delete more than
+      this many remote files. 0 (the default) means unlimited. Only valid
+      without config-file — with a config file, set "guards.max_deletes"
+      there instead.
+    required: false
+    default: "0"
   delete:
     description: >-
       Removed in v2 — use "strategy: clean" instead. Still declared so that a
@@ -181,6 +189,7 @@ runs:
         EASYSFTP_STRATEGY: ${{ inputs.strategy }}
         EASYSFTP_IGNORE: ${{ inputs.ignore }}
         EASYSFTP_IGNORE_FROM: ${{ inputs.ignore-from }}
+        EASYSFTP_MAX_DELETES: ${{ inputs.max-deletes }}
         EASYSFTP_DELETE: ${{ inputs.delete }}
         EASYSFTP_DRY_RUN: ${{ inputs.dry-run }}
         EASYSFTP_CONCURRENCY: ${{ inputs.concurrency }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,10 +30,11 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `uploads` | ² | - | One `local => remote` mapping per line. Directories are uploaded recursively; single files are supported too. |
-| `config-file` | | - | Path to a [YAML config file](#the-yaml-config-file) with per-target strategies and delete guards. Mutually exclusive with `uploads`/`strategy`/`ignore`/`ignore-from`. |
+| `config-file` | | - | Path to a [YAML config file](#the-yaml-config-file) with per-target strategies and delete guards. Mutually exclusive with `uploads`/`strategy`/`ignore`/`ignore-from`/`max-deletes`. |
 | `strategy` | | `overlay` | [Reconciliation strategy](strategies.md): `overlay`, `sync` or `clean`. |
 | `ignore` | | - | Gitignore-style exclude patterns, one per line. `!` re-includes. |
 | `ignore-from` | | - | Path to a file with exclude patterns (e.g. `.sftpignore`). |
+| `max-deletes` | | `0` | Abort a `sync`/`clean` run that would delete more files than this (`0` = unlimited). See [delete guards](strategies.md#delete-guards). |
 
 ² Required unless `config-file` is set.
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -95,9 +95,10 @@ Two safety nets apply before `sync` or `clean` delete anything:
 
 - **Remote root is always refused.** A target that resolves to `/` (or `.`)
   is rejected outright. No strategy will ever wipe a server root.
-- **`guards.max_deletes`** ([config file](configuration.md#fields) only) aborts
-  a run that would delete more files than the limit, catching a
-  misconfiguration before it does damage. `0` means unlimited.
+- **`max_deletes`** aborts a run that would delete more files than the limit,
+  catching a misconfiguration before it does damage. `0` means unlimited. Set
+  it via the `max-deletes` input, or `guards.max_deletes` in the
+  [config file](configuration.md#fields) when using one.
 
 ## Dry runs
 

--- a/internal/actionmeta/actionmeta_test.go
+++ b/internal/actionmeta/actionmeta_test.go
@@ -59,7 +59,7 @@ func TestActionMetadata(t *testing.T) {
 	wantInputs := []string{
 		"build-mode", "server", "port", "username", "password", "private-key",
 		"passphrase", "host-key-fingerprint", "uploads", "config-file", "strategy",
-		"ignore", "ignore-from", "delete", "dry-run", "concurrency", "retries", "timeout",
+		"ignore", "ignore-from", "max-deletes", "delete", "dry-run", "concurrency", "retries", "timeout",
 	}
 	for _, name := range wantInputs {
 		if _, ok := action.Inputs[name]; !ok {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,12 +123,13 @@ func Load() (*Config, error) {
 	uploadsInput := os.Getenv(envPrefix + "UPLOADS")
 	ignoreInput := os.Getenv(envPrefix + "IGNORE")
 	ignoreFrom := get("IGNORE_FROM")
+	maxDeletesInput := get("MAX_DELETES")
 
 	if configFile != "" {
 		if strings.TrimSpace(uploadsInput) != "" || strategyInput != "" ||
-			strings.TrimSpace(ignoreInput) != "" || ignoreFrom != "" {
+			strings.TrimSpace(ignoreInput) != "" || ignoreFrom != "" || maxDeletesInput != "" {
 			return nil, fmt.Errorf("when 'config-file' is set, put targets/strategy/ignore/guards " +
-				"in the file — do not also set the uploads, strategy, ignore or ignore-from inputs")
+				"in the file — do not also set the uploads, strategy, ignore, ignore-from or max-deletes inputs")
 		}
 		if err := loadConfigFile(cfg, configFile); err != nil {
 			return nil, err
@@ -151,6 +152,9 @@ func Load() (*Config, error) {
 				return nil, fmt.Errorf("could not read ignore-from file: %w", err)
 			}
 			cfg.IgnoreLines = append(cfg.IgnoreLines, splitLines(string(data))...)
+		}
+		if cfg.Guards.MaxDeletes, err = parseInt(maxDeletesInput, 0); err != nil {
+			return nil, fmt.Errorf("invalid max-deletes: %w", err)
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,7 +45,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("EASYSFTP_UPLOADS", "./dist/ => /www/")
 	for _, name := range []string{"PORT", "PRIVATE_KEY", "PASSPHRASE", "HOST_KEY_FINGERPRINT",
 		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "RETRIES", "TIMEOUT",
-		"SYNC_FAST_PATH", "CONFIG_FILE", "STRATEGY"} {
+		"SYNC_FAST_PATH", "CONFIG_FILE", "STRATEGY", "MAX_DELETES"} {
 		t.Setenv("EASYSFTP_"+name, "")
 	}
 }
@@ -77,6 +77,8 @@ func TestLoadValidation(t *testing.T) {
 		{"bad port", map[string]string{"EASYSFTP_PORT": "99999"}, "'port' must be between"},
 		{"bad bool", map[string]string{"EASYSFTP_DRY_RUN": "yes-please"}, "invalid dry-run"},
 		{"bad sync-fast-path bool", map[string]string{"EASYSFTP_SYNC_FAST_PATH": "yes-please"}, "invalid sync-fast-path"},
+		{"bad max-deletes", map[string]string{"EASYSFTP_MAX_DELETES": "not-a-number"}, "invalid max-deletes"},
+		{"negative max-deletes", map[string]string{"EASYSFTP_MAX_DELETES": "-1"}, "guards.max_deletes must not be negative"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -113,6 +115,35 @@ func TestLoadIgnoreFrom(t *testing.T) {
 		if cfg.IgnoreLines[i] != want[i] {
 			t.Errorf("ignore line %d: expected %q, got %q", i, want[i], cfg.IgnoreLines[i])
 		}
+	}
+}
+
+func TestLoadMaxDeletes(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("EASYSFTP_MAX_DELETES", "200")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Guards.MaxDeletes != 200 {
+		t.Errorf("expected MaxDeletes 200, got %d", cfg.Guards.MaxDeletes)
+	}
+}
+
+func TestLoadMaxDeletesRejectedWithConfigFile(t *testing.T) {
+	setBaseEnv(t)
+	configFile := filepath.Join(t.TempDir(), "easysftp.yml")
+	if err := os.WriteFile(configFile, []byte("version: 1\ntargets:\n  - local: ./dist/\n    remote: /www/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("EASYSFTP_UPLOADS", "")
+	t.Setenv("EASYSFTP_CONFIG_FILE", configFile)
+	t.Setenv("EASYSFTP_MAX_DELETES", "5")
+
+	_, err := Load()
+	if err == nil || !strings.Contains(err.Error(), "do not also set") {
+		t.Fatalf("expected rejection error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #49.

`guards.max_deletes` — the safety net that stops `sync`/`clean` from wiping a target when the local side is unexpectedly empty — was reachable only through the YAML config file. Users on the plain-inputs path (the "three-line workflow step" the README courts) had no way to enable this guard at all.

- Added a `max-deletes` action input (default `"0"`, unlimited — preserves current behavior), passed through as `EASYSFTP_MAX_DELETES`.
- `internal/config/config.go`: parses it into `cfg.Guards.MaxDeletes` on the non-config-file path, reusing the existing `parseInt` and the existing negative-value validation.
- When `config-file` is set, `max-deletes` is now rejected with the same "put it in the file instead" error as the other deployment inputs (`uploads`/`strategy`/`ignore`/`ignore-from`).
- Docs: added the input to the table in `docs/configuration.md`, and updated `docs/strategies.md` to drop the "config file only" caveat.
- `internal/actionmeta/actionmeta_test.go`: added `max-deletes` to the expected-inputs list so this doesn't regress silently.

The default stays `0` (unlimited) — matching the issue's guidance to keep this change scoped to closing the reachability gap, not changing default behavior.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] New unit tests: `max-deletes` parses correctly, rejects non-numeric and negative values, and is rejected when `config-file` is set


---
_Generated by [Claude Code](https://claude.ai/code/session_01RH3aactuNxTBWxMWkXdu8S)_