### PR TITLE
feat: accept OpenSSH known_hosts entries via a new known-hosts input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,15 @@ inputs:
       not verified. Obtain the fingerprints with:
       ssh-keyscan <server> | ssh-keygen -lf -
     required: false
+  known-hosts:
+    description: >-
+      Expected host key(s) in OpenSSH known_hosts format, e.g. the verbatim
+      output of "ssh-keyscan <server>", or the server's lines from your own
+      ~/.ssh/known_hosts. An alternative to host-key-fingerprint (no
+      ssh-keygen conversion step); if both are set, a key matching either is
+      accepted. Hashed entries and "[host]:port" entries for non-standard
+      ports are supported.
+    required: false
   uploads:
     description: >-
       One "local => remote" mapping per line, e.g. "./dist/ => /var/www/html/".
@@ -208,6 +217,7 @@ runs:
         EASYSFTP_PRIVATE_KEY: ${{ inputs.private-key }}
         EASYSFTP_PASSPHRASE: ${{ inputs.passphrase }}
         EASYSFTP_HOST_KEY_FINGERPRINT: ${{ inputs.host-key-fingerprint }}
+        EASYSFTP_KNOWN_HOSTS: ${{ inputs.known-hosts }}
         EASYSFTP_UPLOADS: ${{ inputs.uploads }}
         EASYSFTP_CONFIG_FILE: ${{ inputs.config-file }}
         EASYSFTP_STRATEGY: ${{ inputs.strategy }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 | `private-key` | ¹ | - | SSH private key (OpenSSH/PEM format). **Use a secret.** |
 | `passphrase` | | - | Passphrase of the private key, if encrypted. |
 | `host-key-fingerprint` | | - | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). **Strongly recommended**, see [Security](security.md). |
+| `known-hosts` | | - | Expected host key(s) in OpenSSH `known_hosts` format (verbatim `ssh-keyscan` output). Alternative to `host-key-fingerprint`; a key matching either is accepted. Hashed entries and `[host]:port` lines are supported. See [Security](security.md). |
 | `timeout` | | `30` | Connection timeout in seconds. `0` disables the timeout entirely. |
 
 ¹ At least one of `password` / `private-key` is required. If both are set, the key is tried first.

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,9 +5,30 @@ How to run easySFTP safely. See also the project's
 
 ## Pin the host key (strongly recommended)
 
-Without `host-key-fingerprint`, easySFTP prints a warning and accepts **any**
-host key. Convenient for a first test, but vulnerable to man-in-the-middle
-attacks. Pin your server's keys once:
+Without `host-key-fingerprint` or `known-hosts`, easySFTP prints a warning
+and accepts **any** host key. Convenient for a first test, but vulnerable to
+man-in-the-middle attacks. Pin your server's keys once, in whichever format
+you already have:
+
+**Option A: `known-hosts`** takes raw OpenSSH `known_hosts` lines, exactly
+what `ssh-keyscan` prints (or the server's lines from your own
+`~/.ssh/known_hosts`), no conversion step:
+
+```console
+$ ssh-keyscan sftp.example.com
+sftp.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...
+sftp.example.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT...
+sftp.example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQ...
+```
+
+```yaml
+known-hosts: ${{ secrets.SFTP_KNOWN_HOSTS }}
+```
+
+Hashed entries (`|1|...`) and `[host]:port` entries for non-standard ports
+(what `ssh-keyscan -p 2222` prints) work too.
+
+**Option B: `host-key-fingerprint`** takes SHA256 fingerprints, one per line:
 
 ```console
 $ ssh-keyscan sftp.example.com | ssh-keygen -lf -
@@ -16,17 +37,15 @@ $ ssh-keyscan sftp.example.com | ssh-keygen -lf -
 3072 SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s sftp.example.com (RSA)
 ```
 
-Store the `SHA256:...` values as a secret (one per line) and pass them as
-`host-key-fingerprint`. The connection is accepted if the server presents a
-key matching **any** of them, so you can simply pin all of your server's keys:
-
 ```yaml
 host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINTS }}
 ```
 
