### PR TITLE
feat(connect): support connecting through a jump host (ProxyJump)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,47 @@ inputs:
       accepted. Hashed entries and "[host]:port" entries for non-standard
       ports are supported.
     required: false
+  proxy-server:
+    description: >-
+      Hostname or IP address of an optional jump host (bastion) through which
+      the SFTP server is reached, like OpenSSH's ProxyJump. When set,
+      easySFTP connects to the jump host first (with its own proxy-*
+      credentials and host key verification) and tunnels the SFTP connection
+      to "server" through it. Leave empty to connect directly.
+    required: false
+  proxy-port:
+    description: SSH port of the jump host.
+    required: false
+  proxy-username:
+    description: Username used for authenticating against the jump host.
+    required: false
+  proxy-password:
+    description: >-
+      Password for the jump host. Provide this or proxy-private-key (or
+      both). Always store this in a GitHub Actions secret.
+    required: false
+  proxy-private-key:
+    description: >-
+      SSH private key (PEM/OpenSSH format) for the jump host. Always store
+      this in a GitHub Actions secret.
+    required: false
+  proxy-passphrase:
+    description: Passphrase for the jump host's private key, if it is encrypted.
+    required: false
+  proxy-host-key-fingerprint:
+    description: >-
+      Expected SHA256 fingerprint(s) of the jump host's host key, one per
+      line (format "SHA256:..."). Host key verification applies to each hop
+      independently; without this input (or proxy-known-hosts) the jump
+      host's identity is not verified, and a warning is printed for this hop.
+    required: false
+  proxy-known-hosts:
+    description: >-
+      Expected host key(s) of the jump host in OpenSSH known_hosts format
+      (e.g. verbatim "ssh-keyscan <jump-host>" output). Alternative to
+      proxy-host-key-fingerprint; if both are set, a key matching either is
+      accepted.
+    required: false
   uploads:
     description: >-
       One "local => remote" mapping per line, e.g. "./dist/ => /var/www/html/".
@@ -283,6 +324,14 @@ runs:
         EASYSFTP_PASSPHRASE: ${{ inputs.passphrase }}
         EASYSFTP_HOST_KEY_FINGERPRINT: ${{ inputs.host-key-fingerprint }}
         EASYSFTP_KNOWN_HOSTS: ${{ inputs.known-hosts }}
+        EASYSFTP_PROXY_SERVER: ${{ inputs.proxy-server }}
+        EASYSFTP_PROXY_PORT: ${{ inputs.proxy-port }}
+        EASYSFTP_PROXY_USERNAME: ${{ inputs.proxy-username }}
+        EASYSFTP_PROXY_PASSWORD: ${{ inputs.proxy-password }}
+        EASYSFTP_PROXY_PRIVATE_KEY: ${{ inputs.proxy-private-key }}
+        EASYSFTP_PROXY_PASSPHRASE: ${{ inputs.proxy-passphrase }}
+        EASYSFTP_PROXY_HOST_KEY_FINGERPRINT: ${{ inputs.proxy-host-key-fingerprint }}
+        EASYSFTP_PROXY_KNOWN_HOSTS: ${{ inputs.proxy-known-hosts }}
         EASYSFTP_UPLOADS: ${{ inputs.uploads }}
         EASYSFTP_CONFIG_FILE: ${{ inputs.config-file }}
         EASYSFTP_STRATEGY: ${{ inputs.strategy }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,49 @@ Everything easySFTP accepts: action inputs, outputs and the YAML config file.
 
 ¹ At least one of `password` / `private-key` is required. If both are set, the key is tried first.
 
+### Jump host (bastion)
+
+If the SFTP server is only reachable through a bastion (OpenSSH's
+`ssh -J jump.example.com target`), set the `proxy-*` inputs. easySFTP then
+connects to the jump host first, with its own credentials and its own host
+key verification, and tunnels the SFTP connection to `server` through it.
+All inputs mirror the primary connection settings:
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `proxy-server` | ² | - | Hostname or IP of the jump host. Setting any other `proxy-*` input without this one fails the run. |
+| `proxy-port` | | `22` | SSH port of the jump host. |
+| `proxy-username` | ² | - | Username for the jump host. |
+| `proxy-password` | ³ | - | Password for the jump host. **Use a secret.** |
+| `proxy-private-key` | ³ | - | SSH private key for the jump host. **Use a secret.** |
+| `proxy-passphrase` | | - | Passphrase of the jump host key, if encrypted. |
+| `proxy-host-key-fingerprint` | | - | SHA256 fingerprint(s) of the jump host's key, one per line. **Strongly recommended.** |
+| `proxy-known-hosts` | | - | Jump host key(s) in `known_hosts` format; alternative to the fingerprint input. |
+
+² Required when using a jump host. ³ At least one of `proxy-password` /
+`proxy-private-key` is required when `proxy-server` is set.
+
+Host key verification applies to **each hop independently**: pinning the
+target but not the jump host (or vice versa) prints the unverified-host-key
+warning for the open hop. The `timeout` input covers each hop's dial. The
+`retries` reconnect logic re-establishes the whole chain (jump host and
+tunnel) when the connection drops mid-run.
+
+```yaml
+- uses: eiserv/easySFTP@v2
+  with:
+    server: sftp.internal.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
+    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+    proxy-server: bastion.example.com
+    proxy-username: ${{ secrets.JUMP_USERNAME }}
+    proxy-private-key: ${{ secrets.JUMP_PRIVATE_KEY }}
+    proxy-host-key-fingerprint: ${{ secrets.JUMP_HOST_KEY_FINGERPRINT }}
+    uploads: |
+      ./dist/ => /var/www/html/
+```
+
 ### What to upload
 
 | Input | Required | Default | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,10 @@ Host key verification applies to **each hop independently**: pinning the
 target but not the jump host (or vice versa) prints the unverified-host-key
 warning for the open hop. The `timeout` input covers each hop's dial. The
 `retries` reconnect logic re-establishes the whole chain (jump host and
-tunnel) when the connection drops mid-run.
+tunnel) when the connection drops mid-run, and the initial-connection retry
+covers either hop: a transient failure reaching the bastion is retried just
+like one reaching the target, while a host key mismatch or an authentication
+failure on either hop fails immediately.
 
 ```yaml
 - uses: eiserv/easySFTP@v2

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,6 +7,7 @@ stored as [encrypted secrets](https://docs.github.com/en/actions/security-guides
 - [Mirror a build with sync](#mirror-a-build-with-sync)
 - [Multiple targets with a config file](#multiple-targets-with-a-config-file)
 - [Key-based authentication](#key-based-authentication)
+- [Deploy through a jump host (bastion)](#deploy-through-a-jump-host-bastion)
 - [Upload a single file (with rename)](#upload-a-single-file-with-rename)
 - [Preview a deploy in pull requests](#preview-a-deploy-in-pull-requests)
 - [Using the outputs](#using-the-outputs)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -108,6 +108,27 @@ Preferred over passwords, see the [security guide](security.md#credentials):
     uploads: ./dist/ => /var/www/html/
 ```
 
