### PR TITLE
feat: add per-target breakdown to the job summary for multi-target deploys

### DIFF
--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"strings"
 	"syscall"
 
 	"github.com/eiserv/easySFTP/internal/config"
@@ -113,7 +114,34 @@ func reportStats(stats *uploader.Stats, mode string, runErr error) {
 	gha.SetOutput("bytes-uploaded", fmt.Sprintf("%d", stats.BytesUploaded))
 	gha.SetOutput("duration-ms", fmt.Sprintf("%d", stats.Duration.Milliseconds()))
 
-	gha.AppendSummary(fmt.Sprintf(
+	summary := fmt.Sprintf(
 		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %d |\n| Duration | %s |\n",
-		status, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.BytesUploaded, stats.Duration.Round(1e6)))
+		status, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.BytesUploaded, stats.Duration.Round(1e6))
+	summary += targetBreakdown(stats.Targets)
+	gha.AppendSummary(summary)
+}
+
+// targetBreakdown renders a per-target table for multi-target deploys, or ""
+// when there is only one target (its row would just repeat the totals above).
+func targetBreakdown(targets []uploader.TargetStats) string {
+	if len(targets) < 2 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n#### Per-target breakdown\n\n| Target | Strategy | Uploaded | Deleted | Skipped | Bytes |\n|---|---|---|---|---|---|\n")
+
+	var totalUploaded, totalDeleted, totalSkipped int
+	var totalBytes int64
+	for _, t := range targets {
+		fmt.Fprintf(&b, "| `%s` => `%s` | %s | %d | %d | %d | %d |\n",
+			t.Local, t.Remote, t.Strategy, t.FilesUploaded, t.FilesDeleted, t.FilesSkipped, t.BytesUploaded)
+		totalUploaded += t.FilesUploaded
+		totalDeleted += t.FilesDeleted
+		totalSkipped += t.FilesSkipped
+		totalBytes += t.BytesUploaded
+	}
+	fmt.Fprintf(&b, "| **Total** | | **%d** | **%d** | **%d** | **%d** |\n",
+		totalUploaded, totalDeleted, totalSkipped, totalBytes)
+	return b.String()
 }

--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -139,6 +139,58 @@ func TestReportStatsOnFailure(t *testing.T) {
 	}
 }
 
