### PR TITLE
fix(gha): sanitize Infof lines against workflow-command spoofing

### DIFF
--- a/internal/gha/gha.go
+++ b/internal/gha/gha.go
@@ -15,9 +15,20 @@ func escapeData(s string) string {
 	return r.Replace(s)
 }
 
-// Infof prints a plain log line.
+// sanitizeLine replaces line breaks with spaces so an interpolated value (for
+// example a local file name, which on Linux may legally contain newlines) can
+// never start a new physical log line and forge a workflow command such as
+// "::error::" or "::add-mask::". Mirrors easysftp_error in
+// scripts/action-lib.sh, which does the same for the same reason.
+func sanitizeLine(s string) string {
+	r := strings.NewReplacer("\r", " ", "\n", " ")
+	return r.Replace(s)
+}
+
+// Infof prints a plain log line. The formatted message is sanitized to a
+// single physical line; see sanitizeLine.
 func Infof(format string, args ...any) {
-	fmt.Printf(format+"\n", args...)
+	fmt.Println(sanitizeLine(fmt.Sprintf(format, args...)))
 }
 
 // Noticef prints a notice annotation.

--- a/internal/gha/gha_test.go
+++ b/internal/gha/gha_test.go
@@ -1,6 +1,7 @@
 package gha
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,44 @@ func parseGithubOutput(t *testing.T, raw string) map[string]string {
 		}
 	}
 	return out
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what
+// it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	w.Close()
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading captured stdout: %v", err)
+	}
+	return string(data)
+}
+
+// A file name containing a newline must not let the second physical line start
+// with a workflow command (::error::, ::add-mask::, ...); the runner would
+// interpret it. See issue #105.
+func TestInfofNeutralizesWorkflowCommandSpoofing(t *testing.T) {
+	name := "dist/x\n::error::deploy compromised, rotate credentials"
+	out := captureStdout(t, func() {
+		Infof("upload %s => %s", name, "/www/x\r\n::add-mask::secret")
+	})
+	if want := "upload dist/x ::error::deploy compromised, rotate credentials => /www/x  ::add-mask::secret\n"; out != want {
+		t.Errorf("Infof output = %q, want %q", out, want)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "::") {
+			t.Errorf("Infof let a physical line start with a workflow command: %q", line)
+		}
+	}
 }
 
 func TestSetOutputRoundTripsSpecialCharacters(t *testing.T) {


### PR DESCRIPTION
Fixes #105

## Problem

`gha.Infof` printed its payload raw while `Warningf`/`Errorf`/`Noticef`/`Group` percent-encode theirs. Every per-file log line interpolates local file names and remote paths into `Infof`; on Linux a file name may legally contain newlines, so a file named e.g. `dist/x\n::error::deploy compromised` produced a second physical line starting with `::error::`, which the runner interprets as a workflow command (forged annotations, and `::add-mask::` can censor arbitrary log content).

## Fix

Format the message, then replace `\r` and `\n` with spaces before printing, so a value can never start a new physical line. This mirrors what `easysftp_error` in `scripts/action-lib.sh` already does for the same reason. Spaces (rather than `%0D`/`%0A` percent-encoding) keep normal log lines readable; `Infof` output is plain text, not a workflow-command payload, so there is nothing to round-trip.

## Test

`TestInfofNeutralizesWorkflowCommandSpoofing` pins a newline-bearing file name (including the `\r\n` variant) and asserts no physical output line starts with `::`.

`go test ./...` passes locally (no C toolchain on this machine, so no `-race`; relying on CI for the race pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)