### PR TITLE
fix(gha): use file-based heredoc syntax for $GITHUB_OUTPUT

### DIFF
--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -109,15 +109,16 @@ func TestReportStatsOnFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{
-		"files-uploaded=3",
-		"files-deleted=1",
-		"files-skipped=4",
-		"bytes-uploaded=2048",
-		"duration-ms=1500",
+	got := parseGithubOutput(t, string(output))
+	for name, want := range map[string]string{
+		"files-uploaded": "3",
+		"files-deleted":  "1",
+		"files-skipped":  "4",
+		"bytes-uploaded": "2048",
+		"duration-ms":    "1500",
 	} {
-		if !strings.Contains(string(output), want) {
-			t.Errorf("output does not contain %q:\n%s", want, output)
+		if got[name] != want {
+			t.Errorf("output %q = %q, want %q:\n%s", name, got[name], want, output)
 		}
 	}
 
@@ -136,4 +137,29 @@ func TestReportStatsOnFailure(t *testing.T) {
 			t.Errorf("summary does not contain %q:\n%s", want, summary)
 		}
 	}
+}
+
+// parseGithubOutput parses the file-based GITHUB_OUTPUT "name<<delimiter"
+// heredoc format into a map, the same way the GitHub Actions runner does.
+func parseGithubOutput(t *testing.T, raw string) map[string]string {
+	t.Helper()
+	out := make(map[string]string)
+	lines := strings.Split(raw, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		idx := strings.Index(line, "<<")
+		if idx == -1 {
+			continue
+		}
+		name := line[:idx]
+		delimiter := line[idx+2:]
+		var value []string
+		i++
+		for i < len(lines) && lines[i] != delimiter {
+			value = append(value, lines[i])
+			i++
+		}
+		out[name] = strings.Join(value, "\n")
+	}
+	return out
 }

--- a/internal/gha/gha.go
+++ b/internal/gha/gha.go
@@ -3,6 +3,7 @@
 package gha
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 	"strings"
@@ -45,6 +46,12 @@ func EndGroup() {
 }
 
 // SetOutput writes a step output. It is a no-op outside of GitHub Actions.
+//
+// $GITHUB_OUTPUT is a file-based protocol, not a workflow command: values are
+// written verbatim using the "name<<delimiter" heredoc syntax so that any
+// value (including one containing "%" or newlines) round-trips exactly,
+// instead of the "::...::" workflow-command percent-encoding used elsewhere
+// in this package, which does not apply here.
 func SetOutput(name, value string) {
 	path := os.Getenv("GITHUB_OUTPUT")
 	if path == "" {
@@ -56,7 +63,20 @@ func SetOutput(name, value string) {
 		return
 	}
 	defer f.Close()
-	fmt.Fprintf(f, "%s=%s\n", name, escapeData(value))
+
+	delimiter := randomDelimiter()
+	for strings.Contains(value, delimiter) {
+		delimiter = randomDelimiter()
+	}
+	fmt.Fprintf(f, "%s<<%s\n%s\n%s\n", name, delimiter, value, delimiter)
+}
+
+// randomDelimiter returns a delimiter for the GITHUB_OUTPUT heredoc syntax
+// that is vanishingly unlikely to collide with real output content.
+func randomDelimiter() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("ghadelimiter_%x", b)
 }
 
 // AppendSummary appends markdown to the job summary. It is a no-op outside

--- a/internal/gha/gha_test.go
+++ b/internal/gha/gha_test.go
@@ -1,0 +1,76 @@
+package gha
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// parseGithubOutput parses the file-based GITHUB_OUTPUT format (both the
+// plain "name=value" and "name<<delimiter" heredoc forms) into a map, the
+// same way the actual GitHub Actions runner does.
+func parseGithubOutput(t *testing.T, raw string) map[string]string {
+	t.Helper()
+	out := make(map[string]string)
+	lines := strings.Split(raw, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if line == "" {
+			continue
+		}
+		if idx := strings.Index(line, "<<"); idx != -1 {
+			name := line[:idx]
+			delimiter := line[idx+2:]
+			var value []string
+			i++
+			for i < len(lines) && lines[i] != delimiter {
+				value = append(value, lines[i])
+				i++
+			}
+			out[name] = strings.Join(value, "\n")
+			continue
+		}
+		if idx := strings.Index(line, "="); idx != -1 {
+			out[line[:idx]] = line[idx+1:]
+		}
+	}
+	return out
+}
+
+func TestSetOutputRoundTripsSpecialCharacters(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output")
+	t.Setenv("GITHUB_OUTPUT", path)
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("failed to create output file: %v", err)
+	}
+
+	cases := map[string]string{
+		"plain":     "42",
+		"percent":   "100% done",
+		"multiline": "line one\nline two\nline three",
+		"crlf":      "line one\r\nline two",
+	}
+	for name, value := range cases {
+		SetOutput(name, value)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read output file: %v", err)
+	}
+	got := parseGithubOutput(t, string(raw))
+
+	for name, want := range cases {
+		if got[name] != want {
+			t.Errorf("output %q: got %q, want %q", name, got[name], want)
+		}
+	}
+}
+
+func TestSetOutputIsNoopWithoutGithubOutput(t *testing.T) {
+	t.Setenv("GITHUB_OUTPUT", "")
+	// Must not panic or attempt to open an empty path.
+	SetOutput("name", "value")
+}


### PR DESCRIPTION
## Summary

`gha.SetOutput` (`internal/gha/gha.go`) wrote step outputs through `escapeData`, the percent-encoding used for **workflow commands** (`::warning::...`). That's the wrong protocol for `$GITHUB_OUTPUT`, which is a plain file: a literal `%` in a value would round-trip as the literal string `%25`, and a multiline value would come out as a single line containing literal `%0D`/`%0A` instead of actual line breaks.

All of today's outputs (`files-uploaded`, `bytes-uploaded`, etc.) are integers, so this was latent — the bug doesn't manifest until a text-valued output is added. Fixed now so it doesn't quietly corrupt a future output.

## Changes

- `SetOutput` now writes the `name<<delimiter` heredoc form that `$GITHUB_OUTPUT` actually expects, with a random per-call delimiter (checked against the value to rule out collision) instead of percent-encoding.
- `escapeData` / the `::...::` workflow-command helpers (`Noticef`, `Warningf`, `Errorf`, `Group`) are unchanged — that escaping is correct for workflow commands.
- Added `internal/gha/gha_test.go` covering plain, `%`-containing, multiline, and CRLF values round-tripping correctly, plus the outside-of-Actions no-op path.
- Updated the existing `cmd/easysftp/main_test.go` output assertions (`TestReportStatsOnFailure`), which asserted the old raw `name=value` line, to parse the heredoc format instead.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test -race ./...`

Fixes #46


---
_Generated by [Claude Code](https://claude.ai/code/session_01DuzZSGrPkQbyiTqQ3ucaDi)_