### PR TITLE
feat: add stall-timeout to fail fast when transfers stop progressing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,9 @@ Look at how existing inputs are wired before adding a new one:
    #62 shipped in v2.0.0. `TestLoadConfigFileWithActionDefaults`
    (`internal/config/config_test.go`) guards against reintroducing this.
 2. **Run-wide behavior** (connection, transfer mechanics): `retries`,
-   `concurrency`, `sftp-request-concurrency`, `timeout`, `dry-run`,
-   `sync-fast-path`, `dir-mode`, `file-mode`. These always come from action
+   `concurrency`, `sftp-request-concurrency`, `timeout`, `stall-timeout`,
+   `dry-run`, `sync-fast-path`, `dir-mode`, `file-mode`. These always come
+   from action
    inputs, regardless of `config-file`, and have **no** per-target override
    and **no** YAML config-file equivalent. Don't add one unless a concrete
    use case needs per-target granularity; it's easy to add later, hard to

--- a/action.yml
+++ b/action.yml
@@ -145,6 +145,18 @@ inputs:
     description: Connection timeout in seconds. 0 disables the timeout entirely.
     required: false
     default: "30"
+  stall-timeout:
+    description: >-
+      Abort the run when active file transfers make no progress for this many
+      seconds. 0 (the default) disables the check. Catches servers that
+      accept the connection and then hang mid-transfer (hung storage backend,
+      half-open connection that still answers keepalives), which would
+      otherwise block the job until the job-level timeout, 6 hours by
+      default. On a stall the connection is closed and the run fails with a
+      clear error. Pick a value comfortably above the longest pause a healthy
+      transfer to your server may hit; 60 to 300 is a reasonable range.
+    required: false
+    default: "0"
   dir-mode:
     description: >-
       Octal permission (e.g. "755") applied to every remote directory the run
@@ -235,5 +247,6 @@ runs:
         EASYSFTP_SYNC_FAST_PATH: ${{ inputs.sync-fast-path }}
         EASYSFTP_RETRIES: ${{ inputs.retries }}
         EASYSFTP_TIMEOUT: ${{ inputs.timeout }}
+        EASYSFTP_STALL_TIMEOUT: ${{ inputs.stall-timeout }}
         EASYSFTP_DIR_MODE: ${{ inputs.dir-mode }}
         EASYSFTP_FILE_MODE: ${{ inputs.file-mode }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,8 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 | `passphrase` | | - | Passphrase of the private key, if encrypted. |
 | `host-key-fingerprint` | | - | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). **Strongly recommended**, see [Security](security.md). |
 | `known-hosts` | | - | Expected host key(s) in OpenSSH `known_hosts` format (verbatim `ssh-keyscan` output). Alternative to `host-key-fingerprint`; a key matching either is accepted. Hashed entries and `[host]:port` lines are supported. See [Security](security.md). |
-| `timeout` | | `30` | Connection timeout in seconds. `0` disables the timeout entirely. |
+| `timeout` | | `30` | Connection timeout in seconds. `0` disables the timeout entirely. Covers the dial and SSH handshake only; for hangs after that, see `stall-timeout`. |
+| `stall-timeout` | | `0` (off) | Abort the run when active file transfers make no progress for this many seconds. Catches servers that accept the connection and then hang mid-transfer, which would otherwise block the job until the job-level timeout (6 hours by default). On a stall the connection is closed and the run fails with a clear error. Pick a value comfortably above the longest pause a healthy transfer to your server may hit; 60 to 300 is a reasonable range. |
 
 ¹ At least one of `password` / `private-key` is required. If both are set, the key is tried first.
 

