### PR TITLE
perf(plan): prune ignored directories during the local walk

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,11 @@ ignore: |
 - `!pattern` re-includes files excluded by an earlier pattern.
 - `ignore` and `ignore-from` are additive; in the config file, per-target
   `ignore` lists add to the global one.
+- An ignored directory (e.g. `node_modules/`) is skipped without being walked
+  at all, so huge excluded trees cost nothing during planning. This pruning is
+  automatically disabled as soon as any pattern is a `!` re-include, because a
+  re-include may point below an ignored directory; results are identical either
+  way, only planning speed differs.
 
 ## The YAML config file
 

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -94,7 +94,7 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		st := effectiveStrategy(pair)
 		lines := append(append([]string{}, cfg.IgnoreLines...), pair.Ignore...)
 		matcher := ignore.CompileIgnoreLines(lines...)
-		p, err := buildPlan(pair, st, matcher)
+		p, err := buildPlan(pair, st, matcher, !hasNegation(lines))
 		if err != nil {
 			return stats, err
 		}
@@ -153,12 +153,30 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	return stats, nil
 }
 
+// hasNegation reports whether any ignore line is a "!" re-include. Directory
+// pruning is disabled in that case: a pruned directory can never have files
+// below it re-included, so pruning only runs when no pattern could do that.
+func hasNegation(lines []string) bool {
+	for _, l := range lines {
+		if strings.HasPrefix(l, "!") {
+			return true
+		}
+	}
+	return false
+}
+
 // buildPlan walks the local side of an upload pair and computes the remote
 // file and directory layout, honoring the ignore patterns. It does not touch
 // the network, so config/path errors surface before a connection is made.
 // Content hashing for the sync strategy happens later, once connected: see
 // executeSync.
-func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore.GitIgnore) (plan, error) {
+//
+// With pruneDirs set, a directory that itself matches the ignore patterns is
+// skipped entirely instead of descended into, so an ignored node_modules/ with
+// hundreds of thousands of entries costs one match instead of a full walk.
+// Callers must clear it when the patterns contain "!" re-includes, which could
+// re-include files below an otherwise ignored directory.
+func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore.GitIgnore, pruneDirs bool) (plan, error) {
 	p := plan{pair: pair, strategy: strategy}
 	remoteBase := normalizeRemote(pair.Remote)
 
@@ -199,14 +217,18 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
-			return nil
-		}
 		rel, err := filepath.Rel(pair.Local, fpath)
 		if err != nil {
 			return err
 		}
 		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			// The trailing slash lets directory-only patterns ("dist/") match.
+			if pruneDirs && rel != "." && matcher.MatchesPath(rel+"/") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
 		if rel == manifestName || matcher.MatchesPath(rel) {
 			return nil
 		}

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -17,9 +17,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eiserv/easySFTP/internal/config"
+	ignore "github.com/sabhiram/go-gitignore"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
+
+	"github.com/eiserv/easySFTP/internal/config"
 )
 
 // writeTree creates files under root; keys are slash-separated relative paths.
