### PR TITLE
refactor(transfer): group the upload chain's run-wide invariants into transferEnv

### DIFF
--- a/internal/uploader/retry.go
+++ b/internal/uploader/retry.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"sync/atomic"
 	"time"
 )
 
@@ -20,7 +19,8 @@ import (
 // path (see uploadFile) so two planned transfers never race over the same
 // temporary name, even if one target's path happens to literally be
 // another's plus tmpSuffix.
-func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.FileMode, sess *session, retries int, watch *stallWatchdog, log Logger, modeWarned, timesWarned *atomic.Bool) (int64, error) {
+func uploadFileWithRetry(ctx context.Context, env *transferEnv, f fileItem, index int, mode fs.FileMode) (int64, error) {
+	sess, watch, log, retries := env.sess, env.watch, env.log, env.cfg.Retries
 	var lastErr error
 	for attempt := 0; attempt <= retries; attempt++ {
 		if attempt > 0 {
@@ -37,7 +37,7 @@ func uploadFileWithRetry(ctx context.Context, f fileItem, index int, mode fs.Fil
 			// fresh attempt starts from a clean slate; harmless when absent.
 			_ = client.Remove(fmt.Sprintf("%s%s.%d", f.remotePath, tmpSuffix, index))
 		}
-		n, err := uploadFile(ctx, f, index, mode, client, watch, log, modeWarned, timesWarned)
+		n, err := uploadFile(ctx, env, f, index, mode, client)
 		if err == nil {
 			return n, nil
 		}

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -21,6 +21,25 @@ import (
 // rename stays on one filesystem and is atomic.
 const tmpSuffix = ".easysftp-tmp"
 
+// transferEnv carries the run-wide invariants that every level of the upload
+// call chain re-threads to the next (the session, the stall watchdog, the
+// logger and the two warn-once flags). It is built once in uploadFiles and
+// passed down, so per-file positions stay short and, in particular, the two
+// adjacent *atomic.Bool flags can no longer be transposed at a call site: they
+// are named struct fields instead of interchangeable positional arguments.
+type transferEnv struct {
+	cfg   *config.Config
+	sess  *session
+	watch *stallWatchdog
+	log   Logger
+	// modeWarned is armed only when file-mode is an explicit override; a
+	// mirrored local mode (the default) stays nil and warns silently. See
+	// uploadFile.
+	modeWarned *atomic.Bool
+	// timesWarned doubles as the preserve-times switch: nil means off.
+	timesWarned *atomic.Bool
+}
+
 // uploadFiles creates the needed remote directories and uploads files in
 // parallel (or, in dry-run mode, only logs what it would do). With
 // skipUnchanged set, a file whose remote counterpart already exists with the
@@ -51,18 +70,17 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(cfg.Concurrency)
 	results := make([]int64, len(files))
+	env := &transferEnv{cfg: cfg, sess: sess, watch: watch, log: log}
 	// modeWarned is only armed when file-mode is an explicit override: a
 	// mirrored local mode (the default) stays silent on failure, as before.
-	var modeWarned *atomic.Bool
 	if cfg.FileMode != nil {
-		modeWarned = new(atomic.Bool)
+		env.modeWarned = new(atomic.Bool)
 	}
 	// timesWarned doubles as the preserve-times switch: nil means off. The
 	// user explicitly asked for preserved times, so a refusing server warns
 	// (once per run); staying silent would defeat the point of the input.
-	var timesWarned *atomic.Bool
 	if cfg.PreserveTimes {
-		timesWarned = new(atomic.Bool)
+		env.timesWarned = new(atomic.Bool)
 	}
 
 	for i, f := range files {
@@ -96,7 +114,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 			if cfg.FileMode != nil {
 				mode = *cfg.FileMode
 			}
-			n, err := uploadFileWithRetry(ctx, f, i, mode, sess, cfg.Retries, watch, log, modeWarned, timesWarned)
+			n, err := uploadFileWithRetry(ctx, env, f, i, mode)
 			if err != nil {
 				return err
 			}
@@ -122,7 +140,8 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 // temporary sibling and, only once that fully succeeds, renames it over the
 // target. Any failure removes the temporary file so a broken or partial upload
 // never replaces the live file and no debris is left behind.
-func uploadFile(ctx context.Context, f fileItem, index int, mode fs.FileMode, client *sftp.Client, watch *stallWatchdog, log Logger, modeWarned, timesWarned *atomic.Bool) (int64, error) {
+func uploadFile(ctx context.Context, env *transferEnv, f fileItem, index int, mode fs.FileMode, client *sftp.Client) (int64, error) {
+	watch, log := env.watch, env.log
 	// Active per attempt (not around the whole retry loop) so retry backoff
 	// sleeps do not count as transfer silence.
 	if watch != nil {
@@ -164,7 +183,7 @@ func uploadFile(ctx context.Context, f fileItem, index int, mode fs.FileMode, cl
 	// override when set. Some servers reject SETSTAT; an explicit override
 	// warns once per run so the user knows it isn't taking effect, but a
 	// mirrored local mode stays silent as before.
-	if cerr := client.Chmod(tmpPath, mode); cerr != nil && modeWarned != nil && !modeWarned.Swap(true) {
+	if cerr := client.Chmod(tmpPath, mode); cerr != nil && env.modeWarned != nil && !env.modeWarned.Swap(true) {
 		log.Warningf("could not set file-mode %04o on %s (server may reject SETSTAT); not warning again this run: %v", mode, f.remotePath, cerr)
 	}
 
@@ -176,9 +195,9 @@ func uploadFile(ctx context.Context, f fileItem, index int, mode fs.FileMode, cl
 	// preserve-times (timesWarned non-nil): keep the local modification time
 	// instead of "now". After the rename, so the request targets the final
 	// path; a failure warns once per run and never fails the deploy.
-	if timesWarned != nil {
+	if env.timesWarned != nil {
 		mtime := time.Unix(f.mtime, 0)
-		if cerr := client.Chtimes(f.remotePath, mtime, mtime); cerr != nil && !timesWarned.Swap(true) {
+		if cerr := client.Chtimes(f.remotePath, mtime, mtime); cerr != nil && !env.timesWarned.Swap(true) {
 			log.Warningf("could not preserve the modification time on %s (server may reject SETSTAT); not warning again this run: %v", f.remotePath, cerr)
 		}
 	}


### PR DESCRIPTION
Closes #111.

## Problem

The upload call chain threaded 9-10 positional parameters at every level, most of them the same run-wide invariants (`sess`, `watch`, `log`, the two warn-once `*atomic.Bool` flags) re-passed down each hop:

```go
func uploadFiles(ctx, cfg, sess, files, dirs, stats, verb, watch, skipUnchanged, log) ([]bool, error)
func uploadFileWithRetry(ctx, f, index, mode, sess, retries, watch, log, modeWarned, timesWarned) (int64, error)
func uploadFile(ctx, f, index, mode, client, watch, log, modeWarned, timesWarned) (int64, error)
```

The two adjacent `*atomic.Bool` parameters were the sharpest edge: swapping `modeWarned` and `timesWarned` at a call site compiles fine and only misdirects which warning fires, a bug no type checker catches.

## Change

Group the run-wide invariants into a small `transferEnv` struct, built once in `uploadFiles` and passed down. Per-file values stay positional:

```go
func uploadFileWithRetry(ctx, env, f, index, mode) (int64, error)   // was 10 params
func uploadFile(ctx, env, f, index, mode, client) (int64, error)    // was 9 params
```

The two warn-once flags are now **named struct fields**, so the transposition class of bug is gone by construction.

`uploadFiles` keeps its signature: it is the natural construction point (the flags are armed there, once per call, preserving today's warn-scope exactly), and its own arguments are largely genuine per-call values.

## Scope

Kept deliberately narrow (KISS / one-issue-one-PR):
- `transferEnv` is transfer-specific (it carries `modeWarned`/`timesWarned`, which the non-transfer phases have no use for). The broader `session.do` / `createRemoteDirs` / `listRemoteContents` seam the issue's follow-up comment mentions (`sess`/`watch`/`ctx` traveling together) is left as-is; folding those together is a separate, wider change.
- #103 (buildPlan's positional parameters) is a distinct function and is left for its own PR.

## Verification

No behavior change intended. `go build`, `go vet` and `go test ./...` all pass; the existing `uploader_test.go`, `retry`/`reconnect` and `preservetimes_test.go` tests pin the behaviors involved. `-race` could not run locally (no cgo toolchain, as CLAUDE.md anticipates); relying on CI for the race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)