### PR TITLE
test(uploader): remove leftover debug print from the test server

### DIFF
--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -468,8 +468,7 @@ func (s *testServer) handleConn(conn net.Conn) {
 				req.Reply(ok, nil)
 				if ok {
 					server := sftp.NewRequestServer(channel, s.handlers)
-					serr := server.Serve()
-					fmt.Printf("DEBUG server.Serve on %v returned: %v\n", conn.RemoteAddr(), serr)
+					_ = server.Serve()
 					server.Close()
 					return
 				}


### PR DESCRIPTION
Fixes #101

The SFTP subsystem handler in `internal/uploader/testserver_test.go` printed a `DEBUG server.Serve on ... returned: ...` line to raw stdout for every connection, flooding `go test` output. It was left over from debugging the reconnect behavior introduced in #90. The `Serve` return value is now discarded again, as it was before that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)