@@ -805,5 +807,102 @@ func TestSkipUnchangedWarnsOnNonOverlay(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected a warning that skip-unchanged is ignored for sync, got %v", log.warnings)
+	}
+}
+
+func TestIgnoredDirectoryIsPruned(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 000 does not restrict directory reads on Windows")
+	}
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"index.html":          "x",
+		"node_modules/x/y.js": "y",
+	})
+	// An unreadable ignored directory: descending into it would fail the walk,
+	// so a successful plan proves it was pruned, not just filtered per file.
+	if err := os.Chmod(filepath.Join(local, "node_modules"), 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(local, "node_modules"), 0o755) })
+
+	matcher := ignore.CompileIgnoreLines("node_modules/")
+	p, err := buildPlan(config.UploadPair{Local: local, Remote: "/www"}, config.StrategyOverlay, matcher, true)
+	if err != nil {
+		t.Fatalf("walk descended into the pruned directory: %v", err)
+	}
+	if len(p.files) != 1 || p.files[0].rel != "index.html" {
+		t.Errorf("unexpected plan files: %+v", p.files)
+	}
+}
+
+func TestIgnoreNegationReincludesBelowIgnoredDirectory(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"index.html":            "x",
+		"node_modules/keep.js":  "keep",
+		"node_modules/other.js": "drop",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+	cfg.IgnoreLines = []string{"node_modules/", "!node_modules/keep.js"}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 2 {
+		t.Errorf("expected 2 uploads, got %d", stats.FilesUploaded)
+	}
+	if got := readRemote(t, srv, "/www/node_modules/keep.js"); got != "keep" {
+		t.Errorf("re-included file missing or wrong: %q", got)
+	}
+	if remoteExists(t, srv, "/www/node_modules/other.js") {
+		t.Error("ignored file other.js was uploaded")
+	}
+}
+
+func TestHasNegation(t *testing.T) {
+	if hasNegation([]string{"*.log", "node_modules/"}) {
+		t.Error("no negation expected")
+	}
+	if !hasNegation([]string{"*.log", "!important.log"}) {
+		t.Error("negation expected")
+	}
+}
+
+// BenchmarkBuildPlanIgnoredTree compares planning over a tree whose bulk sits
+// in an ignored node_modules/ directory, with and without directory pruning.
+func BenchmarkBuildPlanIgnoredTree(b *testing.B) {
+	local := b.TempDir()
+	for i := range 200 {
+		dir := filepath.Join(local, "node_modules", "pkg"+strconv.Itoa(i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			b.Fatal(err)
+		}
+		for j := range 10 {
+			if err := os.WriteFile(filepath.Join(dir, "f"+strconv.Itoa(j)+".js"), []byte("x"), 0o644); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	if err := os.WriteFile(filepath.Join(local, "index.html"), []byte("x"), 0o644); err != nil {
+		b.Fatal(err)
+	}
+	matcher := ignore.CompileIgnoreLines("node_modules/")
+	pair := config.UploadPair{Local: local, Remote: "/www"}
+	for _, bench := range []struct {
+		name  string
+		prune bool
+	}{{"pruned", true}, {"unpruned", false}} {
+		b.Run(bench.name, func(b *testing.B) {
+			for b.Loop() {
+				if _, err := buildPlan(pair, config.StrategyOverlay, matcher, bench.prune); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Closes #9.

`buildPlan` now returns `filepath.SkipDir` for a directory that itself matches the ignore patterns, instead of descending into it and matching every file below it individually. For a typical JS project with an ignored `node_modules/`, planning no longer stats hundreds of thousands of entries.

## The `!` re-include decision

gitignore semantics allow re-including files below an excluded directory (`node_modules/` + `!node_modules/keep.js`), which pruning would break. Instead of matching git's "never re-include below a pruned directory" behavior (a silent behavior change for existing users), pruning is simply **disabled whenever any ignore pattern starts with `!`**:

- No negations (the overwhelmingly common case): full pruning speedup.
- Any negation present: exactly today's behavior, bit for bit.

So results are identical in every case; only planning speed differs. This keeps the conservative "default to today's behavior" principle and avoids taking a working configuration away from anyone. Documented in `docs/configuration.md#ignore-patterns`.

## Benchmark

`BenchmarkBuildPlanIgnoredTree` (200 packages x 10 files under an ignored `node_modules/`, Windows, i9-14900K):

| variant | ns/op |
|---|---|
| unpruned (before) | 7,731,240 |
| pruned (after) | 62,830 |

~120x faster planning on this tree; the gap grows with the size of the ignored directory.

## Tests

- `TestIgnoredDirectoryIsPruned`: the ignored directory is made unreadable (mode 000), so a successful plan proves the walk never descended (skipped on Windows, where chmod 000 does not restrict reads).
- `TestIgnoreNegationReincludesBelowIgnoredDirectory`: end-to-end check that `!` re-includes below an ignored directory keep working.
- `TestHasNegation` unit test.

`go test ./...` passes locally; `-race` needs cgo which is unavailable on this machine (no C toolchain), relying on CI for the race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)