--- a/internal/actionmeta/actionmeta_test.go
+++ b/internal/actionmeta/actionmeta_test.go
@@ -64,7 +64,7 @@ func TestActionMetadata(t *testing.T) {
 		"passphrase", "host-key-fingerprint", "known-hosts", "uploads", "config-file", "strategy",
 		"ignore", "ignore-from", "max-deletes", "delete", "dry-run", "concurrency",
 		"sftp-request-concurrency", "sync-fast-path", "retries", "timeout",
-		"dir-mode", "file-mode",
+		"stall-timeout", "dir-mode", "file-mode",
 	}
 	for _, name := range wantInputs {
 		if _, ok := action.Inputs[name]; !ok {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,11 @@ type Config struct {
 	Retries                int
 	Timeout                time.Duration
 	SyncFastPath           bool
+
+	// StallTimeout, if positive, aborts the run when active transfers make
+	// no progress for this long, instead of hanging until the job-level
+	// timeout. 0 (the default) disables the check.
+	StallTimeout time.Duration
 }
 
 const envPrefix = "EASYSFTP_"
@@ -139,6 +144,12 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("invalid timeout: %w", err)
 	}
 	cfg.Timeout = time.Duration(timeoutSec) * time.Second
+
+	stallSec, err := parseInt(get("STALL_TIMEOUT"), 0)
+	if err != nil {
+		return nil, fmt.Errorf("invalid stall-timeout: %w", err)
+	}
+	cfg.StallTimeout = time.Duration(stallSec) * time.Second
 
 	// The deployment (targets, strategy, ignore, guards) comes either from a
 	// YAML config file or from the plain action inputs, never a mix of both.
@@ -220,6 +231,8 @@ func (c *Config) validate() error {
 		return fmt.Errorf("input 'retries' must not be negative, got %d", c.Retries)
 	case c.Timeout < 0:
 		return fmt.Errorf("input 'timeout' must not be negative (use 0 to disable the timeout), got %d", int(c.Timeout/time.Second))
+	case c.StallTimeout < 0:
+		return fmt.Errorf("input 'stall-timeout' must not be negative (use 0 to disable the check), got %d", int(c.StallTimeout/time.Second))
 	case c.Guards.MaxDeletes < 0:
 		return fmt.Errorf("guards.max_deletes must not be negative, got %d", c.Guards.MaxDeletes)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,7 +47,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("EASYSFTP_PASSWORD", "hunter2")
 	t.Setenv("EASYSFTP_UPLOADS", "./dist/ => /www/")
 	for _, name := range []string{"PORT", "PRIVATE_KEY", "PASSPHRASE", "HOST_KEY_FINGERPRINT", "KNOWN_HOSTS",
-		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "SFTP_REQUEST_CONCURRENCY", "RETRIES", "TIMEOUT",
+		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "SFTP_REQUEST_CONCURRENCY", "RETRIES", "TIMEOUT", "STALL_TIMEOUT",
 		"SYNC_FAST_PATH", "CONFIG_FILE", "STRATEGY", "MAX_DELETES", "DIR_MODE", "FILE_MODE"} {
 		t.Setenv("EASYSFTP_"+name, "")
 	}
@@ -85,6 +85,8 @@ func TestLoadValidation(t *testing.T) {
 		{"zero sftp-request-concurrency", map[string]string{"EASYSFTP_SFTP_REQUEST_CONCURRENCY": "0"}, "'sftp-request-concurrency' must be at least 1"},
 		{"negative max-deletes", map[string]string{"EASYSFTP_MAX_DELETES": "-1"}, "guards.max_deletes must not be negative"},
 		{"negative timeout", map[string]string{"EASYSFTP_TIMEOUT": "-5"}, "'timeout' must not be negative"},
+		{"bad stall-timeout", map[string]string{"EASYSFTP_STALL_TIMEOUT": "soon"}, "invalid stall-timeout"},
+		{"negative stall-timeout", map[string]string{"EASYSFTP_STALL_TIMEOUT": "-5"}, "'stall-timeout' must not be negative"},
 		{"bad dir-mode", map[string]string{"EASYSFTP_DIR_MODE": "not-octal"}, "invalid dir-mode"},
 		{"dir-mode out of range", map[string]string{"EASYSFTP_DIR_MODE": "1755"}, "invalid dir-mode"},
 		{"bad file-mode", map[string]string{"EASYSFTP_FILE_MODE": "999"}, "invalid file-mode"},

--- a/internal/uploader/stall.go
+++ b/internal/uploader/stall.go
@@ -1,0 +1,92 @@
+package uploader
+
+import (
+	"io"
+	"sync/atomic"
+	"time"
+)
+
+// stallWatchdog fails a run fast when its active transfers stop making
+// progress. Transfers mark themselves active for the duration of each upload
+// attempt and tick the watchdog on every read that moved bytes. A monitor
+// goroutine fires when transfers are active but no tick arrived for the
+// configured timeout; firing closes the SSH connection, which unblocks every
+// SFTP operation stuck on the stalled server with an error, so the run fails
+// in minutes with a clear message instead of hanging until the job-level
+// timeout.
+//
+// Closing the whole connection (rather than aborting just the stalled file)
+// is deliberate: all transfers share one SSH session, and a write blocked on
+// an exhausted SSH channel window cannot be interrupted any other way. A
+// server that stalls one transfer has stalled the session.
+type stallWatchdog struct {
+	timeout time.Duration
+	kill    func() // closes the SSH connection
+	log     Logger
+	done    chan struct{}
+
+	active atomic.Int64 // transfers currently inside an upload attempt
+	ticks  atomic.Int64 // bumped whenever any transfer moves bytes
+	fired  atomic.Bool
+}
+
+// startStallWatchdog launches the monitor goroutine; stop it with stop().
+func startStallWatchdog(timeout time.Duration, kill func(), log Logger) *stallWatchdog {
+	w := &stallWatchdog{timeout: timeout, kill: kill, log: log, done: make(chan struct{})}
+	go w.monitor()
+	return w
+}
+
+func (w *stallWatchdog) stop() { close(w.done) }
+
+// begin marks one transfer attempt as active. The tick resets the silence
+// clock, so a transfer that hangs in its very first operation (e.g. opening
+// the remote file on a stalled server) still gets the full timeout window.
+func (w *stallWatchdog) begin() { w.ticks.Add(1); w.active.Add(1) }
+func (w *stallWatchdog) end()   { w.active.Add(-1) }
+
+func (w *stallWatchdog) monitor() {
+	interval := w.timeout / 4
+	if interval < 100*time.Millisecond {
+		interval = 100 * time.Millisecond
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	last := w.ticks.Load()
+	lastChange := time.Now()
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-t.C:
+		}
+		now := w.ticks.Load()
+		if w.active.Load() == 0 || now != last {
+			last = now
+			lastChange = time.Now()
+			continue
+		}
+		if time.Since(lastChange) >= w.timeout {
+			w.fired.Store(true)
+			w.log.Warningf("no transfer progress for %s; closing the connection so the run fails fast (stall-timeout)", w.timeout)
+			w.kill()
+			return
+		}
+	}
+}
+
+// reader wraps r so that every read that moved bytes counts as progress.
+func (w *stallWatchdog) reader(r io.Reader) io.Reader { return &tickReader{w: w, r: r} }
+
+type tickReader struct {
+	w *stallWatchdog
+	r io.Reader
+}
+
+func (t *tickReader) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+	if n > 0 {
+		t.w.ticks.Add(1)
+	}
+	return n, err
+}

--- a/internal/uploader/stall_test.go
+++ b/internal/uploader/stall_test.go
@@ -1,0 +1,119 @@
+package uploader
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// The watchdog must fire only when transfers are active and silent: not while
+// idle, not while progress ticks arrive.
+func TestStallWatchdogFiresOnlyWhenActiveAndSilent(t *testing.T) {
+	killed := make(chan struct{})
+	w := startStallWatchdog(300*time.Millisecond, func() { close(killed) }, testLogger{t})
+	defer w.stop()
+
+	// Idle (no active transfers): must not fire, no matter how long.
+	select {
+	case <-killed:
+		t.Fatal("watchdog fired while no transfer was active")
+	case <-time.After(600 * time.Millisecond):
+	}
+
+	// Active with steady progress: must not fire.
+	w.begin()
+	stopTicks := make(chan struct{})
+	go func() {
+		tick := time.NewTicker(50 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stopTicks:
+				return
+			case <-tick.C:
+				w.ticks.Add(1)
+			}
+		}
+	}()
+	select {
+	case <-killed:
+		t.Fatal("watchdog fired despite steady progress")
+	case <-time.After(600 * time.Millisecond):
+	}
+
+	// Active and silent: must fire within a few check intervals.
+	close(stopTicks)
+	select {
+	case <-killed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("watchdog did not fire on a silent active transfer")
+	}
+	if !w.fired.Load() {
+		t.Error("fired flag not set after the watchdog killed the connection")
+	}
+	w.end()
+}
+
+// A server that accepts the connection and then stops making progress
+// mid-transfer must fail the run quickly with a clear stall error, instead of
+// blocking until an outer timeout.
+func TestStallTimeoutFailsFast(t *testing.T) {
+	// The server stops reading after 256 KiB but keeps the connection open.
+	srv := startTestServer(t, withStallAfter(256*1024))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"big.bin": strings.Repeat("x", 2<<20), // 2 MiB, far beyond the stall point
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+	cfg.Concurrency = 1
+	// One in-flight request per file: reads stop promptly once the server
+	// stops acknowledging, making the stall visible to the watchdog fast.
+	cfg.SftpRequestConcurrency = 1
+	cfg.StallTimeout = 1 * time.Second
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	start := time.Now()
+	_, err := Run(context.Background(), cfg, log)
+	elapsed := time.Since(start)
+
+	if err == nil || !strings.Contains(err.Error(), "stalled") {
+		t.Fatalf("expected a transfer-stalled error, got %v", err)
+	}
+	if elapsed > 30*time.Second {
+		t.Fatalf("run took %s; the stall-timeout should have failed it fast", elapsed)
+	}
+	found := false
+	for _, w := range log.warnings {
+		if strings.Contains(w, "no transfer progress") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a stall warning, got %v", log.warnings)
+	}
+}
+
+// With stall-timeout unset (the default) nothing changes: a normal deploy
+// against a healthy server runs without a watchdog.
+func TestStallTimeoutOffByDefault(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 1 {
+		t.Fatalf("expected 1 upload, got %d", stats.FilesUploaded)
+	}
+}

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -47,7 +47,7 @@ type manifest struct {
 // manifest: it uploads new/changed files, deletes files that the previous sync
 // wrote but are now gone locally, prunes empty directories and rewrites the
 // manifest. Unchanged files are skipped.
-func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, log Logger) error {
+func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, watch *stallWatchdog, log Logger) error {
 	verb := planVerb(cfg)
 	base := normalizeRemote(p.pair.Remote)
 	// Manifest handling and deletions use a client snapshot; only the
@@ -108,7 +108,7 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 	if cfg.DirMode != nil {
 		dirs = p.remoteDirs
 	}
-	if err := uploadFiles(ctx, cfg, sess, upload, dirs, stats, verb, log); err != nil {
+	if err := uploadFiles(ctx, cfg, sess, upload, dirs, stats, verb, watch, log); err != nil {
 		return err
 	}
 

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
@@ -35,6 +36,7 @@ type testServer struct {
 	dropAfter     int64 // if >0, kill each connection after it reads this many bytes
 	dropFirstOnly bool  // with dropAfter: apply the drop to the first accepted connection only
 	dropped       int32 // whether the first connection was already wrapped
+	stallAfter    int64 // if >0, stop reading (but stay connected) after this many bytes
 
 	keepalives *int64 // if set, counts "keepalive@openssh.com" global requests received
 }
@@ -59,6 +61,11 @@ func withDropFirstConnAfter(n int64) serverOption {
 		s.dropFirstOnly = true
 	}
 }
+
+// withStallAfter makes each connection stop reading (while staying open) once
+// it has read n bytes from the client, simulating a server that is alive but
+// makes no progress: the SSH transport stays up, but transfers starve.
+func withStallAfter(n int64) serverOption { return func(s *testServer) { s.stallAfter = n } }
 
 // withFailSetstat makes the server reject every chmod (Setstat) request,
 // simulating a server that refuses SETSTAT.
@@ -285,19 +292,50 @@ func (c *dropConn) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// stallConn stops reading (but keeps the connection open) once it has read
+// limit bytes, simulating a server that is alive but stops making progress.
+// A blocked read is released when the connection closes, or after a generous
+// safety timeout so an abandoned server goroutine cannot outlive the test
+// binary for long.
+type stallConn struct {
+	net.Conn
+	limit int64
+	read  int64
+	stall chan struct{}
+	once  sync.Once
+}
+
+func (c *stallConn) Read(p []byte) (int, error) {
+	if atomic.LoadInt64(&c.read) > c.limit {
+		select {
+		case <-c.stall:
+		case <-time.After(30 * time.Second):
+		}
+		return 0, net.ErrClosed
+	}
+	n, err := c.Conn.Read(p)
+	atomic.AddInt64(&c.read, int64(n))
+	return n, err
+}
+
+func (c *stallConn) Close() error {
+	c.once.Do(func() { close(c.stall) })
+	return c.Conn.Close()
+}
+
 func (s *testServer) acceptLoop() {
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
 			return
 		}
-		wrapped := false
 		if s.dropAfter > 0 &&
 			(!s.dropFirstOnly || atomic.CompareAndSwapInt32(&s.dropped, 0, 1)) {
 			conn = &dropConn{Conn: conn, limit: s.dropAfter}
-			wrapped = true
 		}
-		fmt.Printf("DEBUG accept conn from %v wrapped=%v\n", conn.RemoteAddr(), wrapped)
+		if s.stallAfter > 0 {
+			conn = &stallConn{Conn: conn, limit: s.stallAfter, stall: make(chan struct{})}
+		}
 		go s.handleConn(conn)
 	}
 }

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -115,12 +115,18 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	defer stopKeepalives()
 	go sendKeepalives(keepaliveCtx, sess.currentSSH, keepaliveInterval)
 
