### PR TITLE
feat(sync): persist a merged manifest when a run fails partway

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -65,6 +65,9 @@ Notes:
 - The manifest trusts itself: a file changed *on the server* out of band is not
   re-detected until its local content changes. Run `clean` once to reset.
 - Directories left empty by deletions are pruned automatically.
+- A run that fails partway still records what it actually changed in the
+  manifest (best effort), so a retried deploy resumes where it left off
+  instead of re-uploading files that already made it.
 - Local files are hashed in parallel through a worker pool bounded by
   `concurrency`, so planning a large tree uses the available runner CPU.
 - Remote directories are only created (or confirmed) for files actually being

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -77,10 +77,10 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 		}
 	}
 
-	var toDelete []string
+	var toDelete []string // paths relative to base, ascending
 	for rel := range old.Files {
 		if _, ok := local[rel]; !ok {
-			toDelete = append(toDelete, path.Join(base, rel))
+			toDelete = append(toDelete, rel)
 		}
 	}
 	sort.Strings(toDelete)
@@ -110,22 +110,30 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 	}
 	// skip-unchanged is always off here: sync already decided what changed
 	// from the manifest hashes, which is strictly more precise.
-	if err := uploadFiles(ctx, cfg, sess, upload, dirs, stats, verb, watch, false, log); err != nil {
+	completed, err := uploadFiles(ctx, cfg, sess, upload, dirs, stats, verb, watch, false, log)
+
+	// A reconnect during the uploads leaves the snapshot above dead; refresh
+	// it before anything else touches the server, so the recovery manifest
+	// below (and the deletions after it) use the live client.
+	client, _ = sess.current()
+
+	if err != nil {
+		writeRecoveryManifest(cfg, client, base, mergedManifest(old, upload, completed, nil), log)
 		return err
 	}
 
-	// A reconnect during the uploads leaves the snapshot above dead; refresh
-	// it so deletions and the manifest write use the live client.
-	client, _ = sess.current()
-
-	for _, full := range toDelete {
+	var deleted []string // relative paths actually removed, for the recovery manifest
+	for _, rel := range toDelete {
+		full := path.Join(base, rel)
 		log.Infof("%sdelete %s", verb, full)
 		if !cfg.DryRun {
 			if err := client.Remove(full); err != nil && !errors.Is(err, os.ErrNotExist) {
+				writeRecoveryManifest(cfg, client, base, mergedManifest(old, upload, completed, deleted), log)
 				return fmt.Errorf("deleting %q: %w", full, err)
 			}
 		}
 		stats.FilesDeleted++
+		deleted = append(deleted, rel)
 	}
 	stats.FilesSkipped += len(p.files) - len(upload)
 
@@ -133,11 +141,50 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 		return nil
 	}
 
-	pruneEmptyDirs(client, base, toDelete)
+	deletedFull := make([]string, len(deleted))
+	for i, rel := range deleted {
+		deletedFull[i] = path.Join(base, rel)
+	}
+	pruneEmptyDirs(client, base, deletedFull)
 	if err := writeManifest(client, base, manifest{Version: manifestVersion, Files: local}); err != nil {
 		return fmt.Errorf("writing sync manifest in %q: %w", base, err)
 	}
 	return nil
+}
+
+// mergedManifest builds the manifest a partially failed run leaves behind:
+// files that did upload get their new entry, files that were actually deleted
+// drop out, and everything else keeps its old entry, so the manifest keeps
+// matching what is really on the server.
+func mergedManifest(old manifest, upload []fileItem, completed []bool, deleted []string) manifest {
+	files := make(map[string]manifestEntry, len(old.Files))
+	for rel, e := range old.Files {
+		files[rel] = e
+	}
+	for i, f := range upload {
+		if completed[i] {
+			files[f.rel] = manifestEntry{Hash: f.hash, Size: f.size, MTime: f.mtime}
+		}
+	}
+	for _, rel := range deleted {
+		delete(files, rel)
+	}
+	return manifest{Version: manifestVersion, Files: files}
+}
+
+// writeRecoveryManifest best-effort persists the merged manifest of a failing
+// run, so a retry resumes from the files that did make it instead of
+// re-uploading them. The run is already failing; a manifest write error here
+// is logged, not returned.
+func writeRecoveryManifest(cfg *config.Config, client *sftp.Client, base string, m manifest, log Logger) {
+	if cfg.DryRun {
+		return
+	}
+	if err := writeManifest(client, base, m); err != nil {
+		log.Warningf("could not record partial progress in the sync manifest in %s (a retry will re-upload this run's completed files): %v", base, err)
+		return
+	}
+	log.Infof("recorded partial progress in the sync manifest in %s: a retry will resume from there", base)
 }
 
 // readManifest loads the remote manifest. A missing manifest means a first

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -409,6 +409,152 @@ func mustOpen(t *testing.T, client *sftp.Client, path string) *sftp.File {
 	return f
 }
 
