### PR TITLE
docs: recommend @v2 in README and doc snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ no-longer-maintained [Dylan700/sftp-upload-action][dylan]:
 
 ```yaml
 - name: Deploy via SFTP
-  uses: eiserv/easySFTP@v1
+  uses: eiserv/easySFTP@v2
   with:
     server: sftp.example.com
     username: ${{ secrets.SFTP_USERNAME }}
@@ -94,6 +94,9 @@ no-longer-maintained [Dylan700/sftp-upload-action][dylan]:
 
 That's it. Everything else is optional. More recipes (key auth, multi-target
 deploys, PR previews, `.sftpignore`) live in [docs/examples.md](docs/examples.md).
+
+Upgrading from v1? The only breaking change is that `delete: true` became
+`strategy: clean`; everything else works unchanged.
 
 ## Inputs & outputs
 
@@ -190,14 +193,14 @@ Vulnerability reports: [SECURITY.md](SECURITY.md)
 easySFTP follows [Semantic Versioning](https://semver.org):
 
 ```yaml
-uses: eiserv/easySFTP@v1        # latest 1.x, recommended, gets fixes & features
-uses: eiserv/easySFTP@v1.2.3    # exact, immutable pin
+uses: eiserv/easySFTP@v2        # latest 2.x, recommended, gets fixes & features
+uses: eiserv/easySFTP@v2.0.0    # exact, immutable pin
 ```
 
-`v1`, `v1.2` and `v1.2.3` use the exact version recorded in
+`v2`, `v2.0` and `v2.0.0` use the exact version recorded in
 `.easysftp-version` and download the corresponding asset only from this
 repository's GitHub Release. The asset's SHA-256 digest is checked against
-`checksums.txt` before it is executed. `v1`/`v1.2` are rolling tags; exact tags
+`checksums.txt` before it is executed. `v2`/`v2.0` are rolling tags; exact tags
 never move.
 
 An exact release-commit SHA is accepted after it is matched against the exact

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -47,6 +47,11 @@ version tags or releases by hand.
    the exact release commit. A failed build, test, or upload leaves rolling
    tags unchanged. The exact `vX.Y.Z` tag is never moved.
 
+8. After a **major** release, update the pinned tag in every doc snippet: the
+   `uses: eiserv/easySFTP@vX` examples in `README.md`, `docs/examples.md`,
+   `docs/configuration.md`, and `docs/security.md`, plus the README
+   "Versioning" section. They do not update themselves (see issue #63).
+
 ## Stable asset names
 
 ```text

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,7 @@ file. Connection settings (server, credentials, host key) always stay in the
 action inputs. **Never put credentials in this file**.
 
 ```yaml
-- uses: eiserv/easySFTP@v1
+- uses: eiserv/easySFTP@v2
   with:
     server: sftp.example.com
     username: ${{ secrets.SFTP_USERNAME }}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -31,7 +31,7 @@ jobs:
       - run: npm ci && npm run build
 
       - name: Deploy via SFTP
-        uses: eiserv/easySFTP@v1
+        uses: eiserv/easySFTP@v2
         with:
           server: sftp.example.com
           username: ${{ secrets.SFTP_USERNAME }}
@@ -48,7 +48,7 @@ only files easySFTP itself uploaded ([manifest-based](strategies.md#sync), so
 user uploads and server-generated files survive):
 
 ```yaml
-- uses: eiserv/easySFTP@v1
+- uses: eiserv/easySFTP@v2
   with:
     server: sftp.example.com
     username: ${{ secrets.SFTP_USERNAME }}
@@ -63,7 +63,7 @@ user uploads and server-generated files survive):
 Different directories, different strategies, one connection:
 
 ```yaml
-- uses: eiserv/easySFTP@v1
+- uses: eiserv/easySFTP@v2
   with:
     server: sftp.example.com
     username: ${{ secrets.SFTP_USERNAME }}
@@ -98,7 +98,7 @@ Full field reference: [configuration.md](configuration.md#the-yaml-config-file).
 Preferred over passwords, see the [security guide](security.md#credentials):
 
 ```yaml
-- uses: eiserv/easySFTP@v1
+- uses: eiserv/easySFTP@v2
   with:
     server: sftp.example.com
     username: ${{ secrets.SFTP_USERNAME }}
@@ -136,7 +136,7 @@ jobs:
       - run: npm ci && npm run build
 
       - name: What would deploy?
-        uses: eiserv/easySFTP@v1
+        uses: eiserv/easySFTP@v2
         with:
           server: sftp.example.com
           username: ${{ secrets.SFTP_USERNAME }}
@@ -154,7 +154,7 @@ Give the step an `id` and read the outputs in later steps:
 ```yaml
 - name: Deploy via SFTP
   id: deploy
-  uses: eiserv/easySFTP@v1
+  uses: eiserv/easySFTP@v2
   with:
     # ...
 
@@ -171,7 +171,7 @@ Give the step an `id` and read the outputs in later steps:
 Keep the exclude list out of the workflow file:
 
 ```yaml
-- uses: eiserv/easySFTP@v1
+- uses: eiserv/easySFTP@v2
   with:
     # ...
     uploads: ./dist/ => /var/www/html/
@@ -197,7 +197,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: eiserv/easySFTP@v1
+      - uses: eiserv/easySFTP@v2
         with:
           server: sftp.example.com
           username: ${{ secrets.SFTP_USERNAME }}

--- a/docs/security.md
+++ b/docs/security.md
@@ -59,7 +59,7 @@ new fingerprints.
   `eiserv/easySFTP`'s exact GitHub Release, and verifies SHA-256 before
   execution. Release downloads may follow GitHub's HTTPS redirect to its own
   release-asset CDN; no third-party download source is configured.
-- Pin the action to a major tag for convenience (`eiserv/easySFTP@v1`) or to
+- Pin the action to a major tag for convenience (`eiserv/easySFTP@v2`) or to
   the full commit SHA of an exact release. Prebuilt mode verifies that a SHA is
   the commit behind the version file's release tag. For any development SHA,
   explicitly build that checkout from source so a stale release binary can


### PR DESCRIPTION
Closes #63.

v2.0.0 shipped, but every user-facing snippet still pinned `@v1`, and the README versioning section called 1.x "recommended". New users following the docs landed on the last 1.x release.

## Changes

- All `uses: eiserv/easySFTP@v1` snippets in README, docs/examples.md, docs/configuration.md, and docs/security.md now pin `@v2`.
- README versioning section updated: `@v2` rolling tag recommended, `@v2.0.0` as the exact-pin example, rolling-tag explanation reworded for the v2 line.
- One-line migration note added below the quick start: the only breaking change is `delete: true` -> `strategy: clean`.
- docs/RELEASING.md release flow gained a step 8: after a major release, update the pinned tag in all doc snippets, so this does not go stale again at v3.

The generic `v1.2.3` tag examples in RELEASING.md's tag-policy and repair sections are left as-is; they illustrate tag semantics, not a recommended pin.

No code changes, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)