### PR TITLE
chore: document the two input drift-check lists in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,11 @@ Guiding principles for changes here:
   the `Upload via SFTP` step, parsing/validation in `internal/config/config.go`,
   a row in `docs/configuration.md`, and (if it's a real behavior change) a
   test. Don't forget `action.yml` input descriptions are user-facing docs too.
+  Two drift-check lists must also be extended, or tests fail: `wantInputs` in
+  `internal/actionmeta/actionmeta_test.go` (the actionmeta test errors on any
+  wired env var missing from it), and the cleared-env list in `setBaseEnv`
+  (`internal/config/config_test.go`), which keeps config tests hermetic when
+  the ambient environment sets `EASYSFTP_*` variables.
 
 ## Two categories of settings
 


### PR DESCRIPTION
Small working-notes update: every new `action.yml` input also needs entries in `wantInputs` (`internal/actionmeta/actionmeta_test.go`) and the cleared-env list in `setBaseEnv` (`internal/config/config_test.go`). Every input-adding PR in the current batch (#95, #96, #97, #99) had to touch both lists; recording it in CLAUDE.md saves future sessions the rediscovery.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)