### PR TITLE
perf(sync): derive remote directories from the actual upload set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,13 @@ Look at how existing inputs are wired before adding a new one:
   `withFailRename()`) and connection drops (`withDropAfter`). Follow that
   pattern (wrap the relevant `Handlers` field, add a `serverOption`) for new
   fault-injection needs instead of building a new fake server.
+- Every `FileCmder` wrapper in `testserver_test.go` must implement
+  `PosixRename` (delegate via `posixRenamePassthrough`): pkg/sftp serves
+  posix-rename only when the outermost `FileCmder` implements
+  `PosixRenameFileCmder` and otherwise downgrades it to plain `Rename`, which
+  fails when the target exists. A wrapper without the method makes every
+  overwriting rename (manifest rewrites, re-uploads of existing files) fail
+  with "file already exists", far from the wrapper's apparent concern.
 - Run `go test -race ./...` before committing; uploads are parallelized
   (`errgroup` + `cfg.Concurrency`), so races are the most likely regression
   class in `internal/uploader`. `-race` needs cgo: on a machine without a C

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -46,6 +46,11 @@ Notes:
 - Directories left empty by deletions are pruned automatically.
 - Local files are hashed in parallel through a worker pool bounded by
   `concurrency`, so planning a large tree uses the available runner CPU.
+- Remote directories are only created (or confirmed) for files actually being
+  uploaded, so a sync with nothing to do costs just the manifest read and
+  rewrite, no per-directory round-trips. Exception: with `dir-mode` set, every
+  directory of the plan is still chmod'd, per its documented "creates or
+  touches" semantics.
 
 ### `sync-fast-path`: skip re-hashing unchanged files
 

--- a/internal/uploader/dirsetup_test.go
+++ b/internal/uploader/dirsetup_test.go
@@ -2,6 +2,7 @@ package uploader
 
 import (
 	"context"
+	"io/fs"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -115,5 +116,128 @@ func TestExistingTreeConfirmsOnlyLeaves(t *testing.T) {
 	// One stat per leaf (/www/a/b/c/d and /www/a/b/c/e), not one per ancestor.
 	if got := atomic.LoadInt64(&ops.stat); got != 2 {
 		t.Errorf("deploy stat'd %d paths for directory setup; want 2 (one per leaf)", got)
+	}
+}
+
+// TestSyncNoOpIssuesNoDirRoundTrips verifies a sync with nothing to upload
+// derives its directory set from the (empty) upload list: zero Mkdir and zero
+// directory Stat calls, instead of one round-trip per leaf of the whole plan.
+func TestSyncNoOpIssuesNoDirRoundTrips(t *testing.T) {
+	var ops opCounter
+	srv := startTestServer(t, withOpCounter(&ops))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"a/one.txt": "1",
+		"b/two.txt": "2",
+		"c/tri.txt": "3",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategySync}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	atomic.StoreInt64(&ops.mkdir, 0)
+	atomic.StoreInt64(&ops.stat, 0)
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 0 || stats.FilesSkipped != 3 {
+		t.Fatalf("no-op sync: up=%d skip=%d, want 0/3", stats.FilesUploaded, stats.FilesSkipped)
+	}
+	if got := atomic.LoadInt64(&ops.mkdir); got != 0 {
+		t.Errorf("no-op sync issued %d Mkdir calls; want 0", got)
+	}
+	if got := atomic.LoadInt64(&ops.stat); got != 0 {
+		t.Errorf("no-op sync issued %d Stat calls; want 0", got)
+	}
+}
+
+// TestSyncPartialChangeTouchesOnlyChangedDirs verifies an incremental sync
+// confirms only the directories of the files actually being uploaded, not
+// every leaf of the whole plan.
+func TestSyncPartialChangeTouchesOnlyChangedDirs(t *testing.T) {
+	var ops opCounter
+	srv := startTestServer(t, withOpCounter(&ops))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"a/one.txt": "1",
+		"b/two.txt": "2",
+		"c/tri.txt": "3",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategySync}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTree(t, local, map[string]string{"a/one.txt": "changed"})
+	atomic.StoreInt64(&ops.mkdir, 0)
+	atomic.StoreInt64(&ops.stat, 0)
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 1 {
+		t.Fatalf("incremental sync uploads: got %d, want 1", stats.FilesUploaded)
+	}
+	if got := atomic.LoadInt64(&ops.mkdir); got != 0 {
+		t.Errorf("incremental sync created %d directories; want 0 (all exist)", got)
+	}
+	// MkdirAll confirms just /www/a (the one leaf the changed file needs).
+	if got := atomic.LoadInt64(&ops.stat); got != 1 {
+		t.Errorf("incremental sync stat'd %d paths for directory setup; want 1", got)
+	}
+}
+
+// TestSyncDirModeStillCoversWholePlan pins the documented dir-mode semantics:
+// with dir-mode set, every directory of the plan is chmod'd (the run "touches"
+// them), even when nothing needs uploading. The fake server rejects chmod on
+// directories, so the assertion is on the requests received, not the modes.
+func TestSyncDirModeStillCoversWholePlan(t *testing.T) {
+	rec := &setstatRecorder{}
+	srv := startTestServer(t, withSetstatRecorder(rec))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"a/one.txt": "1",
+		"b/two.txt": "2",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategySync}}
+	mode := fs.FileMode(0o755)
+	cfg.DirMode = &mode
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second, no-op sync: dir-mode must still request a chmod on every plan
+	// directory (/www, /www/a, /www/b).
+	rec.mu.Lock()
+	rec.calls = nil
+	rec.mu.Unlock()
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	got := map[string]bool{}
+	for _, c := range rec.calls {
+		got[c.path] = true
+	}
+	for _, want := range []string{"/www", "/www/a", "/www/b"} {
+		if !got[want] {
+			t.Errorf("no-op sync with dir-mode did not chmod %s; requests: %v", want, rec.calls)
+		}
 	}
 }

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -96,7 +96,16 @@ func executeSync(ctx context.Context, cfg *config.Config, client *sftp.Client, p
 		}
 	}
 
