### PR TITLE
feat(overlay): opt-in skip-unchanged skips same-size remote files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,8 @@ Look at how existing inputs are wired before adding a new one:
    (`internal/config/config_test.go`) guards against reintroducing this.
 2. **Run-wide behavior** (connection, transfer mechanics): `retries`,
    `concurrency`, `sftp-request-concurrency`, `timeout`, `stall-timeout`,
-   `dry-run`, `sync-fast-path`, `dir-mode`, `file-mode`. These always come
-   from action
+   `dry-run`, `sync-fast-path`, `skip-unchanged`, `dir-mode`, `file-mode`.
+   These always come from action
    inputs, regardless of `config-file`, and have **no** per-target override
    and **no** YAML config-file equivalent. Don't add one unless a concrete
    use case needs per-target granularity; it's easy to add later, hard to

--- a/action.yml
+++ b/action.yml
@@ -133,6 +133,16 @@ inputs:
       new modification time on every run, so this has no effect there.
     required: false
     default: "false"
+  skip-unchanged:
+    description: >-
+      If "true", the overlay strategy skips uploading a file when the remote
+      file already exists with the same size (one stat per file, performed
+      inside the parallel workers). Cheap but deliberately coarse: an edit
+      that keeps the file size identical is missed; use the sync strategy for
+      exact content-hash comparison. Ignored (with a warning) by the sync and
+      clean strategies.
+    required: false
+    default: "false"
   retries:
     description: >-
       How often a failed file upload is retried (with backoff). Also bounds
@@ -180,7 +190,9 @@ outputs:
     description: Number of remote files deleted by the clean/sync strategy.
     value: ${{ steps.easysftp.outputs.files-deleted }}
   files-skipped:
-    description: Number of unchanged files skipped by the sync strategy.
+    description: >-
+      Number of unchanged files skipped (by the sync strategy, or by overlay
+      with skip-unchanged).
     value: ${{ steps.easysftp.outputs.files-skipped }}
   bytes-uploaded:
     description: Total number of bytes transferred.
@@ -245,6 +257,7 @@ runs:
         EASYSFTP_CONCURRENCY: ${{ inputs.concurrency }}
         EASYSFTP_SFTP_REQUEST_CONCURRENCY: ${{ inputs.sftp-request-concurrency }}
         EASYSFTP_SYNC_FAST_PATH: ${{ inputs.sync-fast-path }}
