### PR TITLE
fix: make upload temp filenames collision-proof

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -18,9 +18,10 @@ Uploads every local file on top of whatever is already on the server. Nothing
 is ever deleted. This is the default and the backwards-compatible behavior.
 
 Uploads are **atomic per file**: content is streamed to a temporary sibling
-file (`<name>.easysftp-tmp`) and renamed over the target only once the transfer
-fully succeeded. A broken connection never leaves a half-written file where
-the live one was.
+file (`<name>.easysftp-tmp.<n>`, `<n>` being the file's position in the plan so
+two planned transfers never share a temp name) and renamed over the target
+only once the transfer fully succeeded. A broken connection never leaves a
+half-written file where the live one was.
 
 ## `sync`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,11 +83,13 @@ produce directories the web server can't read. Set `dir-mode` (and, if needed,
 
 ### `replacing "<path>": ...` or leftover `.easysftp-tmp` files
 
-easySFTP uploads to a temporary sibling file and renames it over the target
-(atomic on servers supporting the `posix-rename@openssh.com` extension, with a
-remove+rename fallback otherwise). A hard crash mid-upload can leave a
-`*.easysftp-tmp` file behind; it is safe to delete and will be cleaned up by
-the next successful upload of the same file.
+easySFTP uploads to a temporary sibling file (named `<path>.easysftp-tmp.<n>`)
+and renames it over the target (atomic on servers supporting the
+`posix-rename@openssh.com` extension, with a remove+rename fallback
+otherwise). A hard crash mid-upload can leave such a file behind; it is safe
+to delete manually. It usually gets overwritten by the next upload of the
+same file too, but that isn't guaranteed if the deployment's file set changed
+in the meantime and shifted its plan position.
 
 ### Ignored files are uploaded anyway / patterns don't match
 

