### PR TITLE
fix: stop rejecting config-file runs over the max-deletes input default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@ Look at how existing inputs are wired before adding a new one:
    `config-file` — see the check at the top of `config.Load()` — because a
    YAML config file replaces them entirely, and `configfile.go` /
    `schema/easysftp.schema.json` define the per-target equivalents.
+   **Never give these inputs a `default:` in `action.yml`**: the runner
+   exports declared defaults unconditionally, so the mutual-exclusion check
+   sees them as "user-set" and rejects every `config-file` run — that's how
+   #62 shipped in v2.0.0. `TestLoadConfigFileWithActionDefaults`
+   (`internal/config/config_test.go`) guards against reintroducing this.
 2. **Run-wide behavior** (connection, transfer mechanics): `retries`,
    `concurrency`, `sftp-request-concurrency`, `timeout`, `dry-run`,
    `sync-fast-path`, `dir-mode`, `file-mode`. These always come from action

--- a/action.yml
+++ b/action.yml
@@ -77,11 +77,12 @@ inputs:
   max-deletes:
     description: >-
       Refuse the run if the "sync" or "clean" strategy would delete more than
-      this many remote files. 0 (the default) means unlimited. Only valid
+      this many remote files. Unset or 0 means unlimited. Only valid
       without config-file — with a config file, set "guards.max_deletes"
-      there instead.
+      there instead. Deliberately has no declared default: a default value
+      would always be exported and wrongly trip the config-file
+      mutual-exclusion check.
     required: false
-    default: "0"
   delete:
     description: >-
       Removed in v2 — use "strategy: clean" instead. Still declared so that a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,8 +190,8 @@ targets:
 | `targets[].ignore` | | - | Per-target excludes, additive to the global list. |
 
 Unknown keys are rejected with an error (they are never silently ignored), and
-`config-file` cannot be combined with the `uploads`, `strategy`, `ignore` or
-`ignore-from` inputs.
+`config-file` cannot be combined with the `uploads`, `strategy`, `ignore`,
+`ignore-from` or `max-deletes` inputs.
 
 ### Editor support
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,8 +3,11 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseUploads(t *testing.T) {
@@ -149,6 +152,79 @@ func TestLoadMaxDeletesRejectedWithConfigFile(t *testing.T) {
 	_, err := Load()
 	if err == nil || !strings.Contains(err.Error(), "do not also set") {
 		t.Fatalf("expected rejection error, got %v", err)
+	}
+}
+
+// TestLoadConfigFileWithActionDefaults simulates a real composite-action run
+// that only sets connection settings and config-file: every EASYSFTP_* env
+// var wired in action.yml's "Upload via SFTP" step is exported with its
+// declared input default (empty when there is none), exactly as the runner
+// does. Regression test for the max-deletes default "0" tripping the
+// config-file mutual-exclusion check (#62) — and a guard against any future
+// input default reintroducing the same class of bug.
+func TestLoadConfigFileWithActionDefaults(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "action.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var action struct {
+		Inputs map[string]struct {
+			Default string `yaml:"default"`
+		} `yaml:"inputs"`
+		Runs struct {
+			Steps []struct {
+				Name string            `yaml:"name"`
+				Env  map[string]string `yaml:"env"`
+			} `yaml:"steps"`
+		} `yaml:"runs"`
+	}
+	if err := yaml.Unmarshal(data, &action); err != nil {
+		t.Fatalf("parse action.yml: %v", err)
+	}
+
+	var envBlock map[string]string
+	for _, step := range action.Runs.Steps {
+		if step.Name == "Upload via SFTP" {
+			envBlock = step.Env
+		}
+	}
+	if envBlock == nil {
+		t.Fatal("action.yml has no 'Upload via SFTP' step")
+	}
+
+	inputRef := regexp.MustCompile(`^\$\{\{ inputs\.([a-z-]+) \}\}$`)
+	for name, expr := range envBlock {
+		if !strings.HasPrefix(name, envPrefix) {
+			continue
+		}
+		m := inputRef.FindStringSubmatch(expr)
+		if m == nil {
+			t.Errorf("env %s = %q does not reference an input", name, expr)
+			continue
+		}
+		input, ok := action.Inputs[m[1]]
+		if !ok {
+			t.Fatalf("env %s references undeclared input %q", name, m[1])
+		}
+		t.Setenv(name, input.Default)
+	}
+
+	// What a user's config-file workflow actually sets.
+	t.Setenv("EASYSFTP_SERVER", "sftp.example.com")
+	t.Setenv("EASYSFTP_USERNAME", "deploy")
+	t.Setenv("EASYSFTP_PASSWORD", "hunter2")
+	configFile := filepath.Join(t.TempDir(), "easysftp.yml")
+	if err := os.WriteFile(configFile, []byte("version: 1\ntargets:\n  - local: ./dist/\n    remote: /www/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("EASYSFTP_CONFIG_FILE", configFile)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("config-file run with action.yml input defaults was rejected: %v", err)
+	}
+	if len(cfg.Uploads) != 1 || cfg.Uploads[0].Local != "./dist/" {
+		t.Errorf("unexpected uploads from config file: %+v", cfg.Uploads)
 	}
 }
 


### PR DESCRIPTION
Fixes #62 — using `config-file` through the real action has been broken since v2.0.0: `action.yml` declared `default: "0"` for `max-deletes`, so the runner always exported `EASYSFTP_MAX_DELETES=0`, and the mutual-exclusion check in `config.Load()` treated that as a user-set input and rejected every `config-file` run, even when the workflow set none of the conflicting inputs.

## What changed

- **`action.yml`**: dropped the declared `default: "0"` from `max-deletes` (fix option 1 from the issue — smallest change, keeps the strict rejection for explicitly-set values). Empty means unset; `parseInt` already falls back to `0`, so behavior for non-config-file runs is unchanged. The input description now documents why this input deliberately has no declared default.
- **`internal/config/config_test.go`**: new regression test `TestLoadConfigFileWithActionDefaults`. It parses `action.yml`, exports every `EASYSFTP_*` env var wired in the `Upload via SFTP` step with its declared input default — exactly what the runner does — and asserts a `config-file` run loads. This is structural on purpose: any future input whose declared default would re-trip the exclusion check fails this test immediately. Verified the test fails when the old `default: "0"` is restored.
- **`docs/configuration.md`**: aligned the mutually-exclusive input list ("Unknown keys are rejected…" paragraph) with the runtime error message — it omitted `max-deletes` (the docs nit from the issue).
- **`CLAUDE.md`**: working note that deployment-shape inputs must never declare an `action.yml` default, with a pointer to the regression test.

`gofmt` clean, `go test -race ./...` green.

## Issue triage done in this session

- Left a note on #68: the new structural test overlaps with its optional suggestion (every `EASYSFTP_*` env var must reference a declared input), but the `wantInputs` update in `actionmeta_test.go` is still open.
- Checked #6, #25, #70 comment threads — all still current, no action needed here. Note for the maintainer: a contributor asked to be assigned to #70; assignment is your call.
- This session's branch setup allows one PR, so only one code issue was worked; the remaining open issues were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011shFQpsg548kt2CkuShswJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011shFQpsg548kt2CkuShswJ)_