### PR TITLE
docs: add missing punctuation in troubleshooting auth section

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -48,7 +48,7 @@ The server rejected the credentials.
 
 - Verify the secret names in your workflow match the configured secrets
   (a missing secret silently expands to an empty string).
-- Password auth: some servers disable it entirely (`PasswordAuthentication no`)
+- Password auth: some servers disable it entirely (`PasswordAuthentication no`);
   use a key instead.
 - Key auth: the key must be in OpenSSH or PEM format. If it is encrypted, set
   `passphrase`. Check that the *public* key is in the server's


### PR DESCRIPTION
Closes #70.

Adds the missing punctuation after the `PasswordAuthentication no` parenthesis in `docs/troubleshooting.md`. Used a semicolon rather than the dash suggested in the issue; it reads the same and keeps the docs' punctuation style plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)