### PR TITLE
feat: warn once per target when non-regular files are skipped

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -115,6 +115,15 @@ Symlinks, sockets and other non-regular files are skipped by design. SFTP
 uploads regular file content. If your build output contains symlinks (e.g.
 pnpm's `node_modules`), upload a bundled/dereferenced build instead.
 
+When a target has any non-regular files, the log shows one aggregated
+warning per target (not one per file), e.g.:
+
+```
+::warning::skipped 37 non-regular file(s) (symlinks, sockets, …) under ./dist/: SFTP uploads regular files only
+```
+
+No warning is logged when there is nothing to skip.
+
 ## Strategy questions
 
 ### `sync` did not delete a file I removed locally

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -56,10 +56,11 @@ type fileItem struct {
 
 // plan is the complete set of transfers for one upload pair.
 type plan struct {
-	pair       config.UploadPair
-	strategy   config.Strategy
-	files      []fileItem
-	remoteDirs []string // directories to create, sorted parents-first
+	pair              config.UploadPair
+	strategy          config.Strategy
+	files             []fileItem
+	remoteDirs        []string // directories to create, sorted parents-first
+	skippedNonRegular int      // symlinks, sockets, etc. skipped during the walk
 }
 
 // Run executes the configured upload and returns transfer statistics.
@@ -78,6 +79,10 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		p, err := buildPlan(pair, st, matcher)
 		if err != nil {
 			return stats, err
+		}
+		if p.skippedNonRegular > 0 {
+			log.Warningf("skipped %d non-regular file(s) (symlinks, sockets, …) under %s: SFTP uploads regular files only",
+				p.skippedNonRegular, pair.Local)
 		}
 		plans = append(plans, p)
 	}
@@ -169,6 +174,7 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore
 		}
 		if !fi.Mode().IsRegular() {
 			// Symlinks, sockets etc. are skipped; SFTP uploads regular files.
+			p.skippedNonRegular++
 			return nil
 		}
 		item := fileItem{

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -431,6 +432,48 @@ func TestDefaultModeMirrorsLocalBitsSilentlyOnFailure(t *testing.T) {
 		if strings.Contains(w, "SETSTAT") {
 			t.Errorf("expected no chmod warning when mirroring local mode (no explicit override), got %v", log.warnings)
 		}
+	}
+}
+
+func TestSymlinkSkipWarnsOncePerTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1", "b.txt": "2"})
+	if err := os.Symlink(filepath.Join(local, "a.txt"), filepath.Join(local, "link1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(local, "b.txt"), filepath.Join(local, "link2")); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	stats, err := Run(context.Background(), cfg, log)
+	if err != nil {
+		t.Fatalf("symlinks must be skipped, not fail the run: %v", err)
+	}
+	if stats.FilesUploaded != 2 {
+		t.Errorf("expected the 2 regular files to upload, got %d", stats.FilesUploaded)
+	}
+
+	log.mu.Lock()
+	defer log.mu.Unlock()
+	n := 0
+	for _, w := range log.warnings {
+		if strings.Contains(w, "non-regular") {
+			n++
+			if !strings.Contains(w, "2") {
+				t.Errorf("expected the warning to mention the count of 2, got %q", w)
+			}
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected exactly 1 non-regular-file warning, got %d: %v", n, log.warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #15.

`buildPlan` silently skips symlinks, sockets, and other non-regular files during the local walk. Skipping is the right default (SFTP uploads regular file content), but doing it silently costs users real debugging time: a build output containing symlinks (e.g. pnpm's `node_modules`, Hugo's linked assets) deploys "successfully" while files are missing on the server, with nothing in the log explaining why.

This adds one aggregated warning per target (not one per file) when non-regular files were skipped:

```
::warning::skipped 37 non-regular file(s) (symlinks, sockets, …) under ./dist/: SFTP uploads regular files only
```

Nothing is logged when there is nothing to skip.

## Changes

- `plan` gains a `skippedNonRegular` counter, incremented in the `buildPlan` walk when a non-regular file is encountered.
- `Run` logs one warning per target with a nonzero count, right after `buildPlan` (still before connecting, so this doesn't touch the network path).
- `docs/troubleshooting.md`'s existing "Symlinks are missing on the server" section now documents the warning.
- New test `TestSymlinkSkipWarnsOncePerTarget`: two symlinks + two regular files, asserts the regular files still upload, exactly one warning is logged, and it mentions the count of 2. Skipped on Windows (symlink creation needs elevated privileges there).

A `follow-symlinks` input (upload the link target's content) is out of scope here per the issue — the warning alone removes the debugging confusion.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` / `go vet ./...` clean
- [x] `go test -race ./...` passes, including the new symlink test


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRrG4d6AFTqDLfBJXjjzxg)_