+	var watch *stallWatchdog
+	if cfg.StallTimeout > 0 {
+		watch = startStallWatchdog(cfg.StallTimeout, func() { sess.currentSSH().Close() }, log)
+		defer watch.stop()
+	}
+
 	for _, p := range plans {
 		if err := ctx.Err(); err != nil {
 			return stats, err
 		}
 		before := *stats
-		err := executePlan(ctx, cfg, sess, p, stats, log)
+		err := executePlan(ctx, cfg, sess, p, stats, watch, log)
 		if len(plans) > 1 {
 			// Recorded from the before/after delta (not threaded through
 			// executePlan) so a target's partial progress on failure is
@@ -137,6 +143,9 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 			})
 		}
 		if err != nil {
+			if watch != nil && watch.fired.Load() {
+				return stats, fmt.Errorf("transfer stalled: no progress for %s, connection closed (stall-timeout): %w", cfg.StallTimeout, err)
+			}
 			return stats, err
 		}
 	}
@@ -282,19 +291,19 @@ func hashPlanFiles(ctx context.Context, files []fileItem, concurrency int, cache
 }
 
 // executePlan performs (or previews) one plan according to its strategy.
-func executePlan(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, log Logger) error {
+func executePlan(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, watch *stallWatchdog, log Logger) error {
 	log.Group(fmt.Sprintf("%s => %s [%s] (%d local files)", p.pair.Local, p.pair.Remote, p.strategy, len(p.files)))
 	defer log.EndGroup()
 
 	if p.strategy == config.StrategySync {
-		return executeSync(ctx, cfg, sess, p, stats, log)
+		return executeSync(ctx, cfg, sess, p, stats, watch, log)
 	}
-	return executeOverlayOrClean(ctx, cfg, sess, p, stats, log)
+	return executeOverlayOrClean(ctx, cfg, sess, p, stats, watch, log)
 }
 
 // executeOverlayOrClean uploads the plan, first wiping the remote target when
 // the strategy is clean.
-func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, log Logger) error {
+func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, watch *stallWatchdog, log Logger) error {
 	verb := planVerb(cfg)
 	// Non-upload operations (the clean sweep below) use a client snapshot;
 	// only the per-file upload path is reconnect-aware.
@@ -330,12 +339,12 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 		}
 	}
 