-If the server's keys ever change unexpectedly, the deploy fails instead of
-talking to an impostor. When you migrate servers, update the secret with the
-new fingerprints.
+Either way, the connection is accepted if the server presents a key matching
+**any** pinned entry (across both inputs, if you set both), so you can simply
+pin all of your server's keys. If the server's keys ever change unexpectedly,
+the deploy fails instead of talking to an impostor. When you migrate servers,
+update the secret with the new keys.
 
 ## Credentials
 

--- a/internal/actionmeta/actionmeta_test.go
+++ b/internal/actionmeta/actionmeta_test.go
@@ -61,7 +61,7 @@ func TestActionMetadata(t *testing.T) {
 
 	wantInputs := []string{
 		"build-mode", "server", "port", "username", "password", "private-key",
-		"passphrase", "host-key-fingerprint", "uploads", "config-file", "strategy",
+		"passphrase", "host-key-fingerprint", "known-hosts", "uploads", "config-file", "strategy",
 		"ignore", "ignore-from", "max-deletes", "delete", "dry-run", "concurrency",
 		"sftp-request-concurrency", "sync-fast-path", "retries", "timeout",
 		"dir-mode", "file-mode",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,10 @@ type Config struct {
 	PrivateKey          string
 	Passphrase          string
 	HostKeyFingerprints []string
+	// KnownHosts holds raw OpenSSH known_hosts lines (e.g. ssh-keyscan
+	// output), an alternative to SHA256 fingerprints. When both are set, a
+	// key matching either is accepted.
+	KnownHosts string
 
 	Uploads     []UploadPair
 	IgnoreLines []string
@@ -94,6 +98,7 @@ func Load() (*Config, error) {
 		PrivateKey:          os.Getenv(envPrefix + "PRIVATE_KEY"),
 		Passphrase:          os.Getenv(envPrefix + "PASSPHRASE"),
 		HostKeyFingerprints: splitLines(os.Getenv(envPrefix + "HOST_KEY_FINGERPRINT")),
+		KnownHosts:          strings.TrimSpace(os.Getenv(envPrefix + "KNOWN_HOSTS")),
 	}
 
 	var err error

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,7 +46,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("EASYSFTP_USERNAME", "deploy")
 	t.Setenv("EASYSFTP_PASSWORD", "hunter2")
 	t.Setenv("EASYSFTP_UPLOADS", "./dist/ => /www/")
-	for _, name := range []string{"PORT", "PRIVATE_KEY", "PASSPHRASE", "HOST_KEY_FINGERPRINT",
+	for _, name := range []string{"PORT", "PRIVATE_KEY", "PASSPHRASE", "HOST_KEY_FINGERPRINT", "KNOWN_HOSTS",
 		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "SFTP_REQUEST_CONCURRENCY", "RETRIES", "TIMEOUT",
 		"SYNC_FAST_PATH", "CONFIG_FILE", "STRATEGY", "MAX_DELETES", "DIR_MODE", "FILE_MODE"} {
 		t.Setenv("EASYSFTP_"+name, "")

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -23,6 +23,7 @@ type testServer struct {
 	Host          string
 	Port          int
 	HostKeySHA256 string
+	HostPubKey    ssh.PublicKey
 	ClientKeyPEM  string
 	handlers      sftp.Handlers
 	sshConfig     *ssh.ServerConfig
@@ -180,6 +181,7 @@ func startTestServer(t *testing.T, opts ...serverOption) *testServer {
 	srv := &testServer{
 		Addr:          listener.Addr().String(),
 		HostKeySHA256: ssh.FingerprintSHA256(hostSigner.PublicKey()),
+		HostPubKey:    hostSigner.PublicKey(),
 		ClientKeyPEM:  string(pem.EncodeToMemory(clientPEM)),
 		handlers:      sftp.InMemHandler(),
 		sshConfig:     sshConfig,

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/sftp"
 	ignore "github.com/sabhiram/go-gitignore"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/eiserv/easySFTP/internal/config"
@@ -732,17 +733,28 @@ func authMethods(cfg *config.Config) ([]ssh.AuthMethod, error) {
 }
 
 func hostKeyCallback(cfg *config.Config, log Logger) (ssh.HostKeyCallback, error) {
-	if len(cfg.HostKeyFingerprints) == 0 {
-		log.Warningf("no host-key-fingerprint configured; the server's identity will NOT be verified. " +
-			"Run 'ssh-keyscan <server> | ssh-keygen -lf -' and set the host-key-fingerprint input to pin it.")
+	want := cfg.HostKeyFingerprints
+	if len(want) == 0 && cfg.KnownHosts == "" {
+		log.Warningf("no host-key-fingerprint or known-hosts configured; the server's identity will NOT be verified. " +
+			"Run 'ssh-keyscan <server>' and set the known-hosts input (or convert with 'ssh-keygen -lf -' " +
+			"and set host-key-fingerprint) to pin it.")
 		return ssh.InsecureIgnoreHostKey(), nil
 	}
-	want := cfg.HostKeyFingerprints
 	for _, fp := range want {
 		if !strings.HasPrefix(fp, "SHA256:") {
 			return nil, fmt.Errorf("host-key-fingerprint must be a SHA256 fingerprint like 'SHA256:...', got %q", fp)
 		}
 	}
+	var khCallback ssh.HostKeyCallback
+	if cfg.KnownHosts != "" {
+		var err error
+		if khCallback, err = knownHostsCallback(cfg.KnownHosts); err != nil {
+			return nil, err
+		}
+	}
+	// A key matching either input is accepted, mirroring how multiple
+	// fingerprints already OR together: users can pin every key their server
+	// presents, in whichever format they have at hand.
 	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		got := ssh.FingerprintSHA256(key)
 		for _, fp := range want {
@@ -750,8 +762,39 @@ func hostKeyCallback(cfg *config.Config, log Logger) (ssh.HostKeyCallback, error
 				return nil
 			}
 		}
-		return fmt.Errorf("host key mismatch for %s: got %s, want one of: %s", hostname, got, strings.Join(want, ", "))
+		if khCallback != nil && khCallback(hostname, remote, key) == nil {
+			return nil
+		}
+		accepted := append([]string{}, want...)
+		if khCallback != nil {
+			accepted = append(accepted, "the known-hosts entries")
+		}
+		return fmt.Errorf("host key mismatch for %s: got %s, want one of: %s", hostname, got, strings.Join(accepted, ", "))
 	}, nil
+}
+
+// knownHostsCallback builds a host key verifier from raw OpenSSH known_hosts
+// lines (e.g. ssh-keyscan output). x/crypto's knownhosts parser only reads
+// files, so the lines are staged in a temp file that is removed again right
+// after parsing.
+func knownHostsCallback(data string) (ssh.HostKeyCallback, error) {
+	f, err := os.CreateTemp("", "easysftp-known-hosts-*")
+	if err != nil {
+		return nil, fmt.Errorf("staging known-hosts: %w", err)
+	}
+	defer os.Remove(f.Name())
+	_, werr := f.WriteString(data + "\n")
+	if cerr := f.Close(); werr == nil {
+		werr = cerr
+	}
+	if werr != nil {
+		return nil, fmt.Errorf("staging known-hosts: %w", werr)
+	}
+	cb, err := knownhosts.New(f.Name())
+	if err != nil {
+		return nil, fmt.Errorf("parsing known-hosts: %w", err)
+	}
+	return cb, nil
 }
 
 // normalizeRemote converts a remote path to a clean slash path.

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -2,11 +2,15 @@ package uploader
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"io"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -14,6 +18,7 @@ import (
 
 	"github.com/eiserv/easySFTP/internal/config"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // writeTree creates files under root; keys are slash-separated relative paths.
@@ -372,6 +377,93 @@ func TestHostKeyFingerprint(t *testing.T) {
 		_, err := Run(context.Background(), cfg, testLogger{t})
 		if err == nil || !strings.Contains(err.Error(), "SHA256") {
 			t.Fatalf("expected SHA256 format error, got %v", err)
+		}
+	})
+}
+
+func TestKnownHosts(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "known"})
+
+	addr := net.JoinHostPort(srv.Host, strconv.Itoa(srv.Port))
+	// What "ssh-keyscan -p <port> <host>" would print for this server.
+	keyscanLine := knownhosts.Line([]string{addr}, srv.HostPubKey)
+
+	run := func(t *testing.T, cfg *config.Config) error {
+		t.Helper()
+		cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/known"}}
+		_, err := Run(context.Background(), cfg, testLogger{t})
+		return err
+	}
+
+	t.Run("matching keyscan line succeeds", func(t *testing.T) {
+		cfg := baseConfig(srv)
+		cfg.KnownHosts = keyscanLine
+		if err := run(t, cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("hashed entry succeeds", func(t *testing.T) {
+		cfg := baseConfig(srv)
+		hashed := knownhosts.HashHostname(knownhosts.Normalize(addr))
+		cfg.KnownHosts = hashed + " " + strings.TrimSpace(string(ssh.MarshalAuthorizedKey(srv.HostPubKey)))
+		if err := run(t, cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("entry for another key fails", func(t *testing.T) {
+		_, otherPriv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		otherSigner, err := ssh.NewSignerFromKey(otherPriv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := baseConfig(srv)
+		cfg.KnownHosts = knownhosts.Line([]string{addr}, otherSigner.PublicKey())
+		err = run(t, cfg)
+		if err == nil || !strings.Contains(err.Error(), "host key mismatch") {
+			t.Fatalf("expected host key mismatch error, got %v", err)
+		}
+	})
+
+	t.Run("entry for another host fails", func(t *testing.T) {
+		cfg := baseConfig(srv)
+		cfg.KnownHosts = knownhosts.Line([]string{"other.example.com:22"}, srv.HostPubKey)
+		err := run(t, cfg)
+		if err == nil || !strings.Contains(err.Error(), "host key mismatch") {
+			t.Fatalf("expected host key mismatch error, got %v", err)
+		}
+	})
+
+	t.Run("wrong fingerprint plus matching known-hosts succeeds", func(t *testing.T) {
+		cfg := baseConfig(srv)
+		cfg.HostKeyFingerprints = []string{"SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}
+		cfg.KnownHosts = keyscanLine
+		if err := run(t, cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("matching fingerprint plus non-matching known-hosts succeeds", func(t *testing.T) {
+		cfg := baseConfig(srv)
+		cfg.HostKeyFingerprints = []string{srv.HostKeySHA256}
+		cfg.KnownHosts = knownhosts.Line([]string{"other.example.com:22"}, srv.HostPubKey)
+		if err := run(t, cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("garbage known-hosts fails to parse", func(t *testing.T) {
+		cfg := baseConfig(srv)
+		cfg.KnownHosts = "not a known_hosts line"
+		err := run(t, cfg)
+		if err == nil || !strings.Contains(err.Error(), "known-hosts") {
+			t.Fatalf("expected a known-hosts parse error, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Fixes #7

## What

New `known-hosts` input that takes raw OpenSSH `known_hosts` lines, i.e. verbatim `ssh-keyscan` output or the server's lines from an existing `~/.ssh/known_hosts`. This removes the `ssh-keygen -lf -` conversion step (a documented common setup error) that `host-key-fingerprint` requires.

Verification uses `golang.org/x/crypto/ssh/knownhosts` (already a dependency via `x/crypto`, no new module), so **hashed entries** (`|1|...`) and **`[host]:port` entries** for non-standard ports are supported.

## Decision the issue left open: both inputs set

**Accept a key matching either input** (OR semantics), rather than rejecting the combination. This mirrors exactly how multiple `host-key-fingerprint` lines already OR together ("pin all of your server's keys"), and follows the project principle that the user picks their own posture; both inputs express the same intent in different formats. Documented in `action.yml` and `docs/security.md`.

## Implementation notes

- `x/crypto`'s knownhosts parser only reads files, so the input is staged in a temp file that is removed right after parsing (the parse is eager, per the issue's sketch).
- The no-verification warning now names both inputs, suggesting the conversion-free `ssh-keyscan` route first.
- A garbage `known-hosts` value fails the run at connect time with a parse error rather than being silently ignored.

## Docs

`docs/security.md` now presents both pinning formats (known-hosts first, as the lower-friction one); `docs/configuration.md` gets the input row; `action.yml` descriptions updated.

## Tests

`TestKnownHosts` covers: plain keyscan line match, hashed entry match, wrong-key reject, wrong-host reject, wrong fingerprint + matching known-hosts (OR accepted), matching fingerprint + non-matching known-hosts (OR accepted), and garbage input failing to parse. Drift checks (actionmeta, config env list) extended.

`go test ./...` passes locally; `-race` could not run locally (no cgo toolchain), relying on CI for the race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)