### PR TITLE
fix: drop the unused and miscounting Stats.DirsCreated field

### DIFF
--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -38,7 +38,6 @@ type Stats struct {
 	FilesUploaded int
 	FilesDeleted  int
 	FilesSkipped  int // unchanged files skipped by the sync strategy
-	DirsCreated   int
 	BytesUploaded int64
 	Duration      time.Duration
 
@@ -326,7 +325,7 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, client *sftp
 // parallel (or, in dry-run mode, only logs what it would do).
 func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, files []fileItem, dirs []string, stats *Stats, verb string, log Logger) error {
 	if !cfg.DryRun {
-		if err := createRemoteDirs(client, dirs, cfg.DirMode, stats, log); err != nil {
+		if err := createRemoteDirs(client, dirs, cfg.DirMode, log); err != nil {
 			return err
 		}
 	}
@@ -381,7 +380,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, f
 // treats an already-existing directory as success, so ancestors are never
 // stat'd or created one level at a time. Only when a creation fails does it
 // look closer, to report a path that already exists as a file clearly.
-func createRemoteDirs(client *sftp.Client, dirs []string, dirMode *fs.FileMode, stats *Stats, log Logger) error {
+func createRemoteDirs(client *sftp.Client, dirs []string, dirMode *fs.FileMode, log Logger) error {
 	for _, dir := range leafDirs(dirs) {
 		if err := client.MkdirAll(dir); err != nil {
 			if bad := nonDirConflict(client, dir); bad != "" {
@@ -389,7 +388,6 @@ func createRemoteDirs(client *sftp.Client, dirs []string, dirMode *fs.FileMode, 
 			}
 			return fmt.Errorf("creating remote directory %q: %w", dir, err)
 		}
-		stats.DirsCreated++
 	}
 
 	if dirMode != nil {


### PR DESCRIPTION
Closes #65.

## What

`Stats.DirsCreated` was incremented in `createRemoteDirs` but never consumed anywhere (not in the outputs, the job summary, or the done log line). Since the leaf-dirs optimization it also miscounted twice over: it counted once per leaf instead of once per created directory, and `MkdirAll` counts already-existing directories as created.

## Decision made

The issue offered dropping the field or surfacing it honestly (as "dirs ensured"). I dropped it: nothing has ever consumed it, a true "created" count would need the pre-stat round-trips the leaf-dirs optimization deliberately removed, and "dirs ensured" is not a number users have asked for. Easy to reintroduce properly if a real need shows up.

Also removes the now-unused `stats` parameter from `createRemoteDirs`.

`go test ./...` passes. Note: `go test -race` could not run in this environment (no cgo toolchain); CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)