-	return uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, stats, verb, log)
+	return uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, stats, verb, watch, log)
 }
 
 // uploadFiles creates the needed remote directories and uploads files in
 // parallel (or, in dry-run mode, only logs what it would do).
-func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, stats *Stats, verb string, log Logger) error {
+func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, stats *Stats, verb string, watch *stallWatchdog, log Logger) error {
 	if !cfg.DryRun {
 		client, _ := sess.current()
 		if err := createRemoteDirs(client, dirs, cfg.DirMode, log); err != nil {
@@ -371,7 +380,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 			if cfg.FileMode != nil {
 				mode = *cfg.FileMode
 			}
-			n, err := uploadFileWithRetry(ctx, f, i, mode, sess, cfg.Retries, log, modeWarned)
+			n, err := uploadFileWithRetry(ctx, f, i, mode, sess, cfg.Retries, watch, log, modeWarned)
 			if err != nil {
 				return err
 			}
@@ -529,7 +538,7 @@ const tmpSuffix = ".easysftp-tmp"
 // path (see uploadFile) so two planned transfers never race over the same
 // temporary name, even if one target's path happens to literally be
 // another's plus tmpSuffix.
-func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.FileMode, sess *session, retries int, log Logger, modeWarned *atomic.Bool) (int64, error) {
+func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.FileMode, sess *session, retries int, watch *stallWatchdog, log Logger, modeWarned *atomic.Bool) (int64, error) {
 	var lastErr error
 	for attempt := 0; attempt <= retries; attempt++ {
 		if attempt > 0 {
@@ -546,12 +555,19 @@ func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.Fil
 			// fresh attempt starts from a clean slate; harmless when absent.
 			_ = client.Remove(fmt.Sprintf("%s%s.%d", f.remotePath, tmpSuffix, index))
 		}
-		n, err := uploadFile(ctx, f, index, mode, client, log, modeWarned)
+		n, err := uploadFile(ctx, f, index, mode, client, watch, log, modeWarned)
 		if err == nil {
 			return n, nil
 		}
 		lastErr = err
 		if !isRetryable(err) {
+			break
+		}
+		// The watchdog closed the connection because the server stopped
+		// making progress. That reads as a connection drop, but redialing
+		// would just stall again with the watchdog already spent, so fail
+		// fast instead: this is exactly what stall-timeout is for.
+		if watch != nil && watch.fired.Load() {
 			break
 		}
 		if isConnError(err) && attempt < retries {
@@ -567,7 +583,14 @@ func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.Fil
 // temporary sibling and, only once that fully succeeds, renames it over the
 // target. Any failure removes the temporary file so a broken or partial upload
 // never replaces the live file and no debris is left behind.
-func uploadFile(ctx context.Context, f fileItem, index int, mode fs.FileMode, client *sftp.Client, log Logger, modeWarned *atomic.Bool) (int64, error) {
+func uploadFile(ctx context.Context, f fileItem, index int, mode fs.FileMode, client *sftp.Client, watch *stallWatchdog, log Logger, modeWarned *atomic.Bool) (int64, error) {
+	// Active per attempt (not around the whole retry loop) so retry backoff
+	// sleeps do not count as transfer silence.
+	if watch != nil {
+		watch.begin()
+		defer watch.end()
+	}
+
 	src, err := os.Open(f.localPath)
 	if err != nil {
 		return 0, err
@@ -585,7 +608,11 @@ func uploadFile(ctx context.Context, f fileItem, index int, mode fs.FileMode, cl
 
 	// ctxReader aborts the copy promptly when the deployment is cancelled,
 	// instead of streaming a whole large file first.
-	n, err := io.Copy(dst, &ctxReader{ctx: ctx, r: src})
+	var reader io.Reader = &ctxReader{ctx: ctx, r: src}
+	if watch != nil {
+		reader = watch.reader(reader)
+	}
+	n, err := io.Copy(dst, reader)
 	if cerr := dst.Close(); err == nil {
 		err = cerr
 	}


### PR DESCRIPTION
Fixes #45

## What

New opt-in `stall-timeout` input (seconds, default `0` = off, per the project's opt-in principle). When active transfers move no bytes for the configured time, the run fails within minutes with a clear `transfer stalled` error instead of hanging until the GitHub job-level timeout (6h by default).

## Design: why the watchdog closes the connection

The issue sketched wrapping `ctxReader` with a progress-watchdog context. That alone cannot work: when a server stalls, the transfer is blocked in the SFTP **write** path (waiting for acks on an exhausted SSH channel window), so control never returns to the reader, and pkg/sftp has no per-operation cancellation. The only reliable way to unblock a window-starved write is to close the SSH connection.

So the implementation is a run-wide watchdog:

- every upload attempt marks itself active (`begin`/`end`), and every chunk read ticks a shared counter;
- a monitor goroutine fires when transfers are active but silent for `stall-timeout`, logs a warning, and closes the SSH connection;
- every stuck operation then errors out immediately, and `Run` wraps the failure as `transfer stalled: no progress for Xs`.

Closing the whole connection is deliberate and documented in the code: all transfers share one SSH session, so a server that stalls one transfer has stalled the session. Progress is tracked per upload *attempt*, so retry backoff sleeps and idle planning/hashing phases never count as silence.

Keepalive-answering-but-stalled servers (the case the issue calls out) are caught: keepalives are transport-level and do not tick the watchdog; only real transfer bytes do.

## Known limitation (noted for the reviewer)

Non-transfer operations (manifest read/write, deletes, dir creation) are not under the watchdog; covering them would mean wrapping every `*sftp.Client` call site for a rare case. Transfers are where runs actually hang for hours. Can be extended later if it ever bites.

## Tests

- `TestStallWatchdogFiresOnlyWhenActiveAndSilent`: unit-tests the three monitor states (idle, progressing, silent).
- `TestStallTimeoutFailsFast`: integration test against a new `withStallAfter` fake-server option (connection stays open, reads stop after 256 KiB); a 2 MiB upload with `stall-timeout: 1` fails in ~1.5s with the stall error and warning.
- `TestStallTimeoutOffByDefault`: default behavior unchanged.
- Config parsing/validation + actionmeta drift checks extended.

`go test ./...` passes locally; `-race` could not run locally (no cgo toolchain), relying on CI for the race pass.

Note: touches `uploadFiles`/`executeSync` signatures, so it will need a trivial rebase against #86/#87 depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)