+// readRemoteManifest fetches and decodes the manifest the server currently
+// holds for /www.
+func readRemoteManifest(t *testing.T, srv *testServer) manifest {
+	t.Helper()
+	data, err := io.ReadAll(mustOpen(t, srv.verifyClient(t), "/www/"+manifestName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	return m
+}
+
+// A sync that fails partway through its uploads must persist a recovery
+// manifest recording the files that did upload, so the next run resumes
+// instead of re-uploading them.
+func TestSyncPartialUploadFailureWritesRecoveryManifest(t *testing.T) {
+	fault := &faultyPathCmd{method: "PosixRename", path: "/www/b.txt"}
+	srv := startTestServer(t, withFaultyPath(fault))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1", "b.txt": "1"})
+
+	cfg := syncConfig(srv, local)
+	// One worker makes the order deterministic: a.txt completes, b.txt fails.
+	cfg.Concurrency = 1
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTree(t, local, map[string]string{"a.txt": "2", "b.txt": "2"})
+	fault.enabled.Store(true)
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "b.txt") {
+		t.Fatalf("expected the b.txt upload to fail, got %v", err)
+	}
+	if stats.FilesUploaded != 1 {
+		t.Fatalf("partial run uploads: got %d, want 1 (a.txt)", stats.FilesUploaded)
+	}
+
+	hashNew, err := hashFile(filepath.Join(local, "a.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := readRemoteManifest(t, srv)
+	if got := m.Files["a.txt"].Hash; got != hashNew {
+		t.Errorf("recovery manifest a.txt hash = %q, want the new upload's %q", got, hashNew)
+	}
+	if got := m.Files["b.txt"].Hash; got == "" || got == m.Files["a.txt"].Hash {
+		t.Errorf("recovery manifest b.txt entry should keep its old hash, got %q", got)
+	}
+
+	// The fault clears; the retry must resume: only b.txt is re-uploaded.
+	fault.enabled.Store(false)
+	stats, err = Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 1 || stats.FilesSkipped != 1 {
+		t.Fatalf("resume run: up=%d skip=%d, want 1/1 (only b.txt re-uploaded)", stats.FilesUploaded, stats.FilesSkipped)
+	}
+	if got := readRemote(t, srv, "/www/b.txt"); got != "2" {
+		t.Errorf("b.txt not updated on resume: %q", got)
+	}
+}
+
+// A sync that fails partway through its deletions must persist a recovery
+// manifest without the files that were actually removed, so the next run does
+// not count phantom deletions.
+func TestSyncPartialDeleteFailureWritesRecoveryManifest(t *testing.T) {
+	fault := &faultyPathCmd{method: "Remove", path: "/www/c.txt"}
+	srv := startTestServer(t, withFaultyPath(fault))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "a", "b.txt": "b", "c.txt": "c"})
+
+	cfg := syncConfig(srv, local)
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	// b.txt and c.txt disappear locally; deletions run in sorted order, so
+	// b.txt is removed first, then the c.txt removal fails.
+	for _, name := range []string{"b.txt", "c.txt"} {
+		if err := os.Remove(filepath.Join(local, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fault.enabled.Store(true)
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "c.txt") {
+		t.Fatalf("expected the c.txt deletion to fail, got %v", err)
+	}
+	if stats.FilesDeleted != 1 {
+		t.Fatalf("partial run deletions: got %d, want 1 (b.txt)", stats.FilesDeleted)
+	}
+
+	m := readRemoteManifest(t, srv)
+	if _, ok := m.Files["b.txt"]; ok {
+		t.Error("recovery manifest still lists deleted b.txt")
+	}
+	if _, ok := m.Files["c.txt"]; !ok {
+		t.Error("recovery manifest lost c.txt, which is still on the server")
+	}
+
+	fault.enabled.Store(false)
+	stats, err = Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesDeleted != 1 {
+		t.Errorf("resume run deletions: got %d, want 1 (only c.txt)", stats.FilesDeleted)
+	}
+	if remoteExists(t, srv, "/www/c.txt") {
+		t.Error("c.txt still on the server after the resume run")
+	}
+}
+
+// When even the recovery manifest cannot be written (here: every rename
+// fails), the run must fail with the original upload error and only warn
+// about the manifest.
+func TestSyncRecoveryManifestWriteFailureIsNonFatal(t *testing.T) {
+	srv := startTestServer(t, withFailRename())
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1"})
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	_, err := Run(context.Background(), syncConfig(srv, local), log)
+	if err == nil || !strings.Contains(err.Error(), "a.txt") {
+		t.Fatalf("expected the upload failure to surface, got %v", err)
+	}
+	found := false
+	for _, w := range log.warnings {
+		if strings.Contains(w, "partial progress") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about the unwritable recovery manifest, got %v", log.warnings)
+	}
+}
+
 func TestSyncDryRunChangesNothing(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -276,6 +276,49 @@ func (f *faultySetstat) PosixRename(r *sftp.Request) error {
 	return posixRenamePassthrough(f.inner, r)
 }
 
+// faultyPathCmd fails one SFTP method on one exact path while enabled,
+// delegating everything else to the real in-memory handler. Tests toggle
+// enabled between runs to simulate a fault that later clears.
+type faultyPathCmd struct {
+	inner   sftp.FileCmder
+	method  string // e.g. "PosixRename", "Remove"
+	path    string // the request Target for renames, the Filepath otherwise
+	enabled atomic.Bool
+}
+
+// withFaultyPath installs f as the FileCmd handler (wrapping the real one).
+func withFaultyPath(f *faultyPathCmd) serverOption {
+	return func(s *testServer) {
+		f.inner = s.handlers.FileCmd
+		s.handlers.FileCmd = f
+	}
+}
+
+func (f *faultyPathCmd) match(method, path string) bool {
+	return f.enabled.Load() && method == f.method && path == f.path
+}
+
+func (f *faultyPathCmd) Filecmd(r *sftp.Request) error {
+	p := r.Filepath
+	if r.Method == "Rename" || r.Method == "PosixRename" {
+		p = r.Target
+	}
+	if f.match(r.Method, p) {
+		return fmt.Errorf("injected %s failure on %s", f.method, f.path)
+	}
+	return f.inner.Filecmd(r)
+}
+
+// PosixRename must be forwarded explicitly: pkg/sftp only serves posix-rename
+// when the outermost FileCmder implements PosixRenameFileCmder, and otherwise
+// downgrades it to plain Rename, which fails whenever the target exists.
+func (f *faultyPathCmd) PosixRename(r *sftp.Request) error {
+	if f.match("PosixRename", r.Target) {
+		return fmt.Errorf("injected %s failure on %s", f.method, f.path)
+	}
+	return posixRenamePassthrough(f.inner, r)
+}
+
 // dropConn closes the connection once it has read limit bytes, simulating a
 // network drop partway through a transfer.
 type dropConn struct {

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -344,7 +344,8 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 	}
 
 	skipUnchanged := cfg.SkipUnchanged && p.strategy == config.StrategyOverlay
-	return uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, stats, verb, watch, skipUnchanged, log)
+	_, err := uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, stats, verb, watch, skipUnchanged, log)
+	return err
 }
 
 // uploadFiles creates the needed remote directories and uploads files in
@@ -352,19 +353,26 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 // skipUnchanged set, a file whose remote counterpart already exists with the
 // same size is skipped instead of uploaded; the stat happens inside the
 // parallel workers so its latency is amortized by the concurrency.
-func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, stats *Stats, verb string, watch *stallWatchdog, skipUnchanged bool, log Logger) error {
+//
+// It returns which files completed, indexed like files, so that on a partial
+// failure the caller knows what actually made it to the server (the sync
+// strategy uses this to persist a recovery manifest).
+func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, stats *Stats, verb string, watch *stallWatchdog, skipUnchanged bool, log Logger) ([]bool, error) {
+	// Declared before the first failure point: callers index the returned
+	// slice by file, so it must be sized even when nothing was uploaded.
+	completed := make([]bool, len(files))
+	skipped := make([]bool, len(files))
+
 	if !cfg.DryRun {
 		client, _ := sess.current()
 		if err := createRemoteDirs(client, dirs, cfg.DirMode, log); err != nil {
-			return err
+			return completed, err
 		}
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(cfg.Concurrency)
 	results := make([]int64, len(files))
-	completed := make([]bool, len(files))
-	skipped := make([]bool, len(files))
 	// modeWarned is only armed when file-mode is an explicit override: a
 	// mirrored local mode (the default) stays silent on failure, as before.
 	var modeWarned *atomic.Bool
@@ -418,7 +426,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 			stats.BytesUploaded += n
 		}
 	}
