### PR TITLE
fix: report planned bytes in dry-run instead of always 0

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,7 @@ release.
 | `files-uploaded` | Number of uploaded files (planned files in dry-run mode). |
 | `files-deleted` | Number of remote files removed by the `clean`/`sync` strategy. |
 | `files-skipped` | Number of unchanged files skipped by the `sync` strategy. |
-| `bytes-uploaded` | Total bytes transferred. |
+| `bytes-uploaded` | Total bytes transferred (planned bytes in dry-run mode). |
 | `duration-ms` | Total runtime in milliseconds. |
 
 A summary table is also written to the job summary of every run. Outputs and

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -349,6 +349,9 @@ func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, f
 			}
 			log.Infof("%supload %s => %s (%s)", verb, f.localPath, f.remotePath, humanSize(f.size))
 			if cfg.DryRun {
+				// Report the planned byte count so bytes-uploaded matches the
+				// "planned counts" contract of the other dry-run outputs.
+				results[i] = f.size
 				completed[i] = true
 				return nil
 			}

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -303,8 +303,8 @@ func TestDryRun(t *testing.T) {
 	if stats.FilesUploaded != 2 {
 		t.Errorf("expected 2 planned uploads, got %d", stats.FilesUploaded)
 	}
-	if stats.BytesUploaded != 0 {
-		t.Errorf("dry-run must not transfer bytes, got %d", stats.BytesUploaded)
+	if stats.BytesUploaded != 2 {
+		t.Errorf("expected 2 planned bytes, got %d", stats.BytesUploaded)
 	}
 	if remoteExists(t, srv, "/www") {
 		t.Error("dry-run must not create remote directories")


### PR DESCRIPTION
Closes #66.

## What

In dry-run mode, `bytes-uploaded` always reported 0 while `files-uploaded` reported the planned file count. The dry-run branch in `uploadFiles` now records each planned file's local size, so `bytes-uploaded` reports the total planned transfer size, matching the "planned counts" contract documented for the other outputs.

## Changes

- `internal/uploader/uploader.go`: one line, `results[i] = f.size` in the dry-run branch.
- `docs/configuration.md`: outputs table notes the dry-run semantics for `bytes-uploaded`, same wording style as `files-uploaded`.
- `TestDryRun` now asserts the planned byte count instead of asserting 0.

`go test ./...` passes. Note: `go test -race` could not run in this environment (no cgo toolchain); CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)