### PR TITLE
feat: reconnect when the SSH connection drops mid-run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,10 @@ Look at how existing inputs are wired before adding a new one:
   - Directory chmod against this fake server always errors (see above);
     that's a fake-server limitation, not a bug in the code under test.
 - Similar fault-injection wrappers exist for rename (`faultyRename`,
-  `withFailRename()`) and connection drops (`withDropAfter`). Follow that
-  pattern (wrap the relevant `Handlers` field, add a `serverOption`) for new
-  fault-injection needs instead of building a new fake server.
+  `withFailRename()`) and connection drops (`withDropAfter`,
+  `withDropFirstConnAfter`). Follow that pattern (wrap the relevant
+  `Handlers` field, add a `serverOption`) for new fault-injection needs
+  instead of building a new fake server.
 - Every `FileCmder` wrapper in `testserver_test.go` must implement
   `PosixRename` (delegate via `posixRenamePassthrough`): pkg/sftp serves
   posix-rename only when the outermost `FileCmder` implements
@@ -83,6 +84,14 @@ Look at how existing inputs are wired before adding a new one:
   fails when the target exists. A wrapper without the method makes every
   overwriting rename (manifest rewrites, re-uploads of existing files) fail
   with "file already exists", far from the wrapper's apparent concern.
+- The in-memory `memFile` implements pkg/sftp's `TransferError` interface:
+  when a connection dies mid-write, the request server stores the transfer
+  error *into the shared file object*, and every later write through that
+  same in-memory file (from any connection) returns the stale error, e.g.
+  `sftp: "error reading packet body: ..."`. Real servers do not behave like
+  this. The production retry path sidesteps it by removing the leftover temp
+  file before a re-attempt, which also matters on real servers (stale
+  handles/locks); keep that in mind before "simplifying" it away.
 - Run `go test -race ./...` before committing; uploads are parallelized
   (`errgroup` + `cfg.Concurrency`), so races are the most likely regression
   class in `internal/uploader`. `-race` needs cgo: on a machine without a C

--- a/action.yml
+++ b/action.yml
@@ -134,7 +134,11 @@ inputs:
     required: false
     default: "false"
   retries:
-    description: How often a failed file upload is retried (with backoff).
+    description: >-
+      How often a failed file upload is retried (with backoff). Also bounds
+      how often a connection that drops mid-run is redialed; the per-file
+      retry then runs against the fresh connection instead of the dead one.
+      0 disables both.
     required: false
     default: "2"
   timeout:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 | `concurrency` | | `4` | Number of files uploaded in parallel. Also bounds the worker pool that hashes local files for the `sync` strategy. |
 | `sftp-request-concurrency` | | `16` | Advanced. Maximum in-flight SFTP requests *per file*: pipelining within one file's transfer, independent of `concurrency` (which controls how many files transfer at once). The two multiply: with the defaults, a single large file can have up to 16 requests in flight, and up to `concurrency` files transfer at a time. Lower it for a small or resource-constrained server; raise it for more throughput per file on a fast link to a capable server. |
 | `sync-fast-path` | | `false` | For the `sync` strategy, reuse a file's manifest hash instead of re-reading it when size and modification time still match. See [the sync-fast-path trade-off](strategies.md#sync-fast-path-skip-re-hashing-unchanged-files). |
-| `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). |
+| `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). Also bounds how often a connection that drops mid-run is redialed: when an upload fails because the connection died, easySFTP reconnects (up to `retries` times per run) and the per-file retry then runs against the fresh connection. Completed files stay completed. `0` disables both. |
 | `dir-mode` | | - | Octal permission (e.g. `755`) applied to every remote directory the run creates or touches, instead of whatever the server's umask produces. |
 | `file-mode` | | - | Octal permission (e.g. `644`) applied to every uploaded file, instead of mirroring the local file's permission bits. |
 