+        EASYSFTP_SKIP_UNCHANGED: ${{ inputs.skip-unchanged }}
         EASYSFTP_RETRIES: ${{ inputs.retries }}
         EASYSFTP_TIMEOUT: ${{ inputs.timeout }}
         EASYSFTP_STALL_TIMEOUT: ${{ inputs.stall-timeout }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,7 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 | `concurrency` | | `4` | Number of files uploaded in parallel. Also bounds the worker pool that hashes local files for the `sync` strategy. |
 | `sftp-request-concurrency` | | `16` | Advanced. Maximum in-flight SFTP requests *per file*: pipelining within one file's transfer, independent of `concurrency` (which controls how many files transfer at once). The two multiply: with the defaults, a single large file can have up to 16 requests in flight, and up to `concurrency` files transfer at a time. Lower it for a small or resource-constrained server; raise it for more throughput per file on a fast link to a capable server. |
 | `sync-fast-path` | | `false` | For the `sync` strategy, reuse a file's manifest hash instead of re-reading it when size and modification time still match. See [the sync-fast-path trade-off](strategies.md#sync-fast-path-skip-re-hashing-unchanged-files). |
+| `skip-unchanged` | | `false` | For the `overlay` strategy, skip uploading a file when the remote file already exists with the same size (one stat per file). Deliberately coarse but manifest-free; see [the skip-unchanged trade-off](strategies.md#skip-unchanged-skip-same-size-files). Ignored (with a warning) by `sync` and `clean`. |
 | `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). Also bounds how often a connection that drops mid-run is redialed: when an upload fails because the connection died, easySFTP reconnects (up to `retries` times per run) and the per-file retry then runs against the fresh connection. Completed files stay completed. `0` disables both. |
 | `dir-mode` | | - | Octal permission (e.g. `755`) applied to every remote directory the run creates or touches, instead of whatever the server's umask produces. |
 | `file-mode` | | - | Octal permission (e.g. `644`) applied to every uploaded file, instead of mirroring the local file's permission bits. |
@@ -82,7 +83,7 @@ release.
 |---|---|
 | `files-uploaded` | Number of uploaded files (planned files in dry-run mode). |
 | `files-deleted` | Number of remote files removed by the `clean`/`sync` strategy. |
-| `files-skipped` | Number of unchanged files skipped by the `sync` strategy. |
+| `files-skipped` | Number of unchanged files skipped (by the `sync` strategy, or by `overlay` with `skip-unchanged`). |
 | `bytes-uploaded` | Total bytes transferred (planned bytes in dry-run mode). |
 | `duration-ms` | Total runtime in milliseconds. |
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -23,6 +23,27 @@ two planned transfers never share a temp name) and renamed over the target
 only once the transfer fully succeeded. A broken connection never leaves a
 half-written file where the live one was.
 
+### `skip-unchanged`: skip same-size files
+
+By default, `overlay` re-uploads **every** file on every deploy. Setting
+`skip-unchanged: true` stats each remote file first and skips the upload when
+the remote file already exists with the same size, which turns a re-deploy of
+a mostly-unchanged tree from "transfer everything" into "one cheap stat per
+unchanged file". Skipped files count into the `files-skipped` output and are
+left completely untouched (no permission change either).
+
+**The trade-off, precisely:** the comparison is size-only. An edit that keeps
+the file size identical is invisible to it and will *not* be uploaded. Remote
+modification times are not compared; without controlling them at upload time
+they mean nothing. If you need exact change detection, use the `sync`
+strategy, whose manifest compares content hashes; `skip-unchanged` is for
+targets where you want cheap incremental behavior *without* easySFTP writing
+any state (like the sync manifest) to the server.
+
+`skip-unchanged` only applies to `overlay` targets. `sync` already skips
+unchanged files exactly, and `clean` wipes the target first, so both ignore
+the input (with a warning).
+
 ## `sync`
 
 Uploads new and changed files, and deletes remote files that a previous sync

--- a/internal/actionmeta/actionmeta_test.go
+++ b/internal/actionmeta/actionmeta_test.go
@@ -63,8 +63,8 @@ func TestActionMetadata(t *testing.T) {
 		"build-mode", "server", "port", "username", "password", "private-key",
 		"passphrase", "host-key-fingerprint", "known-hosts", "uploads", "config-file", "strategy",
 		"ignore", "ignore-from", "max-deletes", "delete", "dry-run", "concurrency",
-		"sftp-request-concurrency", "sync-fast-path", "retries", "timeout",
-		"stall-timeout", "dir-mode", "file-mode",
+		"sftp-request-concurrency", "sync-fast-path", "skip-unchanged", "retries",
+		"timeout", "stall-timeout", "dir-mode", "file-mode",
 	}
 	for _, name := range wantInputs {
 		if _, ok := action.Inputs[name]; !ok {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,11 @@ type Config struct {
 	// no progress for this long, instead of hanging until the job-level
 	// timeout. 0 (the default) disables the check.
 	StallTimeout time.Duration
+
+	// SkipUnchanged makes the overlay strategy skip a file whose remote
+	// counterpart already exists with the same size (one stat per file).
+	// Deliberately coarse; sync's content hashes are the exact alternative.
+	SkipUnchanged bool
 }
 
 const envPrefix = "EASYSFTP_"
@@ -131,6 +136,9 @@ func Load() (*Config, error) {
 	}
 	if cfg.SyncFastPath, err = parseBool(get("SYNC_FAST_PATH"), false); err != nil {
 		return nil, fmt.Errorf("invalid sync-fast-path: %w", err)
+	}
+	if cfg.SkipUnchanged, err = parseBool(get("SKIP_UNCHANGED"), false); err != nil {
+		return nil, fmt.Errorf("invalid skip-unchanged: %w", err)
 	}
 	if cfg.DirMode, err = parseMode(get("DIR_MODE"), "dir-mode"); err != nil {
 		return nil, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,7 +48,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("EASYSFTP_UPLOADS", "./dist/ => /www/")
 	for _, name := range []string{"PORT", "PRIVATE_KEY", "PASSPHRASE", "HOST_KEY_FINGERPRINT", "KNOWN_HOSTS",
 		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "SFTP_REQUEST_CONCURRENCY", "RETRIES", "TIMEOUT", "STALL_TIMEOUT",
-		"SYNC_FAST_PATH", "CONFIG_FILE", "STRATEGY", "MAX_DELETES", "DIR_MODE", "FILE_MODE"} {
+		"SYNC_FAST_PATH", "SKIP_UNCHANGED", "CONFIG_FILE", "STRATEGY", "MAX_DELETES", "DIR_MODE", "FILE_MODE"} {
 		t.Setenv("EASYSFTP_"+name, "")
 	}
 }
@@ -59,7 +59,7 @@ func TestLoadDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Retries != 2 || cfg.DryRun || cfg.SyncFastPath {
+	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Retries != 2 || cfg.DryRun || cfg.SyncFastPath || cfg.SkipUnchanged {
 		t.Errorf("unexpected defaults: %+v", cfg)
 	}
 	if cfg.Timeout.Seconds() != 30 {
@@ -80,6 +80,7 @@ func TestLoadValidation(t *testing.T) {
 		{"bad port", map[string]string{"EASYSFTP_PORT": "99999"}, "'port' must be between"},
 		{"bad bool", map[string]string{"EASYSFTP_DRY_RUN": "yes-please"}, "invalid dry-run"},
 		{"bad sync-fast-path bool", map[string]string{"EASYSFTP_SYNC_FAST_PATH": "yes-please"}, "invalid sync-fast-path"},
+		{"bad skip-unchanged bool", map[string]string{"EASYSFTP_SKIP_UNCHANGED": "yes-please"}, "invalid skip-unchanged"},
 		{"bad max-deletes", map[string]string{"EASYSFTP_MAX_DELETES": "not-a-number"}, "invalid max-deletes"},
 		{"bad sftp-request-concurrency", map[string]string{"EASYSFTP_SFTP_REQUEST_CONCURRENCY": "not-a-number"}, "invalid sftp-request-concurrency"},
 		{"zero sftp-request-concurrency", map[string]string{"EASYSFTP_SFTP_REQUEST_CONCURRENCY": "0"}, "'sftp-request-concurrency' must be at least 1"},

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -108,7 +108,9 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 	if cfg.DirMode != nil {
 		dirs = p.remoteDirs
 	}
-	if err := uploadFiles(ctx, cfg, sess, upload, dirs, stats, verb, watch, log); err != nil {
+	// skip-unchanged is always off here: sync already decided what changed
+	// from the manifest hashes, which is strictly more precise.
+	if err := uploadFiles(ctx, cfg, sess, upload, dirs, stats, verb, watch, false, log); err != nil {
 		return err
 	}
 

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -38,7 +38,7 @@ type Logger interface {
 type Stats struct {
 	FilesUploaded int
 	FilesDeleted  int
-	FilesSkipped  int // unchanged files skipped by the sync strategy
+	FilesSkipped  int // unchanged files skipped (sync, or overlay with skip-unchanged)
 	BytesUploaded int64
 	Duration      time.Duration
 
@@ -295,6 +295,10 @@ func executePlan(ctx context.Context, cfg *config.Config, sess *session, p plan,
 	log.Group(fmt.Sprintf("%s => %s [%s] (%d local files)", p.pair.Local, p.pair.Remote, p.strategy, len(p.files)))
 	defer log.EndGroup()
 
+	if cfg.SkipUnchanged && p.strategy != config.StrategyOverlay {
+		log.Warningf("skip-unchanged only applies to the overlay strategy; ignoring it for this %s target", p.strategy)
+	}
+
 	if p.strategy == config.StrategySync {
 		return executeSync(ctx, cfg, sess, p, stats, watch, log)
 	}
@@ -339,12 +343,16 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 		}
 	}
 
-	return uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, stats, verb, watch, log)
+	skipUnchanged := cfg.SkipUnchanged && p.strategy == config.StrategyOverlay
+	return uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, stats, verb, watch, skipUnchanged, log)
 }
 
 // uploadFiles creates the needed remote directories and uploads files in
-// parallel (or, in dry-run mode, only logs what it would do).
-func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, stats *Stats, verb string, watch *stallWatchdog, log Logger) error {
+// parallel (or, in dry-run mode, only logs what it would do). With
+// skipUnchanged set, a file whose remote counterpart already exists with the
+// same size is skipped instead of uploaded; the stat happens inside the
+// parallel workers so its latency is amortized by the concurrency.
+func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, stats *Stats, verb string, watch *stallWatchdog, skipUnchanged bool, log Logger) error {
 	if !cfg.DryRun {
 		client, _ := sess.current()
 		if err := createRemoteDirs(client, dirs, cfg.DirMode, log); err != nil {
@@ -356,6 +364,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 	g.SetLimit(cfg.Concurrency)
 	results := make([]int64, len(files))
 	completed := make([]bool, len(files))
+	skipped := make([]bool, len(files))
 	// modeWarned is only armed when file-mode is an explicit override: a
 	// mirrored local mode (the default) stays silent on failure, as before.
 	var modeWarned *atomic.Bool
@@ -367,6 +376,16 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 		g.Go(func() error {
 			if err := ctx.Err(); err != nil {
 				return err
+			}
+			// The stat is read-only, so it also runs in dry-run mode: the
+			// preview then reports the same skips the real run would.
+			if skipUnchanged {
+				client, _ := sess.current()
+				if fi, err := client.Stat(f.remotePath); err == nil && fi.Mode().IsRegular() && fi.Size() == f.size {
+					log.Infof("%sskip %s (remote file has the same size)", verb, f.remotePath)
+					skipped[i] = true
+					return nil
+				}
 			}
 			log.Infof("%supload %s => %s (%s)", verb, f.localPath, f.remotePath, humanSize(f.size))
 			if cfg.DryRun {
@@ -391,7 +410,10 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 	}
 	runErr := g.Wait()
 	for i, n := range results {
-		if completed[i] {
+		switch {
+		case skipped[i]:
+			stats.FilesSkipped++
+		case completed[i]:
 			stats.FilesUploaded++
 			stats.BytesUploaded += n
 		}

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -694,5 +695,115 @@ func TestSendKeepalivesPingsUntilCanceled(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("sendKeepalives did not stop after context cancellation")
+	}
+}
+
+// writeRemoteFiles pre-creates files on the server, so tests can shape the
+// remote side an overlay run will encounter.
+func writeRemoteFiles(t *testing.T, srv *testServer, files map[string]string) {
+	t.Helper()
+	client := srv.verifyClient(t)
+	for name, content := range files {
+		if err := client.MkdirAll(path.Dir(name)); err != nil {
+			t.Fatal(err)
+		}
+		f, err := client.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+	}
+}
+
+// With skip-unchanged, overlay skips a file whose remote counterpart has the
+// same size, uploads size mismatches and missing files. The same-size skip
+// deliberately ignores content: that is the documented size-only trade-off.
+func TestOverlaySkipUnchanged(t *testing.T) {
+	srv := startTestServer(t)
+	writeRemoteFiles(t, srv, map[string]string{
+		"/www/same.txt": "AAA",
+		"/www/diff.txt": "AAAA",
+	})
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"same.txt": "BBB", // same size as remote: skipped
+		"diff.txt": "BB",  // different size: uploaded
+		"new.txt":  "n",   // missing remotely: uploaded
+	})
+
+	cfg := baseConfig(srv)
+	cfg.SkipUnchanged = true
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 2 || stats.FilesSkipped != 1 {
+		t.Fatalf("up=%d skip=%d, want 2/1", stats.FilesUploaded, stats.FilesSkipped)
+	}
+	if got := readRemote(t, srv, "/www/same.txt"); got != "AAA" {
+		t.Errorf("same-size file was touched: %q", got)
+	}
+	if got := readRemote(t, srv, "/www/diff.txt"); got != "BB" {
+		t.Errorf("size-changed file not uploaded: %q", got)
+	}
+	if got := readRemote(t, srv, "/www/new.txt"); got != "n" {
+		t.Errorf("new file not uploaded: %q", got)
+	}
+}
+
+// The skip stat is read-only, so dry-run performs it too and previews the
+// same skips the real run would, without changing anything.
+func TestOverlaySkipUnchangedDryRun(t *testing.T) {
+	srv := startTestServer(t)
+	writeRemoteFiles(t, srv, map[string]string{"/www/same.txt": "AAA"})
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"same.txt": "BBB", "new.txt": "n"})
+
+	cfg := baseConfig(srv)
+	cfg.SkipUnchanged = true
+	cfg.DryRun = true
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 1 || stats.FilesSkipped != 1 {
+		t.Fatalf("dry-run up=%d skip=%d, want 1/1", stats.FilesUploaded, stats.FilesSkipped)
+	}
+	if remoteExists(t, srv, "/www/new.txt") {
+		t.Error("dry-run must not upload anything")
+	}
+}
+
+// skip-unchanged only applies to overlay; other strategies warn and ignore it.
+func TestSkipUnchangedWarnsOnNonOverlay(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1"})
+
+	cfg := baseConfig(srv)
+	cfg.SkipUnchanged = true
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategySync}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, w := range log.warnings {
+		if strings.Contains(w, "skip-unchanged") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning that skip-unchanged is ignored for sync, got %v", log.warnings)
 	}
 }


### PR DESCRIPTION
Fixes #24

## What

New `skip-unchanged` input (default `false`). For `overlay` targets, each file is stat'd on the server first; when a regular remote file with the same size exists, the upload is skipped. Skips count into the existing `files-skipped` output and the job summary, and skipped files are left completely untouched (no chmod either).

## Decisions the issue left open

- **Non-overlay strategies**: ignore + warn (once per target), instead of erroring. Rationale: with a config file, strategies are per-target; a hard error would make `skip-unchanged` unusable in mixed overlay/sync deployments even though it is a run-wide input. Documented in `action.yml`, `docs/configuration.md`, and `docs/strategies.md`.
- **mtime comparison**: not included; remote mtimes are meaningless until preserve-times (#19) exists. The issue text anticipated this.
- **Dry-run**: the stat is read-only, so it also runs in dry-run mode; the preview reports the same skips the real run would.

## Placement

The stat happens inside the existing parallel upload workers (`uploadFiles`), so its latency is amortized by `concurrency`, as the issue suggested. `sync` passes `skipUnchanged=false` since its hash comparison already handles unchanged files exactly.

## Docs

- `docs/strategies.md`: new "skip-unchanged: skip same-size files" section under overlay, with the size-only trade-off spelled out and `sync` pointed to as the exact alternative (mirrors the existing `sync-fast-path` section's structure).
- `docs/configuration.md`: behavior-table row + updated `files-skipped` output description.
- CLAUDE.md: added to the run-wide (category 2) input list.

## Tests

- `TestOverlaySkipUnchanged`: same-size skipped (content deliberately differs, pinning the trade-off), size mismatch uploaded, missing remote uploaded.
- `TestOverlaySkipUnchangedDryRun`: dry-run previews the same skips, uploads nothing.
- `TestSkipUnchangedWarnsOnNonOverlay`: sync target warns and ignores.
- Config parsing/default/validation tests + actionmeta drift check extended.

`go test ./...` passes locally; `-race` could not run locally (no cgo toolchain), relying on CI for the race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)