### PR TITLE
feat: send SSH keepalives to survive idle-timeout firewalls

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,6 +32,16 @@ The runner cannot reach the server.
 - Raise `timeout` (default 30 s) if the server is just slow to accept
   connections.
 
+### A large deploy dies partway through with an EOF or "connection lost"
+
+`timeout` only bounds the initial connection, not the whole run. Once
+connected, easySFTP sends an SSH keepalive every 30 seconds for the rest of
+the run, so idle-looking connections survive NAT gateways/firewalls that
+drop them, and the server's own `ClientAliveInterval` probes get answered.
+This is automatic and not configurable. If transfers still die mid-run, the
+connection itself is being reset (not just idled out) — check for a very
+short server-side session/idle limit, or a flaky network path.
+
 ### `connecting to <host>:22: ssh: handshake failed: ... unable to authenticate`
 
 The server rejected the credentials.

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -32,6 +32,8 @@ type testServer struct {
 	failRename  bool  // make every rename fail with a non-transient error
 	failSetstat bool  // make every chmod (Setstat) fail
 	dropAfter   int64 // if >0, kill each connection after it reads this many bytes
+
+	keepalives *int64 // if set, counts "keepalive@openssh.com" global requests received
 }
 
 // serverOption tweaks a testServer before it starts serving.
@@ -48,6 +50,10 @@ func withDropAfter(n int64) serverOption { return func(s *testServer) { s.dropAf
 // withFailSetstat makes the server reject every chmod (Setstat) request,
 // simulating a server that refuses SETSTAT.
 func withFailSetstat() serverOption { return func(s *testServer) { s.failSetstat = true } }
+
+// withKeepaliveCounter makes the server tally every "keepalive@openssh.com"
+// global request it receives into c, instead of just discarding it.
+func withKeepaliveCounter(c *int64) serverOption { return func(s *testServer) { s.keepalives = c } }
 
 // setstatCall records one chmod request the server received.
 type setstatCall struct {
@@ -258,7 +264,16 @@ func (s *testServer) handleConn(conn net.Conn) {
 		return
 	}
 	defer sshConn.Close()
-	go ssh.DiscardRequests(reqs)
+	go func() {
+		for req := range reqs {
+			if s.keepalives != nil && req.Type == "keepalive@openssh.com" {
+				atomic.AddInt64(s.keepalives, 1)
+			}
+			if req.WantReply {
+				req.Reply(false, nil)
+			}
+		}
+	}()
 
 	for newChannel := range chans {
 		if newChannel.ChannelType() != "session" {

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -89,6 +89,10 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	defer sshClient.Close()
 	defer sftpClient.Close()
 
+	keepaliveCtx, stopKeepalives := context.WithCancel(ctx)
+	defer stopKeepalives()
+	go sendKeepalives(keepaliveCtx, sshClient, keepaliveInterval)
+
 	for _, p := range plans {
 		if err := ctx.Err(); err != nil {
 			return stats, err
@@ -600,6 +604,31 @@ func (c *ctxReader) Read(p []byte) (int, error) {
 		return 0, err
 	}
 	return c.r.Read(p)
+}
+
+// keepaliveInterval is how often sendKeepalives pings the connection. It is
+// deliberately not configurable: it's cheap, harmless to send more often than
+// strictly needed, and there's no evidence yet that any user needs a
+// different value.
+const keepaliveInterval = 30 * time.Second
+
+// sendKeepalives periodically sends an SSH keepalive request until ctx is
+// canceled. This keeps long or idle-looking transfers alive across NAT
+// gateways and firewalls that drop idle TCP connections, and answers sshd's
+// own ClientAliveInterval probes so the server doesn't disconnect us first.
+// interval is a parameter (rather than always reading the keepaliveInterval
+// constant) so tests can drive it with a short tick instead of waiting 30s.
+func sendKeepalives(ctx context.Context, client *ssh.Client, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			_, _, _ = client.SendRequest("keepalive@openssh.com", true, nil)
+		}
+	}
 }
 
 // connect dials the server and opens an SFTP session on top of SSH.

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -7,10 +7,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/eiserv/easySFTP/internal/config"
+	"golang.org/x/crypto/ssh"
 )
 
 // writeTree creates files under root; keys are slash-separated relative paths.
@@ -445,5 +447,43 @@ func TestMissingLocalPathFailsBeforeConnecting(t *testing.T) {
 	_, err := Run(context.Background(), cfg, testLogger{t})
 	if err == nil || !strings.Contains(err.Error(), "local path") {
 		t.Fatalf("expected local path error, got %v", err)
+	}
+}
+
+func TestSendKeepalivesPingsUntilCanceled(t *testing.T) {
+	var received int64
+	srv := startTestServer(t, withKeepaliveCounter(&received))
+
+	sshClient, err := ssh.Dial("tcp", srv.Addr, &ssh.ClientConfig{
+		User:            testUser,
+		Auth:            []ssh.AuthMethod{ssh.Password(testPassword)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sshClient.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		sendKeepalives(ctx, sshClient, 10*time.Millisecond)
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for atomic.LoadInt64(&received) < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("expected at least 3 keepalives, got %d", atomic.LoadInt64(&received))
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendKeepalives did not stop after context cancellation")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #13.

`timeout` only bounds the initial TCP dial + SSH handshake (`connect` in `internal/uploader/uploader.go`). After that, nothing kept the connection alive: NAT gateways/firewalls that drop idle-looking TCP connections, or sshd configs (`ClientAliveInterval` + `ClientAliveCountMax`) that disconnect clients not answering keepalive probes, could kill a large/long upload with an EOF. `uploadFileWithRetry` would then retry against the same dead connection and fail again (that reconnect gap is tracked separately in #43).

This adds a background goroutine, started right after `connect()` succeeds in `Run`, that sends the standard `keepalive@openssh.com` global request every 30 seconds for the lifetime of the run, and stops cleanly when the run finishes or its context is canceled.

- No new input: a fixed 30s interval, per the issue's own proposal — it's cheap, harmless to send more than strictly necessary, and there's no evidence yet anyone needs it tunable. Matches this repo's "run-wide behavior needs a concrete use case before it gets a knob" guidance in CLAUDE.md.
- `sendKeepalives` takes the interval as a parameter (rather than hardcoding the constant) purely so the test can drive it with a short tick instead of a real 30s wait; production always passes the same `keepaliveInterval` constant.
- Added a `docs/troubleshooting.md` entry under "Connection problems" so users hitting mid-run drops know this now happens automatically and what it does (and doesn't) cover.

## Testing

- New test server option (`withKeepaliveCounter`) that tallies `keepalive@openssh.com` global requests instead of silently discarding them (previous behavior was `ssh.DiscardRequests`, which is preserved for every other request type/reply semantics).
- `TestSendKeepalivesPingsUntilCanceled`: dials the in-process test server directly, runs `sendKeepalives` with a 10ms interval, asserts at least 3 requests arrive, then cancels the context and asserts the goroutine exits.
- `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
- `go test -race ./...` passes.

## Test plan

- [x] Keepalives sent every 30s while a run is active in production (interval is a constant; tests exercise the mechanism with a short interval)
- [x] Goroutine exits cleanly on run completion and on context cancellation
- [x] `go test -race ./...` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01VZKnXRj7SQQ2mmHZjjeJ2V)_