--- a/internal/uploader/reconnect_test.go
+++ b/internal/uploader/reconnect_test.go
@@ -1,0 +1,138 @@
+package uploader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+func TestIsConnError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"sftp connection lost", sftp.ErrSSHFxConnectionLost, true},
+		{"wrapped EOF", fmt.Errorf("replacing %q: %w", "/x", io.EOF), true},
+		{"unexpected EOF", io.ErrUnexpectedEOF, true},
+		{"permission denied", os.ErrPermission, false},
+		{"not exist", os.ErrNotExist, false},
+		{"plain sftp failure", errors.New("sftp: \"failure\" (SSH_FX_FAILURE)"), false},
+		{"stringly broken pipe", errors.New("write: broken pipe"), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isConnError(c.err); got != c.want {
+				t.Errorf("isConnError(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// A one-off mid-run connection drop must not kill the deploy: the session
+// redials, per-file retries re-run against the fresh client, and already
+// completed files stay completed.
+func TestReconnectResumesAfterMidRunDrop(t *testing.T) {
+	// The first connection dies once ~200 KiB have flowed; the redial gets a
+	// clean connection.
+	srv := startTestServer(t, withDropFirstConnAfter(200*1024))
+
+	local := t.TempDir()
+	files := map[string]string{}
+	for i := 0; i < 6; i++ {
+		files[fmt.Sprintf("f%d.bin", i)] = strings.Repeat(fmt.Sprintf("%d", i), 100*1024)
+	}
+	writeTree(t, local, files)
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 2
+	cfg.Retries = 2
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	stats, err := Run(context.Background(), cfg, log)
+	if err != nil {
+		t.Fatalf("expected the run to survive the drop via reconnect, got %v", err)
+	}
+	if stats.FilesUploaded != 6 {
+		t.Errorf("uploads: got %d, want 6", stats.FilesUploaded)
+	}
+	for name, content := range files {
+		if got := readRemote(t, srv, "/www/"+name); got != content {
+			t.Errorf("%s: wrong content after reconnect (len %d, want %d)", name, len(got), len(content))
+		}
+	}
+	reconnected := false
+	for _, w := range log.warnings {
+		if strings.Contains(w, "reconnecting") {
+			reconnected = true
+		}
+	}
+	if !reconnected {
+		t.Errorf("expected a reconnect warning, got %v", log.warnings)
+	}
+}
+
+// When every connection keeps dying, the reconnect budget (the retries input)
+// bounds the redials and the run fails instead of looping forever.
+func TestReconnectBudgetBoundsRedials(t *testing.T) {
+	// Every connection dies after 64 KiB; a 1 MiB file can never finish.
+	srv := startTestServer(t, withDropAfter(64*1024))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"big.bin": strings.Repeat("x", 1<<20)})
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 1
+	cfg.Retries = 2
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	start := time.Now()
+	stats, err := Run(context.Background(), cfg, log)
+	if err == nil {
+		t.Fatal("expected the run to fail once the reconnect budget is spent")
+	}
+	if stats.FilesUploaded != 0 {
+		t.Errorf("uploads: got %d, want 0", stats.FilesUploaded)
+	}
+	reconnects := 0
+	for _, w := range log.warnings {
+		if strings.Contains(w, "reconnecting") {
+			reconnects++
+		}
+	}
+	if reconnects > cfg.Retries {
+		t.Errorf("observed %d reconnects, budget is %d", reconnects, cfg.Retries)
+	}
+	if elapsed := time.Since(start); elapsed > 60*time.Second {
+		t.Errorf("run took %s; it should fail fast once the budget is spent", elapsed)
+	}
+}
+
+// Retries=0 disables reconnects along with per-file retries: a dropped
+// connection fails the run on the first error, as before.
+func TestReconnectDisabledWithZeroRetries(t *testing.T) {
+	srv := startTestServer(t, withDropFirstConnAfter(64*1024))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"big.bin": strings.Repeat("x", 1<<20)})
+
+	cfg := baseConfig(srv) // Retries: 0
+	cfg.Concurrency = 1
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err == nil {
+		t.Fatal("expected the run to fail without retries/reconnects")
+	}
+}

