### PR TITLE
fix(sync): write the recovery manifest after a stall-timeout failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,14 @@ Look at how existing inputs are wired before adding a new one:
   this. The production retry path sidesteps it by removing the leftover temp
   file before a re-attempt, which also matters on real servers (stale
   handles/locks); keep that in mind before "simplifying" it away.
+- The stall watchdog is one-shot: once `monitor` fires (closes the connection,
+  sets `fired`), its goroutine exits, so `fired` stays true forever and a
+  watchdog passed to any later `session.do` protects nothing. `session.do`
+  deliberately refuses to redial once `fired` is set (a stalled server usually
+  just stalls again). `writeRecoveryManifest` is the one exception: it drops
+  the spent watchdog so `do` may spend one reconnect to record partial progress
+  before the run fails (issue #115). Keep this asymmetry in mind before routing
+  a new post-stall operation through `do`.
 - Run `go test -race ./...` before committing; uploads are parallelized
   (`errgroup` + `cfg.Concurrency`), so races are the most likely regression
   class in `internal/uploader`. `-race` needs cgo: on a machine without a C

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -193,9 +193,22 @@ func mergedManifest(old manifest, upload []fileItem, completed []bool, deleted [
 // is logged, not returned. It goes through sess.do so a run that failed to a
 // connection drop still records its progress on the redialed connection
 // (budget permitting).
+//
+// When the failure was a stall-timeout, sess.do would normally refuse to
+// redial (see its watch.fired short-circuit): redialing a server that stalled
+// on large transfers usually just stalls again. But the manifest is a single
+// small round-trip that will likely go through on a fresh connection even so,
+// and recording progress is exactly what saves a large deploy from
+// re-uploading everything on the retry. The watchdog has already fired (its
+// monitor goroutine has exited), so it protects nothing here anyway; dropping
+// it lets do() spend one reconnect from the shared budget for this write, then
+// the caller fails the run as before. See issue #115.
 func writeRecoveryManifest(ctx context.Context, cfg *config.Config, sess *session, watch *stallWatchdog, base string, m manifest, log Logger) {
 	if cfg.DryRun {
 		return
+	}
+	if watch != nil && watch.fired.Load() {
+		watch = nil
 	}
 	err := sess.do(ctx, watch, func(client *sftp.Client) error {
 		return writeManifest(client, base, cfg.SyncManifestName(), m)

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -589,6 +589,73 @@ func TestSyncRecoveryManifestWriteFailureIsNonFatal(t *testing.T) {
 	}
 }
 
+// A sync whose upload is killed by the stall-timeout watchdog must still
+// record its progress in the recovery manifest: sess.do refuses to redial a
+// stalled server, but the recovery write is a single small round-trip that is
+// let through on one fresh connection so the retry resumes instead of
+// re-uploading everything. See issue #115.
+func TestSyncRecoveryManifestWrittenAfterStall(t *testing.T) {
+	// The server stalls each connection after 256 KiB. A fresh connection
+	// carrying only the handshake plus the tiny manifest write stays well
+	// under that, so the recovery write goes through even though the big
+	// upload starved.
+	srv := startTestServer(t, withStallAfter(256*1024))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1", "b.txt": "1"})
+
+	cfg := syncConfig(srv, local)
+	cfg.Concurrency = 1            // a.txt completes before b.txt is attempted
+	cfg.SftpRequestConcurrency = 1 // makes the stall visible to the watchdog fast
+	cfg.StallTimeout = 1 * time.Second
+	cfg.Retries = 1 // one reconnect for the recovery write
+
+	// Seed the manifest with a healthy first sync (both files tiny).
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	// a.txt changes small; b.txt grows past the stall point.
+	writeTree(t, local, map[string]string{"a.txt": "2", "b.txt": strings.Repeat("x", 2<<20)})
+	log := &recordingLogger{testLogger: testLogger{t}}
+	_, err := Run(context.Background(), cfg, log)
+	if err == nil || !strings.Contains(err.Error(), "stalled") {
+		t.Fatalf("expected a transfer-stalled error, got %v", err)
+	}
+
+	// The recovery manifest was written despite the stall: a.txt carries its
+	// new hash, b.txt keeps the old one. Without the fix the write is refused
+	// and the manifest still shows a.txt's original hash.
+	hashNew, err := hashFile(filepath.Join(local, "a.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := readRemoteManifest(t, srv)
+	if got := m.Files["a.txt"].Hash; got != hashNew {
+		t.Fatalf("recovery manifest a.txt hash = %q, want the new upload's %q (recovery write did not run after the stall)", got, hashNew)
+	}
+	found := false
+	for _, msg := range log.infos {
+		if strings.Contains(msg, "recorded partial progress") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an info that partial progress was recorded, got %v", log.infos)
+	}
+
+	// Shrink b.txt again so a resume run runs clean: a.txt is now unchanged
+	// (skipped), only b.txt re-uploads.
+	writeTree(t, local, map[string]string{"b.txt": "3"})
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 1 || stats.FilesSkipped != 1 {
+		t.Fatalf("resume run: up=%d skip=%d, want 1/1 (only b.txt re-uploaded)", stats.FilesUploaded, stats.FilesSkipped)
+	}
+}
+
 func TestSyncDryRunChangesNothing(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()


### PR DESCRIPTION
Closes #115.

## Problem

When the stall watchdog fires, it closes the connection and `session.do` deliberately refuses to redial (a server that stalled on large transfers usually just stalls again, with the watchdog already spent). A side effect: `writeRecoveryManifest` also goes through `session.do`, so a stall-induced upload/delete failure could **not** record the files that did complete. The next run then re-uploaded everything this run had already transferred, exactly the case that hurts most (large deploys behind a flaky server).

## Decision (the `needs-check` question)

The issue asked whether redialing a server we just declared stalled is wise, or whether fail-fast simplicity should win (YAGNI). Call: **do the redial, but only for the recovery-manifest write.**

- The recovery manifest is a single small round-trip. The stall was about a large transfer saturating the SSH window, not the server being dead; a fresh connection with fresh windows will almost certainly get a few-KB write through. If the server really is dead, the redial itself fails at dial time (bounded by the reconnect budget) and we log and move on, same graceful degradation as before.
- No stall protection is lost: the watchdog is one-shot. Once it fires, its `monitor` goroutine has exited, so passing it to a later `session.do` protects nothing anyway. Dropping it just lets `do` spend one reconnect from the shared budget.
- The run still fails afterwards, exactly as today. This only changes whether progress is recorded on the way down.

## Change

One guard in `writeRecoveryManifest`: if the watchdog has fired, drop it before calling `session.do`. Non-stall failures (plain connection drops) are unchanged, they still pass the live watchdog and redial normally.

## Test

`TestSyncRecoveryManifestWrittenAfterStall`: a sync whose big-file upload is killed by the stall-timeout, asserting the recovery manifest is written on a fresh connection (the completed file carries its new hash) and that a resume run only re-uploads the file that had failed. Verified it fails without the fix (manifest keeps the stale hash) and passes with it.

The existing generic promise in `docs/strategies.md` ("a run that fails partway still records what it actually changed ... so a retried deploy resumes where it left off") now holds even for the stall case, which was previously the one exception, so no doc wording change was needed.

## Notes

- `-race` could not run locally (no cgo toolchain, as CLAUDE.md anticipates); relying on CI for the race pass. `go test ./...` passes.
- Added a CLAUDE.md note about the watchdog being one-shot and the `session.do` post-stall asymmetry, since it is a subtle invariant for anyone touching the stall/reconnect seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)