-	if err := uploadFiles(ctx, cfg, client, upload, p.remoteDirs, stats, verb, log); err != nil {
+	// Directories are derived from the files actually being uploaded, so an
+	// unchanged (or barely changed) sync pays no directory round-trips for
+	// the untouched parts of the tree. With dir-mode set, the full plan's
+	// directory list is kept instead: dir-mode is documented as applying to
+	// every remote directory the run creates or touches.
+	dirs := dirsForFiles(upload)
+	if cfg.DirMode != nil {
+		dirs = p.remoteDirs
+	}
+	if err := uploadFiles(ctx, cfg, client, upload, dirs, stats, verb, log); err != nil {
 		return err
 	}
 

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -79,6 +79,24 @@ func (r *setstatRecorder) Filecmd(req *sftp.Request) error {
 	return r.inner.Filecmd(req)
 }
 
+func (r *setstatRecorder) PosixRename(req *sftp.Request) error {
+	return posixRenamePassthrough(r.inner, req)
+}
+
+// posixRenamePassthrough forwards posix-rename to the wrapped handler. Every
+// FileCmder wrapper in this file needs a PosixRename method calling this:
+// pkg/sftp only serves posix-rename when the outermost FileCmder implements
+// PosixRenameFileCmder, and otherwise silently downgrades it to plain
+// "Rename", which unlike posix-rename fails when the target exists. Without
+// the passthrough, wrapping the server makes every overwriting rename (e.g. a
+// manifest rewrite) fail with "file already exists".
+func posixRenamePassthrough(inner sftp.FileCmder, req *sftp.Request) error {
+	if pr, ok := inner.(sftp.PosixRenameFileCmder); ok {
+		return pr.PosixRename(req)
+	}
+	return inner.Filecmd(req)
+}
+
 // withSetstatRecorder records chmod requests. It must be given before any
 // fault-injecting option so the recorder observes the request regardless of
 // whether a later wrapper then fails it.
@@ -115,6 +133,10 @@ func (c *opCounter) Filecmd(r *sftp.Request) error {
 		atomic.AddInt64(&c.mkdir, 1)
 	}
 	return c.cmd.Filecmd(r)
+}
+
+func (c *opCounter) PosixRename(r *sftp.Request) error {
+	return posixRenamePassthrough(c.cmd, r)
 }
 
 func (c *opCounter) Filelist(r *sftp.Request) (sftp.ListerAt, error) {
@@ -227,6 +249,10 @@ func (f *faultySetstat) Filecmd(r *sftp.Request) error {
 		return errors.New("injected setstat failure")
 	}
 	return f.inner.Filecmd(r)
+}
+
+func (f *faultySetstat) PosixRename(r *sftp.Request) error {
+	return posixRenamePassthrough(f.inner, r)
 }
 
 // dropConn closes the connection once it has read limit bytes, simulating a

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -186,7 +186,6 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore
 		return p, nil
 	}
 