+## Deploy through a jump host (bastion)
+
+For servers that are not reachable from the public internet, connect through
+a bastion like OpenSSH's `ProxyJump`. Each hop has its own credentials and
+its own host key verification (see
+[configuration](configuration.md#jump-host-bastion)):
+
+```yaml
+- uses: eiserv/easySFTP@v2
+  with:
+    server: sftp.internal.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
+    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+    proxy-server: bastion.example.com
+    proxy-username: ${{ secrets.JUMP_USERNAME }}
+    proxy-private-key: ${{ secrets.JUMP_PRIVATE_KEY }}
+    proxy-host-key-fingerprint: ${{ secrets.JUMP_HOST_KEY_FINGERPRINT }}
+    uploads: ./dist/ => /var/www/html/
+```
+
 ## Upload a single file (with rename)
 
 A single file maps onto the exact remote path, so you can rename on the fly.

--- a/internal/actionmeta/actionmeta_test.go
+++ b/internal/actionmeta/actionmeta_test.go
@@ -61,7 +61,10 @@ func TestActionMetadata(t *testing.T) {
 
 	wantInputs := []string{
 		"build-mode", "server", "port", "username", "password", "private-key",
-		"passphrase", "host-key-fingerprint", "known-hosts", "uploads", "config-file", "strategy",
+		"passphrase", "host-key-fingerprint", "known-hosts",
+		"proxy-server", "proxy-port", "proxy-username", "proxy-password",
+		"proxy-private-key", "proxy-passphrase", "proxy-host-key-fingerprint",
+		"proxy-known-hosts", "uploads", "config-file", "strategy",
 		"ignore", "ignore-from", "max-deletes", "delete", "dry-run", "concurrency",
 		"sftp-request-concurrency", "sync-fast-path", "skip-unchanged", "retries",
 		"timeout", "stall-timeout", "dir-mode", "file-mode", "log-level", "manifest-name",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,22 @@ type UploadPair struct {
 	Ignore   []string // target-specific ignore patterns, additive to the global ones
 }
 
+// Proxy holds the connection settings of an optional jump host (bastion)
+// through which the SFTP server is reached, mirroring the primary connection
+// settings. Host key verification applies to this hop independently.
+type Proxy struct {
+	Server              string
+	Port                int
+	Username            string
+	Password            string
+	PrivateKey          string
+	Passphrase          string
+	HostKeyFingerprints []string
+	// KnownHosts holds raw OpenSSH known_hosts lines for the jump host, an
+	// alternative to fingerprints, exactly like the primary input.
+	KnownHosts string
+}
+
 // Guards holds the safety limits applied before any destructive operation.
 type Guards struct {
 	// MaxDeletes refuses a run that would delete more than this many files.
@@ -89,6 +105,9 @@ type Config struct {
 	// output), an alternative to SHA256 fingerprints. When both are set, a
 	// key matching either is accepted.
 	KnownHosts string
+
+	// Proxy, if non-nil, routes the connection through a jump host.
+	Proxy *Proxy
 
 	Uploads     []UploadPair
 	IgnoreLines []string
@@ -183,6 +202,9 @@ func Load() (*Config, error) {
 	var err error
 	if cfg.Port, err = parseInt(get("PORT"), 22); err != nil {
 		return nil, fmt.Errorf("invalid port: %w", err)
+	}
+	if cfg.Proxy, err = loadProxy(get); err != nil {
+		return nil, err
 	}
 	if cfg.Concurrency, err = parseInt(get("CONCURRENCY"), 4); err != nil {
 		return nil, fmt.Errorf("invalid concurrency: %w", err)
@@ -285,6 +307,35 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
+// loadProxy reads the optional proxy-* (jump host) inputs. Without
+// proxy-server, every other proxy input must be empty, so a typo'd or
+// half-configured bastion setup fails loudly instead of silently connecting
+// directly.
+func loadProxy(get func(string) string) (*Proxy, error) {
+	p := &Proxy{
+		Server:              get("PROXY_SERVER"),
+		Username:            get("PROXY_USERNAME"),
+		Password:            os.Getenv(envPrefix + "PROXY_PASSWORD"),
+		PrivateKey:          os.Getenv(envPrefix + "PROXY_PRIVATE_KEY"),
+		Passphrase:          os.Getenv(envPrefix + "PROXY_PASSPHRASE"),
+		HostKeyFingerprints: splitLines(os.Getenv(envPrefix + "PROXY_HOST_KEY_FINGERPRINT")),
+		KnownHosts:          strings.TrimSpace(os.Getenv(envPrefix + "PROXY_KNOWN_HOSTS")),
+	}
+	if p.Server == "" {
+		if p.Username != "" || p.Password != "" || strings.TrimSpace(p.PrivateKey) != "" ||
+			p.Passphrase != "" || len(p.HostKeyFingerprints) > 0 || p.KnownHosts != "" ||
+			get("PROXY_PORT") != "" {
+			return nil, fmt.Errorf("proxy-* inputs are set but 'proxy-server' is empty; set proxy-server or remove the other proxy inputs")
+		}
+		return nil, nil
+	}
+	var err error
+	if p.Port, err = parseInt(get("PROXY_PORT"), 22); err != nil {
+		return nil, fmt.Errorf("invalid proxy-port: %w", err)
+	}
+	return p, nil
+}
+
 // resolveStrategy maps the strategy input to a concrete strategy.
 func resolveStrategy(input string) (Strategy, error) {
 	if input == "" {
@@ -321,6 +372,16 @@ func (c *Config) validate() error {
 		return fmt.Errorf("input 'stall-timeout' must not be negative (use 0 to disable the check), got %d", int(c.StallTimeout/time.Second))
 	case c.Guards.MaxDeletes < 0:
 		return fmt.Errorf("guards.max_deletes must not be negative, got %d", c.Guards.MaxDeletes)
+	}
+	if p := c.Proxy; p != nil {
+		switch {
+		case p.Username == "":
+			return fmt.Errorf("input 'proxy-username' is required when 'proxy-server' is set")
+		case p.Password == "" && strings.TrimSpace(p.PrivateKey) == "":
+			return fmt.Errorf("either input 'proxy-password' or 'proxy-private-key' is required when 'proxy-server' is set")
+		case p.Port < 1 || p.Port > 65535:
+			return fmt.Errorf("input 'proxy-port' must be between 1 and 65535, got %d", p.Port)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -49,7 +49,9 @@ func setBaseEnv(t *testing.T) {
 	for _, name := range []string{"PORT", "PRIVATE_KEY", "PASSPHRASE", "HOST_KEY_FINGERPRINT", "KNOWN_HOSTS",
 		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "SFTP_REQUEST_CONCURRENCY", "RETRIES", "TIMEOUT", "STALL_TIMEOUT",
 		"SYNC_FAST_PATH", "SKIP_UNCHANGED", "CONFIG_FILE", "STRATEGY", "MAX_DELETES", "DIR_MODE", "FILE_MODE",
-		"LOG_LEVEL", "MANIFEST_NAME", "PRESERVE_TIMES"} {
+		"LOG_LEVEL", "MANIFEST_NAME", "PRESERVE_TIMES",
+		"PROXY_SERVER", "PROXY_PORT", "PROXY_USERNAME", "PROXY_PASSWORD", "PROXY_PRIVATE_KEY", "PROXY_PASSPHRASE",
+		"PROXY_HOST_KEY_FINGERPRINT", "PROXY_KNOWN_HOSTS"} {
 		t.Setenv("EASYSFTP_"+name, "")
 	}
 }
@@ -96,6 +98,10 @@ func TestLoadValidation(t *testing.T) {
 		{"manifest-name with slash", map[string]string{"EASYSFTP_MANIFEST_NAME": "sub/manifest.json"}, "'manifest-name' must be a bare file name"},
 		{"manifest-name with backslash", map[string]string{"EASYSFTP_MANIFEST_NAME": `sub\manifest.json`}, "'manifest-name' must be a bare file name"},
 		{"manifest-name dot-dot", map[string]string{"EASYSFTP_MANIFEST_NAME": ".."}, "'manifest-name' must be a bare file name"},
+		{"proxy inputs without proxy-server", map[string]string{"EASYSFTP_PROXY_USERNAME": "jump"}, "'proxy-server' is empty"},
+		{"proxy-server without username", map[string]string{"EASYSFTP_PROXY_SERVER": "jump.example.com", "EASYSFTP_PROXY_PASSWORD": "pw"}, "'proxy-username' is required"},
+		{"proxy-server without auth", map[string]string{"EASYSFTP_PROXY_SERVER": "jump.example.com", "EASYSFTP_PROXY_USERNAME": "jump"}, "'proxy-password' or 'proxy-private-key'"},
+		{"bad proxy-port", map[string]string{"EASYSFTP_PROXY_SERVER": "jump.example.com", "EASYSFTP_PROXY_USERNAME": "jump", "EASYSFTP_PROXY_PASSWORD": "pw", "EASYSFTP_PROXY_PORT": "99999"}, "'proxy-port' must be between"},
 		{"bad dir-mode", map[string]string{"EASYSFTP_DIR_MODE": "not-octal"}, "invalid dir-mode"},
 		{"dir-mode out of range", map[string]string{"EASYSFTP_DIR_MODE": "1755"}, "invalid dir-mode"},
 		{"bad file-mode", map[string]string{"EASYSFTP_FILE_MODE": "999"}, "invalid file-mode"},
@@ -111,6 +117,43 @@ func TestLoadValidation(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestLoadProxy(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("EASYSFTP_PROXY_SERVER", "jump.example.com")
+	t.Setenv("EASYSFTP_PROXY_USERNAME", "jumper")
+	t.Setenv("EASYSFTP_PROXY_PASSWORD", "jump-pw")
+	t.Setenv("EASYSFTP_PROXY_HOST_KEY_FINGERPRINT", "SHA256:abc\nSHA256:def")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := cfg.Proxy
+	if p == nil {
+		t.Fatal("expected a proxy config")
+	}
+	if p.Server != "jump.example.com" || p.Username != "jumper" || p.Password != "jump-pw" {
+		t.Errorf("unexpected proxy config: %+v", p)
+	}
+	if p.Port != 22 {
+		t.Errorf("expected default proxy port 22, got %d", p.Port)
+	}
+	if len(p.HostKeyFingerprints) != 2 {
+		t.Errorf("expected 2 proxy fingerprints, got %v", p.HostKeyFingerprints)
+	}
+}
+
+func TestLoadNoProxyByDefault(t *testing.T) {
+	setBaseEnv(t)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Proxy != nil {
+		t.Errorf("expected no proxy config, got %+v", cfg.Proxy)
 	}
 }
 

--- a/internal/uploader/jumpserver_test.go
+++ b/internal/uploader/jumpserver_test.go
@@ -1,0 +1,123 @@
+package uploader
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// testJumpServer is an in-process SSH server that only serves direct-tcpip
+// channel forwarding, the mechanism a ProxyJump tunnel uses. It hosts no SFTP
+// subsystem at all, so a test passing through it proves the SFTP traffic
+// really flowed through the tunnel.
+type testJumpServer struct {
+	Addr          string
+	Host          string
+	Port          int
+	HostKeySHA256 string
+	forwarded     int64 // direct-tcpip channels opened, for asserting the tunnel was used
+}
+
+func startTestJumpServer(t *testing.T) *testJumpServer {
+	t.Helper()
+
+	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostSigner, err := ssh.NewSignerFromKey(hostPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sshConfig := &ssh.ServerConfig{
+		PasswordCallback: func(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
+			if conn.User() == testUser && string(password) == testPassword {
+				return nil, nil
+			}
+			return nil, errors.New("access denied")
+		},
+	}
+	sshConfig.AddHostKey(hostSigner)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { listener.Close() })
+
+	tcpAddr := listener.Addr().(*net.TCPAddr)
+	srv := &testJumpServer{
+		Addr:          listener.Addr().String(),
+		Host:          tcpAddr.IP.String(),
+		Port:          tcpAddr.Port,
+		HostKeySHA256: ssh.FingerprintSHA256(hostSigner.PublicKey()),
+	}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go srv.handleConn(conn, sshConfig)
+		}
+	}()
+	return srv
+}
+
+func (s *testJumpServer) handleConn(conn net.Conn, cfg *ssh.ServerConfig) {
+	sshConn, chans, reqs, err := ssh.NewServerConn(conn, cfg)
+	if err != nil {
+		return
+	}
+	defer sshConn.Close()
+	go ssh.DiscardRequests(reqs)
+
+	for newChannel := range chans {
+		if newChannel.ChannelType() != "direct-tcpip" {
+			newChannel.Reject(ssh.UnknownChannelType, "only direct-tcpip is served")
+			continue
+		}
+		// See RFC 4254, section 7.2 for the payload layout.
+		var d struct {
+			DestAddr string
+			DestPort uint32
+			SrcAddr  string
+			SrcPort  uint32
+		}
+		if err := ssh.Unmarshal(newChannel.ExtraData(), &d); err != nil {
+			newChannel.Reject(ssh.ConnectionFailed, "bad direct-tcpip payload")
+			continue
+		}
+		dst, err := net.Dial("tcp", net.JoinHostPort(d.DestAddr, fmt.Sprintf("%d", d.DestPort)))
+		if err != nil {
+			newChannel.Reject(ssh.ConnectionFailed, err.Error())
+			continue
+		}
+		channel, channelReqs, err := newChannel.Accept()
+		if err != nil {
+			dst.Close()
+			continue
+		}
+		atomic.AddInt64(&s.forwarded, 1)
+		go ssh.DiscardRequests(channelReqs)
+		go func() {
+			defer channel.Close()
+			defer dst.Close()
+			_, _ = io.Copy(channel, dst)
+		}()
+		go func() {
+			defer channel.Close()
+			defer dst.Close()
+			_, _ = io.Copy(dst, channel)
+		}()
+	}
+}

--- a/internal/uploader/proxyjump_test.go
+++ b/internal/uploader/proxyjump_test.go
@@ -1,0 +1,115 @@
+package uploader
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// proxyFor returns proxy settings pointing at the jump server, pinned to its
+// host key.
+func proxyFor(jump *testJumpServer) *config.Proxy {
+	return &config.Proxy{
+		Server:              jump.Host,
+		Port:                jump.Port,
+		Username:            testUser,
+		Password:            testPassword,
+		HostKeyFingerprints: []string{jump.HostKeySHA256},
+	}
+}
+
+func TestProxyJumpUpload(t *testing.T) {
+	target := startTestServer(t)
+	jump := startTestJumpServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "via bastion", "sub/a.txt": "a"})
+
+	cfg := baseConfig(target)
+	cfg.HostKeyFingerprints = []string{target.HostKeySHA256}
+	cfg.Proxy = proxyFor(jump)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 2 {
+		t.Errorf("expected 2 uploads, got %d", stats.FilesUploaded)
+	}
+	if got := readRemote(t, target, "/www/index.html"); got != "via bastion" {
+		t.Errorf("unexpected content: %q", got)
+	}
+	if atomic.LoadInt64(&jump.forwarded) == 0 {
+		t.Error("the jump server forwarded no connection; the run must have bypassed the tunnel")
+	}
+}
+
+func TestProxyJumpVerifiesJumpHostKey(t *testing.T) {
+	target := startTestServer(t)
+	jump := startTestJumpServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "x"})
+
+	cfg := baseConfig(target)
+	cfg.HostKeyFingerprints = []string{target.HostKeySHA256}
+	cfg.Proxy = proxyFor(jump)
+	cfg.Proxy.HostKeyFingerprints = []string{"SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	_, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "host key mismatch") {
+		t.Fatalf("expected a jump-host key mismatch error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "jump host") {
+		t.Errorf("the error should name the jump host hop, got %v", err)
+	}
+}
+
+func TestProxyJumpVerifiesTargetHostKey(t *testing.T) {
+	target := startTestServer(t)
+	jump := startTestJumpServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "x"})
+
+	cfg := baseConfig(target)
+	cfg.HostKeyFingerprints = []string{"SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}
+	cfg.Proxy = proxyFor(jump)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	_, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "host key mismatch") {
+		t.Fatalf("expected a target host key mismatch error through the tunnel, got %v", err)
+	}
+}
+
+func TestProxyJumpWarnsPerUnpinnedHop(t *testing.T) {
+	target := startTestServer(t)
+	jump := startTestJumpServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "x"})
+
+	cfg := baseConfig(target)
+	cfg.HostKeyFingerprints = []string{target.HostKeySHA256} // target pinned, jump not
+	cfg.Proxy = proxyFor(jump)
+	cfg.Proxy.HostKeyFingerprints = nil
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	log.mu.Lock()
+	for _, w := range log.warnings {
+		if strings.Contains(w, "proxy-host-key-fingerprint") {
+			found = true
+		}
+	}
+	log.mu.Unlock()
+	if !found {
+		t.Errorf("expected an unverified-host-key warning naming the proxy inputs, got %v", log.warnings)
+	}
+}

--- a/internal/uploader/session.go
+++ b/internal/uploader/session.go
@@ -26,8 +26,9 @@ type session struct {
 	mu         sync.Mutex
 	sshClient  *ssh.Client
 	sftpClient *sftp.Client
-	gen        int // bumped on every successful reconnect
-	reconnects int // spent so far; bounded by cfg.Retries
+	closeJump  func() // closes the jump-host transport; no-op for direct connections
+	gen        int    // bumped on every successful reconnect
+	reconnects int    // spent so far; bounded by cfg.Retries
 }
 
 // newSession dials the server and opens the initial SFTP session, retrying
@@ -35,7 +36,9 @@ type session struct {
 // input) as per-file uploads: a momentary DNS hiccup or a restarting sshd
 // should cost a short wait, not a red pipeline. Permanent failures, most
 // importantly a host key mismatch (a security signal) and an authentication
-// failure (retrying risks fail2ban-style lockouts), fail immediately.
+// failure (retrying risks fail2ban-style lockouts), fail immediately. With a
+// jump host configured, this covers either hop: a transient failure reaching
+// the bastion is retried exactly like one reaching the target.
 func newSession(ctx context.Context, cfg *config.Config, log Logger) (*session, error) {
 	var lastErr error
 	for attempt := 0; attempt <= cfg.Retries; attempt++ {
@@ -46,9 +49,9 @@ func newSession(ctx context.Context, cfg *config.Config, log Logger) (*session, 
 				return nil, err
 			}
 		}
-		sshClient, sftpClient, err := connect(cfg, log)
+		sshClient, sftpClient, closeJump, err := connect(cfg, log)
 		if err == nil {
-			return &session{cfg: cfg, log: log, sshClient: sshClient, sftpClient: sftpClient}, nil
+			return &session{cfg: cfg, log: log, sshClient: sshClient, sftpClient: sftpClient, closeJump: closeJump}, nil
 		}
 		lastErr = err
 		if !isRetryableConnect(err) {
@@ -70,6 +73,7 @@ func (e permanentError) Unwrap() error { return e.err }
 // isRetryableConnect reports whether an initial-connection failure is worth
 // another attempt. Anything tagged permanentError is not; neither is an SSH
 // authentication failure, which x/crypto/ssh only reports as a string error.
+// Both apply per hop, so a bad jump-host key or password fails fast too.
 func isRetryableConnect(err error) bool {
 	var pe permanentError
 	if errors.As(err, &pe) {
@@ -121,11 +125,12 @@ func (s *session) reconnect(ctx context.Context, gen int) (*sftp.Client, error) 
 	}
 	s.sftpClient.Close()
 	s.sshClient.Close()
-	sshClient, sftpClient, err := connect(s.cfg, s.log)
+	s.closeJump()
+	sshClient, sftpClient, closeJump, err := connect(s.cfg, s.log)
 	if err != nil {
 		return nil, fmt.Errorf("reconnecting: %w", err)
 	}
-	s.sshClient, s.sftpClient = sshClient, sftpClient
+	s.sshClient, s.sftpClient, s.closeJump = sshClient, sftpClient, closeJump
 	s.gen++
 	return s.sftpClient, nil
 }
@@ -136,6 +141,7 @@ func (s *session) close() {
 	defer s.mu.Unlock()
 	s.sftpClient.Close()
 	s.sshClient.Close()
+	s.closeJump()
 }
 
 // isConnError reports whether err looks like the connection itself died (as

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -830,32 +830,94 @@ func sendKeepalives(ctx context.Context, client func() *ssh.Client, interval tim
 	}
 }
 
-// connect dials the server and opens an SFTP session on top of SSH.
-func connect(cfg *config.Config, log Logger) (*ssh.Client, *sftp.Client, error) {
+// hop carries the connection parameters of one SSH hop: the primary server,
+// or the optional jump host in front of it. inputPrefix ("" or "proxy-")
+// names the inputs in warnings and errors, so each hop's message points at
+// the right knobs.
+type hop struct {
+	addr         string
+	user         string
+	password     string
+	privateKey   string
+	passphrase   string
+	fingerprints []string
+	knownHosts   string
+	inputPrefix  string
+}
+
+// clientConfig builds the ssh.ClientConfig for this hop, including its own
+// host key verification.
+func (h hop) clientConfig(timeout time.Duration, log Logger) (*ssh.ClientConfig, error) {
 	// Auth and host key setup errors are local configuration problems, never
 	// fixed by dialing again; tag them so the connect retry loop fails fast.
-	auth, err := authMethods(cfg)
+	auth, err := authMethods(h)
 	if err != nil {
-		return nil, nil, permanentError{err}
+		return nil, permanentError{err}
 	}
-
-	hostKeyCallback, err := hostKeyCallback(cfg, log)
+	cb, err := hostKeyCallback(h, log)
 	if err != nil {
-		return nil, nil, permanentError{err}
+		return nil, permanentError{err}
 	}
-
-	sshConfig := &ssh.ClientConfig{
-		User:            cfg.Username,
+	return &ssh.ClientConfig{
+		User:            h.user,
 		Auth:            auth,
-		HostKeyCallback: hostKeyCallback,
-		Timeout:         cfg.Timeout,
+		HostKeyCallback: cb,
+		Timeout:         timeout,
+	}, nil
+}
+
+// targetHop maps the primary connection settings onto a hop.
+func targetHop(cfg *config.Config) hop {
+	return hop{
+		addr:         net.JoinHostPort(cfg.Server, fmt.Sprintf("%d", cfg.Port)),
+		user:         cfg.Username,
+		password:     cfg.Password,
+		privateKey:   cfg.PrivateKey,
+		passphrase:   cfg.Passphrase,
+		fingerprints: cfg.HostKeyFingerprints,
+		knownHosts:   cfg.KnownHosts,
+	}
+}
+
+// jumpHop maps the proxy-* settings onto a hop.
+func jumpHop(p *config.Proxy) hop {
+	return hop{
+		addr:         net.JoinHostPort(p.Server, fmt.Sprintf("%d", p.Port)),
+		user:         p.Username,
+		password:     p.Password,
+		privateKey:   p.PrivateKey,
+		passphrase:   p.Passphrase,
+		fingerprints: p.HostKeyFingerprints,
+		knownHosts:   p.KnownHosts,
+		inputPrefix:  "proxy-",
+	}
+}
+
+// connect dials the server, optionally through the configured jump host, and
+// opens an SFTP session on top of SSH. The returned cleanup function closes
+// the jump-host transport (it is a no-op for direct connections) and must be
+// called after the SSH client is closed.
+func connect(cfg *config.Config, log Logger) (*ssh.Client, *sftp.Client, func(), error) {
+	noop := func() {}
+	target := targetHop(cfg)
+	targetConfig, err := target.clientConfig(cfg.Timeout, log)
+	if err != nil {
+		return nil, nil, noop, err
 	}
 
-	addr := net.JoinHostPort(cfg.Server, fmt.Sprintf("%d", cfg.Port))
-	log.Infof("connecting to %s as %s ...", addr, cfg.Username)
-	sshClient, err := ssh.Dial("tcp", addr, sshConfig)
-	if err != nil {
-		return nil, nil, fmt.Errorf("connecting to %s: %w", addr, err)
+	var sshClient *ssh.Client
+	cleanup := noop
+	if cfg.Proxy == nil {
+		log.Infof("connecting to %s as %s ...", target.addr, target.user)
+		sshClient, err = ssh.Dial("tcp", target.addr, targetConfig)
+		if err != nil {
+			return nil, nil, noop, fmt.Errorf("connecting to %s: %w", target.addr, err)
+		}
+	} else {
+		sshClient, cleanup, err = dialViaJump(cfg, target.addr, targetConfig, log)
+		if err != nil {
+			return nil, nil, noop, err
+		}
 	}
 
 	sftpClient, err := sftp.NewClient(sshClient,
@@ -864,49 +926,82 @@ func connect(cfg *config.Config, log Logger) (*ssh.Client, *sftp.Client, error) 
 	)
 	if err != nil {
 		sshClient.Close()
-		return nil, nil, fmt.Errorf("opening SFTP session: %w", err)
+		cleanup()
+		return nil, nil, noop, fmt.Errorf("opening SFTP session: %w", err)
 	}
-	return sshClient, sftpClient, nil
+	return sshClient, sftpClient, cleanup, nil
 }
 
-func authMethods(cfg *config.Config) ([]ssh.AuthMethod, error) {
+// dialViaJump connects to the jump host with its own auth and host key
+// verification, opens a TCP tunnel to the target through it, and runs the
+// target's SSH handshake (with the target's own host key verification) over
+// that tunnel. The returned cleanup closes the jump transport.
+func dialViaJump(cfg *config.Config, targetAddr string, targetConfig *ssh.ClientConfig, log Logger) (*ssh.Client, func(), error) {
+	jump := jumpHop(cfg.Proxy)
+	jumpConfig, err := jump.clientConfig(cfg.Timeout, log)
+	if err != nil {
+		return nil, nil, err
+	}
+	log.Infof("connecting to jump host %s as %s ...", jump.addr, jump.user)
+	jumpClient, err := ssh.Dial("tcp", jump.addr, jumpConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("connecting to jump host %s: %w", jump.addr, err)
+	}
+	log.Infof("connecting to %s as %s through the jump host ...", targetAddr, targetConfig.User)
+	conn, err := jumpClient.Dial("tcp", targetAddr)
+	if err != nil {
+		jumpClient.Close()
+		return nil, nil, fmt.Errorf("dialing %s through jump host %s: %w", targetAddr, jump.addr, err)
+	}
+	ncc, chans, reqs, err := ssh.NewClientConn(conn, targetAddr, targetConfig)
+	if err != nil {
+		conn.Close()
+		jumpClient.Close()
+		return nil, nil, fmt.Errorf("connecting to %s through jump host %s: %w", targetAddr, jump.addr, err)
+	}
+	return ssh.NewClient(ncc, chans, reqs), func() { jumpClient.Close() }, nil
+}
+
+func authMethods(h hop) ([]ssh.AuthMethod, error) {
 	var methods []ssh.AuthMethod
-	if key := strings.TrimSpace(cfg.PrivateKey); key != "" {
+	if key := strings.TrimSpace(h.privateKey); key != "" {
 		var signer ssh.Signer
 		var err error
-		if cfg.Passphrase != "" {
-			signer, err = ssh.ParsePrivateKeyWithPassphrase([]byte(key+"\n"), []byte(cfg.Passphrase))
+		if h.passphrase != "" {
+			signer, err = ssh.ParsePrivateKeyWithPassphrase([]byte(key+"\n"), []byte(h.passphrase))
 		} else {
 			signer, err = ssh.ParsePrivateKey([]byte(key + "\n"))
 		}
 		if err != nil {
-			return nil, fmt.Errorf("parsing private key: %w", err)
+			return nil, fmt.Errorf("parsing %sprivate-key: %w", h.inputPrefix, err)
 		}
 		methods = append(methods, ssh.PublicKeys(signer))
 	}
-	if cfg.Password != "" {
-		methods = append(methods, ssh.Password(cfg.Password))
+	if h.password != "" {
+		methods = append(methods, ssh.Password(h.password))
 	}
 	return methods, nil
 }
 
-func hostKeyCallback(cfg *config.Config, log Logger) (ssh.HostKeyCallback, error) {
-	want := cfg.HostKeyFingerprints
-	if len(want) == 0 && cfg.KnownHosts == "" {
-		log.Warningf("no host-key-fingerprint or known-hosts configured; the server's identity will NOT be verified. " +
-			"Run 'ssh-keyscan <server>' and set the known-hosts input (or convert with 'ssh-keygen -lf -' " +
-			"and set host-key-fingerprint) to pin it.")
+func hostKeyCallback(h hop, log Logger) (ssh.HostKeyCallback, error) {
+	want := h.fingerprints
+	if len(want) == 0 && h.knownHosts == "" {
+		// The warning fires per hop: a pinned target behind an unpinned jump
+		// host (or vice versa) still deserves a nudge for the open hop.
+		log.Warningf("no %[1]shost-key-fingerprint or %[1]sknown-hosts configured; the identity of %[2]s will NOT be verified. "+
+			"Run 'ssh-keyscan <server>' and set the %[1]sknown-hosts input (or convert with 'ssh-keygen -lf -' "+
+			"and set %[1]shost-key-fingerprint) to pin it.", h.inputPrefix, h.addr)
 		return ssh.InsecureIgnoreHostKey(), nil
 	}
 	for _, fp := range want {
 		if !strings.HasPrefix(fp, "SHA256:") {
-			return nil, fmt.Errorf("host-key-fingerprint must be a SHA256 fingerprint like 'SHA256:...', got %q", fp)
+			return nil, fmt.Errorf("%shost-key-fingerprint must be a SHA256 fingerprint like 'SHA256:...', got %q", h.inputPrefix, fp)
 		}
 	}
 	var khCallback ssh.HostKeyCallback
-	if cfg.KnownHosts != "" {
+	if h.knownHosts != "" {
 		var err error
-		if khCallback, err = knownHostsCallback(cfg.KnownHosts); err != nil {
+		if khCallback, err = knownHostsCallback(h.knownHosts); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Summary

Closes #26.

New `proxy-*` inputs mirroring the primary connection settings: `proxy-server`, `proxy-port` (default 22), `proxy-username`, `proxy-password`, `proxy-private-key`, `proxy-passphrase`, `proxy-host-key-fingerprint`, `proxy-known-hosts`. When `proxy-server` is set, easySFTP:

1. `ssh.Dial`s the jump host with its own auth and host key verification,
2. opens a `direct-tcpip` tunnel to the target via `jumpClient.Dial("tcp", targetAddr)`,
3. runs the target's SSH handshake (with the target's own host key verification) over that tunnel via `ssh.NewClientConn`.

Exactly the implementation sketch from the issue; `x/crypto/ssh` only, no new dependency. Everything downstream of `connect()` is untouched.

## Acceptance criteria

- [x] All proxy inputs plumbed `action.yml` → env → config with validation: `proxy-server` requires `proxy-username` and one of password/key; any other `proxy-*` input without `proxy-server` fails loudly (so a half-configured bastion can't silently connect directly); `proxy-port` range-checked. `proxy-passphrase` and `proxy-known-hosts` added beyond the issue's list for full symmetry with the primary inputs.
- [x] Both hops verify host keys independently. The connection code was refactored around a per-hop `hop` struct so `authMethods`/`hostKeyCallback` are shared by both hops; the unverified-host-key warning fires **per hop** and names that hop's inputs (`proxy-host-key-fingerprint` vs `host-key-fingerprint`).
- [x] Docs: new "Jump host (bastion)" section in `docs/configuration.md` + example in `docs/examples.md`.
- [x] Test: chained in-process servers (see below).

## Lifetime of the jump transport

`connect()` now returns a cleanup func that closes the jump-host transport (no-op for direct connections). The session closes it on teardown and before every reconnect, so mid-run redials re-establish the whole chain instead of leaking bastion connections. Keepalives ride the target transport, which flows through the jump TCP connection and keeps both hops alive.

## Tests

A new `testJumpServer` serves **only** `direct-tcpip` forwarding (no SFTP subsystem at all), so a passing test proves the traffic really went through the tunnel; it also counts forwarded channels.

- `TestProxyJumpUpload`: full deploy through the chain, content verified on the target, forwarded-channel count > 0.
- `TestProxyJumpVerifiesJumpHostKey` / `TestProxyJumpVerifiesTargetHostKey`: a bogus fingerprint on either hop fails with a host key mismatch (the jump-hop error names the jump host).
- `TestProxyJumpWarnsPerUnpinnedHop`: pinned target + unpinned jump warns naming `proxy-host-key-fingerprint`.
- Config: proxy parsing/validation cases plus a no-proxy-by-default check; actionmeta drift check updated.

`go test ./...` passes locally; `-race` needs cgo which is unavailable on this machine, relying on CI for the race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
