### PR TITLE
fix: warn when opening the sync manifest fails

### DIFF
--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -202,6 +202,9 @@ func readManifest(client *sftp.Client, dir, name string, log Logger) manifest {
 	empty := manifest{Version: manifestVersion, Files: map[string]manifestEntry{}}
 	f, err := client.Open(path.Join(dir, name))
 	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Warningf("could not open sync manifest in %s (%v); treating as first sync", dir, err)
+		}
 		return empty
 	}
 	defer f.Close()

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -22,6 +22,34 @@ func syncConfig(srv *testServer, local string) *config.Config {
 	return cfg
 }
 
+func TestReadManifestWarnsWhenOpenFails(t *testing.T) {
+	srv := startTestServer(t, withFailOpen("/www/"+manifestName))
+	log := &recordingLogger{testLogger: testLogger{t}}
+
+	got := readManifest(srv.verifyClient(t), "/www", manifestName, log)
+
+	if len(got.Files) != 0 {
+		t.Fatalf("readManifest returned %d files after an open failure, want 0", len(got.Files))
+	}
+	if len(log.warnings) != 1 || !strings.Contains(log.warnings[0], "could not open sync manifest") {
+		t.Fatalf("expected one manifest open warning, got %v", log.warnings)
+	}
+}
+
+func TestReadManifestKeepsMissingManifestSilent(t *testing.T) {
+	srv := startTestServer(t)
+	log := &recordingLogger{testLogger: testLogger{t}}
+
+	got := readManifest(srv.verifyClient(t), "/www", manifestName, log)
+
+	if len(got.Files) != 0 {
+		t.Fatalf("readManifest returned %d files for a missing manifest, want 0", len(got.Files))
+	}
+	if len(log.warnings) != 0 {
+		t.Fatalf("missing manifest should be silent, got warnings %v", log.warnings)
+	}
+}
+
 func TestSyncIncremental(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -45,6 +46,26 @@ type testServer struct {
 
 // serverOption tweaks a testServer before it starts serving.
 type serverOption func(*testServer)
+
+// faultyOpen rejects reads of one exact path while delegating every other
+// request to the in-memory handler.
+type faultyOpen struct {
+	inner sftp.FileReader
+	path  string
+}
+
+func (f *faultyOpen) Fileread(r *sftp.Request) (io.ReaderAt, error) {
+	if r.Filepath == f.path {
+		return nil, errors.New("injected open failure")
+	}
+	return f.inner.Fileread(r)
+}
+
+func withFailOpen(path string) serverOption {
+	return func(s *testServer) {
+		s.handlers.FileGet = &faultyOpen{inner: s.handlers.FileGet, path: path}
+	}
+}
 
 // withFailRename makes the server reject every (Posix)Rename, simulating a
 // server that lets the temp upload through but cannot swap it into place.


### PR DESCRIPTION
## Summary
- keep a genuinely missing sync manifest silent as the normal first-sync case
- warn when opening the manifest fails for another reason
- add focused fault-injection coverage for both paths

## Verification
- `go test ./...`
- `go test -race ./internal/uploader`
- `go vet ./...`
- `gofmt -l .`
- `go build ./cmd/easysftp`

Closes #106