-	dirSet := map[string]struct{}{}
 	err = filepath.WalkDir(pair.Local, func(fpath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -220,21 +219,31 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore
 			mode:       fi.Mode(),
 		}
 		p.files = append(p.files, item)
-		for _, dir := range parentDirs(item.remotePath) {
-			dirSet[dir] = struct{}{}
-		}
 		return nil
 	})
 	if err != nil {
 		return p, fmt.Errorf("walking local path %q: %w", pair.Local, err)
 	}
 
-	for dir := range dirSet {
-		p.remoteDirs = append(p.remoteDirs, dir)
-	}
-	// Parents sort before their children, so creation order is safe.
-	sort.Strings(p.remoteDirs)
+	p.remoteDirs = dirsForFiles(p.files)
 	return p, nil
+}
+
+// dirsForFiles returns the set of ancestor directories of the given files,
+// sorted so parents come before their children (creation order is safe).
+func dirsForFiles(files []fileItem) []string {
+	dirSet := map[string]struct{}{}
+	for _, f := range files {
+		for _, dir := range parentDirs(f.remotePath) {
+			dirSet[dir] = struct{}{}
+		}
+	}
+	dirs := make([]string, 0, len(dirSet))
+	for dir := range dirSet {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	return dirs
 }
 
 // hashPlanFiles fills in each file's sha256 content hash, hashing through a


### PR DESCRIPTION
Fixes #69

## What

For the `sync` strategy, the set of remote directories passed to `uploadFiles` is now derived from the files actually being uploaded, not from the whole plan:

- A no-change sync performs **zero** directory round-trips (previously one `MkdirAll` per leaf directory of the entire tree, sequential, per run).
- An incremental sync only confirms the directories of the changed files.

### dir-mode decision (the issue left this open)

Kept the documented semantics: with `dir-mode` set, the **full** plan directory list is still used, so every directory the run "creates or touches" gets its chmod, exactly as `action.yml` and `docs/configuration.md` describe. The fast path applies only when `dir-mode` is unset (the default), so no user-visible behavior changes for dir-mode users. Documented in `docs/strategies.md`.

### Refactor

`buildPlan`'s inline ancestor-set computation moved into a reusable `dirsForFiles` helper; `executeSync` uses it on the upload subset.

## Test-server fix (surfaced by the new tests, latent before)

pkg/sftp only serves `posix-rename` when the outermost `FileCmder` implements `PosixRenameFileCmder`; otherwise it silently downgrades to plain `Rename`, which fails when the target exists. Our test wrappers (`setstatRecorder`, `opCounter`, `faultySetstat`) didn't implement it, so any wrapped-server test that overwrites a file (e.g. a second sync rewriting the manifest) failed with "file already exists". Added a `posixRenamePassthrough` helper + methods on all wrappers, and a note in CLAUDE.md so future wrappers don't trip over this.

## Tests

- `TestSyncNoOpIssuesNoDirRoundTrips`: second sync with no changes issues 0 Mkdir + 0 Stat.
- `TestSyncPartialChangeTouchesOnlyChangedDirs`: one changed file confirms exactly one leaf dir.
- `TestSyncDirModeStillCoversWholePlan`: no-op sync with `dir-mode` still requests chmod on every plan directory.

`go test ./...` passes locally. `-race` could not run locally (no cgo toolchain on this machine); relying on CI for the race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)