--- a/internal/uploader/session.go
+++ b/internal/uploader/session.go
@@ -1,0 +1,123 @@
+package uploader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// session holds the run's SSH/SFTP client pair and can transparently redial
+// it when the connection drops mid-run, so per-file retries run against a
+// live client instead of burning their backoff on a dead one.
+type session struct {
+	cfg *config.Config
+	log Logger
+
+	mu         sync.Mutex
+	sshClient  *ssh.Client
+	sftpClient *sftp.Client
+	gen        int // bumped on every successful reconnect
+	reconnects int // spent so far; bounded by cfg.Retries
+}
+
+// newSession dials the server and opens the initial SFTP session.
+func newSession(cfg *config.Config, log Logger) (*session, error) {
+	sshClient, sftpClient, err := connect(cfg, log)
+	if err != nil {
+		return nil, err
+	}
+	return &session{cfg: cfg, log: log, sshClient: sshClient, sftpClient: sftpClient}, nil
+}
+
+// current returns the live SFTP client and its generation. The generation is
+// handed back to reconnect so that concurrent workers failing on the same
+// dead connection trigger only one redial between them.
+func (s *session) current() (*sftp.Client, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sftpClient, s.gen
+}
+
+// currentSSH returns the live SSH client (used by the keepalive loop, which
+// must follow reconnects to the fresh transport).
+func (s *session) currentSSH() *ssh.Client {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sshClient
+}
+
+// reconnect redials after a connection-class failure. gen is the generation
+// of the caller's failed client: when another worker already reconnected, the
+// fresh client is returned without dialing again. Reconnects are bounded by
+// the retries input; past that budget, or when the redial itself fails, an
+// error is returned and the caller gives up.
+//
+// The lock is held across the backoff and redial on purpose: workers that
+// fail in the meantime block in current()/reconnect() until the fresh client
+// is up, instead of hammering the dead one.
+func (s *session) reconnect(ctx context.Context, gen int) (*sftp.Client, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.gen != gen {
+		return s.sftpClient, nil
+	}
+	if s.reconnects >= s.cfg.Retries {
+		return nil, fmt.Errorf("connection lost and the reconnect budget is spent (%d, from the retries input)", s.cfg.Retries)
+	}
+	s.reconnects++
+	backoff := time.Duration(1<<(s.reconnects-1)) * time.Second
+	s.log.Warningf("connection to the server was lost; reconnecting in %s (reconnect %d/%d)", backoff, s.reconnects, s.cfg.Retries)
+	if err := sleepCtx(ctx, backoff); err != nil {
+		return nil, err
+	}
+	s.sftpClient.Close()
+	s.sshClient.Close()
+	sshClient, sftpClient, err := connect(s.cfg, s.log)
+	if err != nil {
+		return nil, fmt.Errorf("reconnecting: %w", err)
+	}
+	s.sshClient, s.sftpClient = sshClient, sftpClient
+	s.gen++
+	return s.sftpClient, nil
+}
+
+// close tears the session down at the end of the run.
+func (s *session) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sftpClient.Close()
+	s.sshClient.Close()
+}
+
+// isConnError reports whether err looks like the connection itself died (as
+// opposed to a per-file SFTP failure), meaning a retry only helps against a
+// fresh connection.
+func isConnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, sftp.ErrSSHFxConnectionLost) ||
+		errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var opErr *net.OpError // resets, broken pipes and friends
+	if errors.As(err, &opErr) {
+		return true
+	}
+	// The ssh transport reports some transport deaths as plain string errors.
+	msg := err.Error()
+	return strings.Contains(msg, "connection lost") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection reset")
+}

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -47,9 +47,12 @@ type manifest struct {
 // manifest: it uploads new/changed files, deletes files that the previous sync
 // wrote but are now gone locally, prunes empty directories and rewrites the
 // manifest. Unchanged files are skipped.
-func executeSync(ctx context.Context, cfg *config.Config, client *sftp.Client, p plan, stats *Stats, log Logger) error {
+func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, log Logger) error {
 	verb := planVerb(cfg)
 	base := normalizeRemote(p.pair.Remote)
+	// Manifest handling and deletions use a client snapshot; only the
+	// per-file upload path is reconnect-aware.
+	client, _ := sess.current()
 
 	old := readManifest(client, base, log)
 
@@ -105,9 +108,13 @@ func executeSync(ctx context.Context, cfg *config.Config, client *sftp.Client, p
 	if cfg.DirMode != nil {
 		dirs = p.remoteDirs
 	}
-	if err := uploadFiles(ctx, cfg, client, upload, dirs, stats, verb, log); err != nil {
+	if err := uploadFiles(ctx, cfg, sess, upload, dirs, stats, verb, log); err != nil {
 		return err
 	}
+
+	// A reconnect during the uploads leaves the snapshot above dead; refresh
+	// it so deletions and the manifest write use the live client.
+	client, _ = sess.current()
 
 	for _, full := range toDelete {
 		log.Infof("%sdelete %s", verb, full)

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -30,9 +30,11 @@ type testServer struct {
 	listener      net.Listener
 
 	// Fault injection (set via options before the accept loop starts).
-	failRename  bool  // make every rename fail with a non-transient error
-	failSetstat bool  // make every chmod (Setstat) fail
-	dropAfter   int64 // if >0, kill each connection after it reads this many bytes
+	failRename    bool  // make every rename fail with a non-transient error
+	failSetstat   bool  // make every chmod (Setstat) fail
+	dropAfter     int64 // if >0, kill each connection after it reads this many bytes
+	dropFirstOnly bool  // with dropAfter: apply the drop to the first accepted connection only
+	dropped       int32 // whether the first connection was already wrapped
 
 	keepalives *int64 // if set, counts "keepalive@openssh.com" global requests received
 }
@@ -47,6 +49,16 @@ func withFailRename() serverOption { return func(s *testServer) { s.failRename =
 // withDropAfter closes each connection once it has read n bytes from the
 // client, simulating a mid-transfer connection drop.
 func withDropAfter(n int64) serverOption { return func(s *testServer) { s.dropAfter = n } }
+
+// withDropFirstConnAfter kills only the first accepted connection after n
+// bytes; later connections (reconnects) run clean. Simulates a one-off
+// mid-run drop (NAT reset, server restart) that a redial recovers from.
+func withDropFirstConnAfter(n int64) serverOption {
+	return func(s *testServer) {
+		s.dropAfter = n
+		s.dropFirstOnly = true
+	}
+}
 
 // withFailSetstat makes the server reject every chmod (Setstat) request,
 // simulating a server that refuses SETSTAT.
@@ -279,9 +291,13 @@ func (s *testServer) acceptLoop() {
 		if err != nil {
 			return
 		}
-		if s.dropAfter > 0 {
+		wrapped := false
+		if s.dropAfter > 0 &&
+			(!s.dropFirstOnly || atomic.CompareAndSwapInt32(&s.dropped, 0, 1)) {
 			conn = &dropConn{Conn: conn, limit: s.dropAfter}
+			wrapped = true
 		}
+		fmt.Printf("DEBUG accept conn from %v wrapped=%v\n", conn.RemoteAddr(), wrapped)
 		go s.handleConn(conn)
 	}
 }
@@ -320,7 +336,8 @@ func (s *testServer) handleConn(conn net.Conn) {
 				req.Reply(ok, nil)
 				if ok {
 					server := sftp.NewRequestServer(channel, s.handlers)
-					server.Serve()
+					serr := server.Serve()
+					fmt.Printf("DEBUG server.Serve on %v returned: %v\n", conn.RemoteAddr(), serr)
 					server.Close()
 					return
 				}

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -105,23 +105,22 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		plans = append(plans, p)
 	}
 
-	sshClient, sftpClient, err := connect(cfg, log)
+	sess, err := newSession(cfg, log)
 	if err != nil {
 		return stats, err
 	}
-	defer sshClient.Close()
-	defer sftpClient.Close()
+	defer sess.close()
 
 	keepaliveCtx, stopKeepalives := context.WithCancel(ctx)
 	defer stopKeepalives()
-	go sendKeepalives(keepaliveCtx, sshClient, keepaliveInterval)
+	go sendKeepalives(keepaliveCtx, sess.currentSSH, keepaliveInterval)
 
 	for _, p := range plans {
 		if err := ctx.Err(); err != nil {
 			return stats, err
 		}
 		before := *stats
-		err := executePlan(ctx, cfg, sftpClient, p, stats, log)
+		err := executePlan(ctx, cfg, sess, p, stats, log)
 		if len(plans) > 1 {
 			// Recorded from the before/after delta (not threaded through
 			// executePlan) so a target's partial progress on failure is
@@ -283,20 +282,23 @@ func hashPlanFiles(ctx context.Context, files []fileItem, concurrency int, cache
 }
 
 // executePlan performs (or previews) one plan according to its strategy.
-func executePlan(ctx context.Context, cfg *config.Config, client *sftp.Client, p plan, stats *Stats, log Logger) error {
+func executePlan(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, log Logger) error {
 	log.Group(fmt.Sprintf("%s => %s [%s] (%d local files)", p.pair.Local, p.pair.Remote, p.strategy, len(p.files)))
 	defer log.EndGroup()
 
 	if p.strategy == config.StrategySync {
-		return executeSync(ctx, cfg, client, p, stats, log)
+		return executeSync(ctx, cfg, sess, p, stats, log)
 	}
-	return executeOverlayOrClean(ctx, cfg, client, p, stats, log)
+	return executeOverlayOrClean(ctx, cfg, sess, p, stats, log)
 }
 
 // executeOverlayOrClean uploads the plan, first wiping the remote target when
 // the strategy is clean.
-func executeOverlayOrClean(ctx context.Context, cfg *config.Config, client *sftp.Client, p plan, stats *Stats, log Logger) error {
+func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, log Logger) error {
 	verb := planVerb(cfg)
+	// Non-upload operations (the clean sweep below) use a client snapshot;
+	// only the per-file upload path is reconnect-aware.
+	client, _ := sess.current()
 
 	if p.strategy == config.StrategyClean {
 		base := normalizeRemote(p.pair.Remote)
@@ -328,13 +330,14 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, client *sftp
 		}
 	}
 
-	return uploadFiles(ctx, cfg, client, p.files, p.remoteDirs, stats, verb, log)
+	return uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, stats, verb, log)
 }
 
 // uploadFiles creates the needed remote directories and uploads files in
 // parallel (or, in dry-run mode, only logs what it would do).
-func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, files []fileItem, dirs []string, stats *Stats, verb string, log Logger) error {
+func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, stats *Stats, verb string, log Logger) error {
 	if !cfg.DryRun {
+		client, _ := sess.current()
 		if err := createRemoteDirs(client, dirs, cfg.DirMode, log); err != nil {
 			return err
 		}
@@ -368,7 +371,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, client *sftp.Client, f
 			if cfg.FileMode != nil {
 				mode = *cfg.FileMode
 			}
-			n, err := uploadFileWithRetry(ctx, f, i, mode, client, cfg.Retries, log, modeWarned)
+			n, err := uploadFileWithRetry(ctx, f, i, mode, sess, cfg.Retries, log, modeWarned)
 			if err != nil {
 				return err
 			}
@@ -519,12 +522,14 @@ const tmpSuffix = ".easysftp-tmp"
 // uploadFileWithRetry uploads one file, retrying transient failures with
 // exponential backoff. It stops early when the context is cancelled or the
 // error is permanent (see isRetryable), so a doomed transfer fails fast.
+// When a failure looks connection-class, the session is asked to reconnect
+// first, so the retry runs against a live client instead of the dead one.
 //
 // index is the file's position in the plan and is folded into the temp
 // path (see uploadFile) so two planned transfers never race over the same
 // temporary name, even if one target's path happens to literally be
 // another's plus tmpSuffix.
-func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.FileMode, client *sftp.Client, retries int, log Logger, modeWarned *atomic.Bool) (int64, error) {
+func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.FileMode, sess *session, retries int, log Logger, modeWarned *atomic.Bool) (int64, error) {
 	var lastErr error
 	for attempt := 0; attempt <= retries; attempt++ {
 		if attempt > 0 {
@@ -534,6 +539,13 @@ func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.Fil
 				return 0, err
 			}
 		}
+		client, gen := sess.current()
+		if attempt > 0 {
+			// A previous attempt may have left its temp file behind (a dead
+			// connection cannot run the normal cleanup). Clear it so the
+			// fresh attempt starts from a clean slate; harmless when absent.
+			_ = client.Remove(fmt.Sprintf("%s%s.%d", f.remotePath, tmpSuffix, index))
+		}
 		n, err := uploadFile(ctx, f, index, mode, client, log, modeWarned)
 		if err == nil {
 			return n, nil
@@ -541,6 +553,11 @@ func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.Fil
 		lastErr = err
 		if !isRetryable(err) {
 			break
+		}
+		if isConnError(err) && attempt < retries {
+			if _, rerr := sess.reconnect(ctx, gen); rerr != nil {
+				return 0, fmt.Errorf("uploading %q to %q: %w (%v)", f.localPath, f.remotePath, lastErr, rerr)
+			}
 		}
 	}
 	return 0, fmt.Errorf("uploading %q to %q: %w", f.localPath, f.remotePath, lastErr)
@@ -668,9 +685,10 @@ const keepaliveInterval = 30 * time.Second
 // canceled. This keeps long or idle-looking transfers alive across NAT
 // gateways and firewalls that drop idle TCP connections, and answers sshd's
 // own ClientAliveInterval probes so the server doesn't disconnect us first.
-// interval is a parameter (rather than always reading the keepaliveInterval
-// constant) so tests can drive it with a short tick instead of waiting 30s.
-func sendKeepalives(ctx context.Context, client *ssh.Client, interval time.Duration) {
+// client is a getter (not a fixed *ssh.Client) so one loop follows the
+// session across reconnects; interval is a parameter so tests can drive it
+// with a short tick instead of waiting 30s.
+func sendKeepalives(ctx context.Context, client func() *ssh.Client, interval time.Duration) {
 	t := time.NewTicker(interval)
 	defer t.Stop()
 	for {
@@ -678,7 +696,7 @@ func sendKeepalives(ctx context.Context, client *ssh.Client, interval time.Durat
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			_, _, _ = client.SendRequest("keepalive@openssh.com", true, nil)
+			_, _, _ = client().SendRequest("keepalive@openssh.com", true, nil)
 		}
 	}
 }

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -676,7 +676,7 @@ func TestSendKeepalivesPingsUntilCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		sendKeepalives(ctx, sshClient, 10*time.Millisecond)
+		sendKeepalives(ctx, func() *ssh.Client { return sshClient }, 10*time.Millisecond)
 		close(done)
 	}()
 


### PR DESCRIPTION
Fixes #43

## What

A dropped connection mid-run no longer kills the deploy. A new \`session\` holder (\`internal/uploader/session.go\`) wraps the SSH/SFTP client pair:

- \`uploadFileWithRetry\` classifies failures with \`isConnError\` (sftp's \`ErrSSHFxConnectionLost\`, EOFs, \`net.OpError\`, and the ssh transport's stringly deaths); on a connection-class failure it asks the session to reconnect before the next attempt, so retries run against a live client instead of burning backoff on a dead one.
- A **generation guard** makes concurrent workers cheap: the first failing worker redials; workers failing on the same dead generation get the fresh client without further dials. The session lock is held across the redial on purpose, so meanwhile-failing workers wait for the fresh client instead of hammering the dead one.
- **Bounded** by the \`retries\` input (the issue offered this or a fixed number; the input keeps it user-controllable, and \`retries: 0\` preserves today's fail-fast exactly, pinned by \`TestReconnectDisabledWithZeroRetries\` and the pre-existing \`TestConnectionDropFailsCleanly\`).
- Completed files stay completed; sync's manifest logic is untouched (written at the end; its client snapshot is refreshed after uploads in case a reconnect happened).
- The keepalive loop now takes a client *getter* so one loop follows the session across reconnects.
- Non-upload operations (manifest, deletes, clean sweep, dir creation) intentionally stay on a snapshot without reconnect coverage; uploads are where long runs die. Extension is easy later.

## The interesting bug the tests surfaced

Retry attempts now remove the previous attempt's leftover temp file before re-uploading. Two reasons:
- Real servers: a temp file abandoned by a dead session can carry baggage (locks/ownership); starting clean is strictly safer, and it is one extra round-trip only on retry attempts.
- The in-memory test server: pkg/sftp's \`memFile\` implements \`TransferError\`, so a connection dying mid-write **stores the transfer error into the shared file object**; any later write through the same path, from any connection, returns that stale error (\`sftp: \"error reading packet body: ...\"\`). Real servers do not do this. Documented in CLAUDE.md so nobody \"simplifies\" the cleanup away and chases this ghost again.

## Tests

- \`TestReconnectResumesAfterMidRunDrop\`: first connection dies at ~200 KiB (new \`withDropFirstConnAfter\` option), 6x100 KiB files, concurrency 2: run succeeds, all contents verified, reconnect warning present.
- \`TestReconnectBudgetBoundsRedials\`: every connection dies: run fails, observed reconnects never exceed the budget, bounded wall time.
- \`TestReconnectDisabledWithZeroRetries\`, \`TestIsConnError\` (classification table).

\`go test ./...\` passes locally (reconnect tests run twice to check for flakiness); \`-race\` could not run locally (no cgo toolchain), relying on CI for the race pass.

Note: overlaps with #86/#87/#89 in \`uploadFiles\`/\`executeSync\`/keepalive wiring; whichever merges later needs a small rebase. Merge-order suggestion: this one and #89 (stall-timeout) touch the same connection lifecycle; on the second rebase the stall watchdog's kill closure should call \`session\`'s current SSH client.