-	return runErr
+	return completed, runErr
 }
 
 // createRemoteDirs creates every remote directory the plan needs with as few


### PR DESCRIPTION
Fixes #47

## What

When a sync run fails partway (upload error or delete error), it now best-effort writes a **recovery manifest** merging its actual progress into a copy of the old one:

- files that **did** upload get their new hash/size/mtime entry,
- deletions that were **actually performed** drop out,
- everything else keeps its old entry.

A retried deploy then resumes where the failed run left off instead of re-uploading files that already made it. Manifest write failures on this path are logged as a warning, never returned; the run is already failing with the real error. Dry-run behavior is unchanged.

## How

- `uploadFiles` now returns a per-file `completed` slice next to its error (the loop already tracked it for the stats; it's just exposed now). The overlay/clean path ignores it.
- `executeSync` tracks which deletions actually happened, and on either failure path calls `writeRecoveryManifest(mergedManifest(...))`.
- `toDelete` switched from full paths to base-relative paths so the merged manifest and the delete loop share one representation.

## Tests

- `TestSyncPartialUploadFailureWritesRecoveryManifest`: b.txt's rename fails; manifest records a.txt's new hash and keeps b.txt's old one; the retry uploads only b.txt.
- `TestSyncPartialDeleteFailureWritesRecoveryManifest`: c.txt's removal fails after b.txt's succeeded; manifest drops b.txt, keeps c.txt; the retry deletes only c.txt.
- `TestSyncRecoveryManifestWriteFailureIsNonFatal`: every rename fails; the original upload error surfaces and the unwritable recovery manifest only warns.
- New reusable test-server fault `faultyPathCmd` / `withFaultyPath` (fails one method on one path, toggleable between runs), following the existing wrapper pattern.

## Notes for the reviewer

- Touches the same `executeSync` region as #85 (issue #69); whichever merges second needs a trivial rebase.
- `go test ./...` passes locally; `-race` could not run locally (no cgo toolchain on this machine), relying on CI for the race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)