+func TestReportStatsMultiTargetBreakdown(t *testing.T) {
+	summaryPath := filepath.Join(t.TempDir(), "summary")
+	t.Setenv("GITHUB_OUTPUT", filepath.Join(t.TempDir(), "output"))
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	stats := &uploader.Stats{
+		FilesUploaded: 252,
+		FilesDeleted:  217,
+		FilesSkipped:  1988,
+		BytesUploaded: 17_825_792,
+		Duration:      2*time.Minute + 13*time.Second,
+		Targets: []uploader.TargetStats{
+			{Local: "./dist/", Remote: "/var/www/html/", Strategy: "sync", FilesUploaded: 12, FilesDeleted: 3, FilesSkipped: 1988, BytesUploaded: 4_297_523},
+			{Local: "./docs/", Remote: "/var/www/docs/", Strategy: "clean", FilesUploaded: 240, FilesDeleted: 214, FilesSkipped: 0, BytesUploaded: 13_528_269},
+		},
+	}
+	reportStats(stats, "uploaded", nil)
+
+	summary, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"#### Per-target breakdown",
+		"| Target | Strategy | Uploaded | Deleted | Skipped | Bytes |",
+		"| `./dist/` => `/var/www/html/` | sync | 12 | 3 | 1988 | 4297523 |",
+		"| `./docs/` => `/var/www/docs/` | clean | 240 | 214 | 0 | 13528269 |",
+		"| **Total** | | **252** | **217** | **1988** | **17825792** |",
+	} {
+		if !strings.Contains(string(summary), want) {
+			t.Errorf("summary does not contain %q:\n%s", want, summary)
+		}
+	}
+}
+
+func TestReportStatsSingleTargetHasNoBreakdown(t *testing.T) {
+	summaryPath := filepath.Join(t.TempDir(), "summary")
+	t.Setenv("GITHUB_OUTPUT", filepath.Join(t.TempDir(), "output"))
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	stats := &uploader.Stats{FilesUploaded: 3, BytesUploaded: 2048, Duration: time.Second}
+	reportStats(stats, "uploaded", nil)
+
+	summary, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(summary), "Per-target breakdown") {
+		t.Errorf("expected no per-target breakdown for a single target:\n%s", summary)
+	}
+}
+
 // parseGithubOutput parses the file-based GITHUB_OUTPUT "name<<delimiter"
 // heredoc format into a map, the same way the GitHub Actions runner does.
 func parseGithubOutput(t *testing.T, raw string) map[string]string {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,13 @@ as failed. Use `if: ${{ always() }}` when a later reporting or rollback step
 must consume these partial results. See [examples](examples.md#using-the-outputs)
 for how to consume outputs in later steps.
 
+When `uploads` (or a `config-file`) defines more than one target, the job
+summary also breaks the totals down per target — local path, remote path,
+strategy, and that target's own uploaded/deleted/skipped/bytes counts — so a
+number that looks off in the totals can be traced to the target that produced
+it. The `files-*`/`bytes-uploaded` outputs stay run-wide totals; there is no
+per-target output.
+
 ## The `uploads` mapping
 
 One mapping per line, `local => remote`. Lines starting with `#` are ignored.

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -41,6 +41,24 @@ type Stats struct {
 	DirsCreated   int
 	BytesUploaded int64
 	Duration      time.Duration
+
+	// Targets breaks the totals above down per upload pair. It is only
+	// populated when the config has more than one pair: a single-target run
+	// has nothing to break down, so it stays nil and callers can use that to
+	// decide whether a per-target table is worth showing.
+	Targets []TargetStats
+}
+
+// TargetStats summarizes what a run did (or would do) for a single upload
+// pair, so a multi-target deploy can be broken down in the job summary.
+type TargetStats struct {
+	Local         string
+	Remote        string
+	Strategy      config.Strategy
+	FilesUploaded int
+	FilesDeleted  int
+	FilesSkipped  int
+	BytesUploaded int64
 }
 
 // fileItem is a single planned file transfer.
@@ -97,7 +115,24 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		if err := ctx.Err(); err != nil {
 			return stats, err
 		}
-		if err := executePlan(ctx, cfg, sftpClient, p, stats, log); err != nil {
+		before := *stats
+		err := executePlan(ctx, cfg, sftpClient, p, stats, log)
+		if len(plans) > 1 {
+			// Recorded from the before/after delta (not threaded through
+			// executePlan) so a target's partial progress on failure is
+			// still captured, matching the totals' own partial-progress
+			// behavior.
+			stats.Targets = append(stats.Targets, TargetStats{
+				Local:         p.pair.Local,
+				Remote:        p.pair.Remote,
+				Strategy:      p.strategy,
+				FilesUploaded: stats.FilesUploaded - before.FilesUploaded,
+				FilesDeleted:  stats.FilesDeleted - before.FilesDeleted,
+				FilesSkipped:  stats.FilesSkipped - before.FilesSkipped,
+				BytesUploaded: stats.BytesUploaded - before.BytesUploaded,
+			})
+		}
+		if err != nil {
 			return stats, err
 		}
 	}

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -118,6 +118,80 @@ func TestUploadDirectoryWithIgnore(t *testing.T) {
 	}
 }
 
+func TestMultiTargetStatsBreakdown(t *testing.T) {
+	srv := startTestServer(t)
+
+	siteLocal := t.TempDir()
+	writeTree(t, siteLocal, map[string]string{
+		"index.html": "<h1>hi</h1>",
+		"style.css":  "body{}",
+	})
+	docsLocal := t.TempDir()
+	writeTree(t, docsLocal, map[string]string{
+		"readme.md": "# docs",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{
+		{Local: siteLocal, Remote: "/www/site", Strategy: config.StrategyOverlay},
+		{Local: docsLocal, Remote: "/www/docs", Strategy: config.StrategyOverlay},
+	}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(stats.Targets) != 2 {
+		t.Fatalf("expected 2 target entries, got %d: %+v", len(stats.Targets), stats.Targets)
+	}
+
+	site, docs := stats.Targets[0], stats.Targets[1]
+	if site.Local != siteLocal || site.Remote != "/www/site" || site.Strategy != config.StrategyOverlay {
+		t.Errorf("unexpected site target stats: %+v", site)
+	}
+	if site.FilesUploaded != 2 {
+		t.Errorf("expected 2 files uploaded for site, got %d", site.FilesUploaded)
+	}
+	if docs.Local != docsLocal || docs.Remote != "/www/docs" {
+		t.Errorf("unexpected docs target stats: %+v", docs)
+	}
+	if docs.FilesUploaded != 1 {
+		t.Errorf("expected 1 file uploaded for docs, got %d", docs.FilesUploaded)
+	}
+
+	// Per-target totals must sum to the run-wide totals.
+	var sumUploaded int
+	var sumBytes int64
+	for _, ts := range stats.Targets {
+		sumUploaded += ts.FilesUploaded
+		sumBytes += ts.BytesUploaded
+	}
+	if sumUploaded != stats.FilesUploaded {
+		t.Errorf("target FilesUploaded sum %d != total %d", sumUploaded, stats.FilesUploaded)
+	}
+	if sumBytes != stats.BytesUploaded {
+		t.Errorf("target BytesUploaded sum %d != total %d", sumBytes, stats.BytesUploaded)
+	}
+}
+
+func TestSingleTargetStatsHaveNoBreakdown(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "hi"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Targets != nil {
+		t.Errorf("expected no per-target breakdown for a single target, got %+v", stats.Targets)
+	}
+}
+
 func TestUploadDirectoryFailsWhenRemoteDirIsFile(t *testing.T) {
 	srv := startTestServer(t)
 	client := srv.verifyClient(t)


### PR DESCRIPTION
## Summary

Closes #18.

With a config file (or `uploads`) deploying several targets, the job summary previously showed only run-wide totals. When a number looked off ("why were 214 files deleted?"), there was no way to see *which target* did that without scrolling the raw log.

This adds a per-target table to the job summary, shown only when the run has more than one upload pair:

| Target | Strategy | Uploaded | Deleted | Skipped | Bytes |
|---|---|---|---|---|---|
| `./dist/` => `/var/www/html/` | sync | 12 | 3 | 1988 | 4297523 |
| `./docs/` => `/var/www/docs/` | clean | 240 | 214 | 0 | 13528269 |
| **Total** | | **252** | **217** | **1988** | **17825792** |

- `uploader.Stats` gains a `Targets []TargetStats` field, populated in `Run` from a before/after delta around each `executePlan` call. Using a delta (rather than threading a fresh `Stats` through `executePlan`) means a target's partial progress is still captured if it fails partway, matching the existing partial-progress-on-failure behavior of the totals.
- `Targets` stays `nil` for single-target runs, so `cmd/easysftp`'s `targetBreakdown` helper renders nothing and the existing single-target summary is byte-for-byte unchanged.
- The `files-*`/`bytes-uploaded` **outputs** are untouched — still run-wide totals, no per-target output added (kept out of scope; nobody asked for it, and it's easy to add later per YAGNI).
- Bytes are shown as raw numbers in the new table, consistent with today's totals table (`docs/configuration.md` / `cmd/easysftp/main.go`) — human-readable sizes are already tracked separately in #16 and out of scope here.
- Docs: added a short paragraph to `docs/configuration.md` describing when the breakdown appears.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test -race ./...` — all packages pass
- [x] New tests: `TestMultiTargetStatsBreakdown` / `TestSingleTargetStatsHaveNoBreakdown` (`internal/uploader`), `TestReportStatsMultiTargetBreakdown` / `TestReportStatsSingleTargetHasNoBreakdown` (`cmd/easysftp`) — cover multi-target delta correctness (including sum-equals-total) and that single-target summaries are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rdy9V43Q6YSnmKjxQRaYb

---
_Generated by [Claude Code](https://claude.ai/code/session_013rdy9V43Q6YSnmKjxQRaYb)_