### PR TITLE
chore: spell Round(1e6) as Round(time.Millisecond) in main.go

### DIFF
--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/eiserv/easySFTP/internal/config"
 	"github.com/eiserv/easySFTP/internal/gha"
@@ -59,7 +60,7 @@ func run() error {
 	}
 	if runErr == nil {
 		gha.Infof("done: %s %d file(s), %d byte(s), deleted %d file(s), skipped %d unchanged, took %s",
-			mode, stats.FilesUploaded, stats.BytesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.Duration.Round(1e6))
+			mode, stats.FilesUploaded, stats.BytesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.Duration.Round(time.Millisecond))
 	}
 
 	reportStats(stats, mode, runErr)
@@ -116,7 +117,7 @@ func reportStats(stats *uploader.Stats, mode string, runErr error) {
 
 	summary := fmt.Sprintf(
 		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %d |\n| Duration | %s |\n",
-		status, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.BytesUploaded, stats.Duration.Round(1e6))
+		status, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.BytesUploaded, stats.Duration.Round(time.Millisecond))
 	summary += targetBreakdown(stats.Targets)
 	gha.AppendSummary(summary)
 }


### PR DESCRIPTION
Closes #71.

Replaces the magic number `stats.Duration.Round(1e6)` with `stats.Duration.Round(time.Millisecond)` in both places (`run()` and `reportStats`). Pure readability, no behavior change; `1e6` nanoseconds is exactly `time.Millisecond`.

`go build ./...` and `go test ./...` pass. Note: `go test -race` could not run in this environment (no cgo toolchain); CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)