### PR TITLE
feat: make SFTP per-file request concurrency configurable, lower default to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,15 @@ inputs:
       hashes local files for the sync strategy.
     required: false
     default: "4"
+  sftp-request-concurrency:
+    description: >-
+      Advanced. Maximum number of in-flight SFTP requests per file (pipelining
+      within a single file's transfer, independent of "concurrency" which
+      controls how many files are transferred at once). Lower it if a small
+      or resource-constrained SFTP server struggles under load; raise it to
+      push more throughput per file on a fast link to a capable server.
+    required: false
+    default: "16"
   sync-fast-path:
     description: >-
       If "true", the sync strategy skips re-hashing a file whose size and
@@ -193,6 +202,7 @@ runs:
         EASYSFTP_DELETE: ${{ inputs.delete }}
         EASYSFTP_DRY_RUN: ${{ inputs.dry-run }}
         EASYSFTP_CONCURRENCY: ${{ inputs.concurrency }}
+        EASYSFTP_SFTP_REQUEST_CONCURRENCY: ${{ inputs.sftp-request-concurrency }}
         EASYSFTP_SYNC_FAST_PATH: ${{ inputs.sync-fast-path }}
         EASYSFTP_RETRIES: ${{ inputs.retries }}
         EASYSFTP_TIMEOUT: ${{ inputs.timeout }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 | `build-mode` | | `prebuilt` | `prebuilt` downloads the platform-specific release binary and verifies its SHA-256 digest. `source` installs Go and compiles the selected action checkout. |
 | `dry-run` | | `false` | Connect and log what would happen, change nothing. |
 | `concurrency` | | `4` | Number of files uploaded in parallel. Also bounds the worker pool that hashes local files for the `sync` strategy. |
+| `sftp-request-concurrency` | | `16` | Advanced. Maximum in-flight SFTP requests *per file* — pipelining within one file's transfer, independent of `concurrency` (which controls how many files transfer at once). The two multiply: with the defaults, a single large file can have up to 16 requests in flight, and up to `concurrency` files transfer at a time. Lower it for a small or resource-constrained server; raise it for more throughput per file on a fast link to a capable server. |
 | `sync-fast-path` | | `false` | For the `sync` strategy, reuse a file's manifest hash instead of re-reading it when size and modification time still match. See [the sync-fast-path trade-off](strategies.md#sync-fast-path-skip-re-hashing-unchanged-files). |
 | `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,11 +62,12 @@ type Config struct {
 	IgnoreLines []string
 	Guards      Guards
 
-	DryRun       bool
-	Concurrency  int
-	Retries      int
-	Timeout      time.Duration
-	SyncFastPath bool
+	DryRun                 bool
+	Concurrency            int
+	SftpRequestConcurrency int
+	Retries                int
+	Timeout                time.Duration
+	SyncFastPath           bool
 }
 
 const envPrefix = "EASYSFTP_"
@@ -92,6 +93,9 @@ func Load() (*Config, error) {
 	}
 	if cfg.Concurrency, err = parseInt(get("CONCURRENCY"), 4); err != nil {
 		return nil, fmt.Errorf("invalid concurrency: %w", err)
+	}
+	if cfg.SftpRequestConcurrency, err = parseInt(get("SFTP_REQUEST_CONCURRENCY"), 16); err != nil {
+		return nil, fmt.Errorf("invalid sftp-request-concurrency: %w", err)
 	}
 	if cfg.Retries, err = parseInt(get("RETRIES"), 2); err != nil {
 		return nil, fmt.Errorf("invalid retries: %w", err)
@@ -190,6 +194,8 @@ func (c *Config) validate() error {
 		return fmt.Errorf("input 'port' must be between 1 and 65535, got %d", c.Port)
 	case c.Concurrency < 1:
 		return fmt.Errorf("input 'concurrency' must be at least 1, got %d", c.Concurrency)
+	case c.SftpRequestConcurrency < 1:
+		return fmt.Errorf("input 'sftp-request-concurrency' must be at least 1, got %d", c.SftpRequestConcurrency)
 	case c.Retries < 0:
 		return fmt.Errorf("input 'retries' must not be negative, got %d", c.Retries)
 	case c.Guards.MaxDeletes < 0:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,7 +44,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("EASYSFTP_PASSWORD", "hunter2")
 	t.Setenv("EASYSFTP_UPLOADS", "./dist/ => /www/")
 	for _, name := range []string{"PORT", "PRIVATE_KEY", "PASSPHRASE", "HOST_KEY_FINGERPRINT",
-		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "RETRIES", "TIMEOUT",
+		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "SFTP_REQUEST_CONCURRENCY", "RETRIES", "TIMEOUT",
 		"SYNC_FAST_PATH", "CONFIG_FILE", "STRATEGY", "MAX_DELETES"} {
 		t.Setenv("EASYSFTP_"+name, "")
 	}
@@ -56,7 +56,7 @@ func TestLoadDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.Retries != 2 || cfg.DryRun || cfg.SyncFastPath {
+	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Retries != 2 || cfg.DryRun || cfg.SyncFastPath {
 		t.Errorf("unexpected defaults: %+v", cfg)
 	}
 	if cfg.Timeout.Seconds() != 30 {
@@ -78,6 +78,8 @@ func TestLoadValidation(t *testing.T) {
 		{"bad bool", map[string]string{"EASYSFTP_DRY_RUN": "yes-please"}, "invalid dry-run"},
 		{"bad sync-fast-path bool", map[string]string{"EASYSFTP_SYNC_FAST_PATH": "yes-please"}, "invalid sync-fast-path"},
 		{"bad max-deletes", map[string]string{"EASYSFTP_MAX_DELETES": "not-a-number"}, "invalid max-deletes"},
+		{"bad sftp-request-concurrency", map[string]string{"EASYSFTP_SFTP_REQUEST_CONCURRENCY": "not-a-number"}, "invalid sftp-request-concurrency"},
+		{"zero sftp-request-concurrency", map[string]string{"EASYSFTP_SFTP_REQUEST_CONCURRENCY": "0"}, "'sftp-request-concurrency' must be at least 1"},
 		{"negative max-deletes", map[string]string{"EASYSFTP_MAX_DELETES": "-1"}, "guards.max_deletes must not be negative"},
 	}
 	for _, tc := range cases {

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -596,7 +596,7 @@ func connect(cfg *config.Config, log Logger) (*ssh.Client, *sftp.Client, error) 
 
 	sftpClient, err := sftp.NewClient(sshClient,
 		sftp.UseConcurrentWrites(true),
-		sftp.MaxConcurrentRequestsPerFile(64),
+		sftp.MaxConcurrentRequestsPerFile(cfg.SftpRequestConcurrency),
 	)
 	if err != nil {
 		sshClient.Close()

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -28,13 +28,14 @@ func writeTree(t *testing.T, root string, files map[string]string) {
 
 func baseConfig(srv *testServer) *config.Config {
 	return &config.Config{
-		Server:      srv.Host,
-		Port:        srv.Port,
-		Username:    testUser,
-		Password:    testPassword,
-		Concurrency: 4,
-		Retries:     0,
-		Timeout:     10 * time.Second,
+		Server:                 srv.Host,
+		Port:                   srv.Port,
+		Username:               testUser,
+		Password:               testPassword,
+		Concurrency:            4,
+		SftpRequestConcurrency: 16,
+		Retries:                0,
+		Timeout:                10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #29.

- Added a new advanced input `sftp-request-concurrency` (env `EASYSFTP_SFTP_REQUEST_CONCURRENCY`) that controls `sftp.MaxConcurrentRequestsPerFile`, the number of in-flight SFTP requests allowed per file. Previously this was hardcoded to `64`.
- Lowered the default from `64` to `16` — more conservative for small/shared-hosting SFTP servers, while still configurable upward for users on fast links to capable servers.
- This is independent of and multiplies with the existing `concurrency` input (files transferred in parallel); the docs now spell out the relationship explicitly.
- Validated like the other numeric inputs (`must be at least 1`).

Kept this scoped to the file-request-concurrency knob only, per YAGNI — the issue's "document how file-level concurrency and per-file request concurrency interact" acceptance point is addressed inline in `docs/configuration.md` rather than as a separate doc.

## Design decision

The issue asked whether to only lower the default or also expose it as an input. Given this project's philosophy of leaving security/performance trade-offs to the user rather than deciding for them, I exposed it as an opt-in advanced input (default `16`) rather than hardcoding a new fixed value — users on very small servers can go lower, users who know their server can take it can raise it back toward the old `64` or beyond.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `gofmt -l .` (clean)
- [x] New/updated unit tests in `internal/config/config_test.go` covering the default value and validation (non-numeric, zero)
- [x] Existing uploader tests updated to set the new config field explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W283Kb9FthQTAUneaeMJCQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01W283Kb9FthQTAUneaeMJCQ)_