### PR TITLE
fix: reject negative timeout, document 0 as no-timeout escape hatch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -129,7 +129,7 @@ inputs:
     required: false
     default: "2"
   timeout:
-    description: Connection timeout in seconds.
+    description: Connection timeout in seconds. 0 disables the timeout entirely.
     required: false
     default: "30"
   dir-mode:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 | `private-key` | ¹ | - | SSH private key (OpenSSH/PEM format). **Use a secret.** |
 | `passphrase` | | - | Passphrase of the private key, if encrypted. |
 | `host-key-fingerprint` | | - | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). **Strongly recommended**, see [Security](security.md). |
-| `timeout` | | `30` | Connection timeout in seconds. |
+| `timeout` | | `30` | Connection timeout in seconds. `0` disables the timeout entirely. |
 
 ¹ At least one of `password` / `private-key` is required. If both are set, the key is tried first.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,6 +213,8 @@ func (c *Config) validate() error {
 		return fmt.Errorf("input 'sftp-request-concurrency' must be at least 1, got %d", c.SftpRequestConcurrency)
 	case c.Retries < 0:
 		return fmt.Errorf("input 'retries' must not be negative, got %d", c.Retries)
+	case c.Timeout < 0:
+		return fmt.Errorf("input 'timeout' must not be negative (use 0 to disable the timeout), got %d", int(c.Timeout/time.Second))
 	case c.Guards.MaxDeletes < 0:
 		return fmt.Errorf("guards.max_deletes must not be negative, got %d", c.Guards.MaxDeletes)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,7 @@ func TestLoadValidation(t *testing.T) {
 		{"bad sftp-request-concurrency", map[string]string{"EASYSFTP_SFTP_REQUEST_CONCURRENCY": "not-a-number"}, "invalid sftp-request-concurrency"},
 		{"zero sftp-request-concurrency", map[string]string{"EASYSFTP_SFTP_REQUEST_CONCURRENCY": "0"}, "'sftp-request-concurrency' must be at least 1"},
 		{"negative max-deletes", map[string]string{"EASYSFTP_MAX_DELETES": "-1"}, "guards.max_deletes must not be negative"},
+		{"negative timeout", map[string]string{"EASYSFTP_TIMEOUT": "-5"}, "'timeout' must not be negative"},
 		{"bad dir-mode", map[string]string{"EASYSFTP_DIR_MODE": "not-octal"}, "invalid dir-mode"},
 		{"dir-mode out of range", map[string]string{"EASYSFTP_DIR_MODE": "1755"}, "invalid dir-mode"},
 		{"bad file-mode", map[string]string{"EASYSFTP_FILE_MODE": "999"}, "invalid file-mode"},
@@ -99,6 +100,19 @@ func TestLoadValidation(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestLoadZeroTimeoutDisablesTimeout(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("EASYSFTP_TIMEOUT", "0")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Timeout != 0 {
+		t.Errorf("expected timeout 0 (disabled), got %s", cfg.Timeout)
 	}
 }
 


### PR DESCRIPTION
Closes #67.

## What

`timeout: "-5"` was silently accepted and became `ssh.ClientConfig.Timeout < 0`, meaning no timeout at all. `validate()` now rejects negative values with a friendly error, consistent with the neighboring port/concurrency/retries validations.

## Decision made

The issue offered two options: reject `<= 0` entirely, or keep `0` as a deliberate escape hatch. I kept `0` = no timeout and documented it in `action.yml` and `docs/configuration.md`, since the project principle is user choice over enforced opinions. A user who wants to wait indefinitely on a slow server can now do so explicitly, and the semantics are no longer undocumented.

## Tests

- New validation case: `timeout: -5` is rejected.
- New `TestLoadZeroTimeoutDisablesTimeout`: `0` loads as disabled timeout.
- `go test ./...` passes. Note: `go test -race` could not run in this environment (no cgo toolchain on the Windows runner); CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)