--- a/internal/uploader/atomic_test.go
+++ b/internal/uploader/atomic_test.go
@@ -42,7 +42,7 @@ func TestAtomicReplaceLeavesNoTempFile(t *testing.T) {
 	if got := readRemote(t, srv, "/www/index.html"); got != "new" {
 		t.Errorf("content not replaced: %q", got)
 	}
-	if remoteExists(t, srv, "/www/index.html"+tmpSuffix) {
+	if remoteHasTmpFile(t, srv, "/www", "index.html") {
 		t.Error("temporary upload file was left behind")
 	}
 }
@@ -79,8 +79,36 @@ func TestRenameFailureCleansUpAndKeepsOriginal(t *testing.T) {
 	if got := readRemote(t, srv, "/www/index.html"); got != "original" {
 		t.Errorf("live file was clobbered by a failed upload: %q", got)
 	}
-	if remoteExists(t, srv, "/www/index.html"+tmpSuffix) {
+	if remoteHasTmpFile(t, srv, "/www", "index.html") {
 		t.Error("temporary file was not cleaned up after the failed rename")
+	}
+}
+
+// TestTempNameCollisionAvoided verifies that a deployment containing both
+// "app.js" and a file literally named "app.js.easysftp-tmp" uploads both
+// correctly: the temp path used while streaming "app.js" must not collide
+// with the real target path of the other file (issue #42).
+func TestTempNameCollisionAvoided(t *testing.T) {
+	srv := startTestServer(t)
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"app.js":             "real-app-content",
+		"app.js" + tmpSuffix: "literal-file-named-like-a-temp",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 4
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	if got := readRemote(t, srv, "/www/app.js"); got != "real-app-content" {
+		t.Errorf("/www/app.js = %q, want unclobbered content", got)
+	}
+	if got := readRemote(t, srv, "/www/app.js"+tmpSuffix); got != "literal-file-named-like-a-temp" {
+		t.Errorf("/www/app.js%s = %q, want unclobbered content", tmpSuffix, got)
 	}
 }
 

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -311,7 +311,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, f
 			if cfg.FileMode != nil {
 				mode = *cfg.FileMode
 			}
-			n, err := uploadFileWithRetry(ctx, f, mode, client, cfg.Retries, log, modeWarned)
+			n, err := uploadFileWithRetry(ctx, f, i, mode, client, cfg.Retries, log, modeWarned)
 			if err != nil {
 				return err
 			}
@@ -463,7 +463,12 @@ const tmpSuffix = ".easysftp-tmp"
 // uploadFileWithRetry uploads one file, retrying transient failures with
 // exponential backoff. It stops early when the context is cancelled or the
 // error is permanent (see isRetryable), so a doomed transfer fails fast.
-func uploadFileWithRetry(ctx context.Context, f fileItem, mode fs.FileMode, client *sftp.Client, retries int, log Logger, modeWarned *atomic.Bool) (int64, error) {
+//
+// index is the file's position in the plan and is folded into the temp
+// path (see uploadFile) so two planned transfers never race over the same
+// temporary name, even if one target's path happens to literally be
+// another's plus tmpSuffix.
+func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.FileMode, client *sftp.Client, retries int, log Logger, modeWarned *atomic.Bool) (int64, error) {
 	var lastErr error
 	for attempt := 0; attempt <= retries; attempt++ {
 		if attempt > 0 {
@@ -473,7 +478,7 @@ func uploadFileWithRetry(ctx context.Context, f fileItem, mode fs.FileMode, clie
 				return 0, err
 			}
 		}
-		n, err := uploadFile(ctx, f, mode, client, log, modeWarned)
+		n, err := uploadFile(ctx, f, index, mode, client, log, modeWarned)
 		if err == nil {
 			return n, nil
 		}
@@ -489,14 +494,17 @@ func uploadFileWithRetry(ctx context.Context, f fileItem, mode fs.FileMode, clie
 // temporary sibling and, only once that fully succeeds, renames it over the
 // target. Any failure removes the temporary file so a broken or partial upload
 // never replaces the live file and no debris is left behind.
-func uploadFile(ctx context.Context, f fileItem, mode fs.FileMode, client *sftp.Client, log Logger, modeWarned *atomic.Bool) (int64, error) {
+func uploadFile(ctx context.Context, f fileItem, index int, mode fs.FileMode, client *sftp.Client, log Logger, modeWarned *atomic.Bool) (int64, error) {
 	src, err := os.Open(f.localPath)
 	if err != nil {
 		return 0, err
 	}
 	defer src.Close()
 
-	tmpPath := f.remotePath + tmpSuffix
+	// The index makes the temp path unique per planned transfer, so it can't
+	// collide with another planned file whose real name is this one's plus
+	// tmpSuffix (see issue #42).
+	tmpPath := fmt.Sprintf("%s%s.%d", f.remotePath, tmpSuffix, index)
 	dst, err := client.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
 	if err != nil {
 		return 0, err

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -62,6 +62,24 @@ func remoteExists(t *testing.T, srv *testServer, path string) bool {
 	return err == nil
 }
 
+// remoteHasTmpFile reports whether dir contains any leftover temp upload file
+// for base, i.e. an entry named "<base><tmpSuffix>" or "<base><tmpSuffix>.N".
+func remoteHasTmpFile(t *testing.T, srv *testServer, dir, base string) bool {
+	t.Helper()
+	client := srv.verifyClient(t)
+	entries, err := client.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix := base + tmpSuffix
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestUploadDirectoryWithIgnore(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()


### PR DESCRIPTION
## Summary

Fixes #42.

`uploadFile` wrote every upload to a temp sibling named `<remotePath>.easysftp-tmp` before the atomic rename onto the real target. Since that suffix is a fixed constant, a deployment containing both `app.js` and a file literally named `app.js.easysftp-tmp` planned two independent, concurrently-running uploads whose temp/target paths collide:

- uploading `app.js` writes into temp path `app.js.easysftp-tmp`
- that is also the **real target** of the other planned file, which is concurrently streaming into *its own* temp file and renaming onto `app.js.easysftp-tmp`

Whichever rename lands last can silently clobber the other transfer — a silent-corruption-class bug, low likelihood but a one-line fix.

## Fix

Fold each file's position in the upload plan into its temp path: `<remotePath>.easysftp-tmp.<planIndex>`. Plan indices are unique per upload pair, so no two planned transfers can ever share a temp name, regardless of what any file happens to be named.

## Changes

- `internal/uploader/uploader.go`: `uploadFileWithRetry`/`uploadFile` take the file's plan index and use it when building the temp path.
- `internal/uploader/atomic_test.go`: added `TestTempNameCollisionAvoided`, which deploys both `app.js` and a file named `app.js.easysftp-tmp` and asserts neither clobbers the other. Updated the two existing "no leftover temp file" assertions to check for *any* temp-suffixed sibling (via a new `remoteHasTmpFile` test helper) rather than the old fixed literal path, since that path no longer exists in the new naming scheme.
- `docs/strategies.md`, `docs/troubleshooting.md`: updated the temp-filename description to match, and softened the "cleaned up by the next successful upload" claim in the troubleshooting doc — that's no longer guaranteed if the plan's file ordering shifts between runs (e.g. a file was added/removed elsewhere in the tree), since the same file's index can then differ from one run to the next. Manual deletion of a leftover `*.easysftp-tmp.<n>` file is always safe.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (all packages pass)
- [x] New regression test `TestTempNameCollisionAvoided` specifically exercises the collision scenario from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCFM9D1YsD6U84SGbrUmnm)_