### PR TITLE
refactor(plan): group buildPlan's walk-shaping arguments into planOptions

### DIFF
--- a/internal/uploader/planner.go
+++ b/internal/uploader/planner.go
@@ -48,25 +48,37 @@ func hasNegation(lines []string) bool {
 	return false
 }
 
+// planOptions carries the ignore/walk-shaping inputs buildPlan needs beyond
+// the pair and strategy it is planning: the matcher and its two derived knobs
+// (pruneDirs, verbose) plus the effective manifest name. Grouping them keeps
+// buildPlan's signature short and, in particular, takes the easy-to-transpose
+// bool and nil-able Logger out of the positional argument list (they are named
+// fields here instead).
+//
+//   - pruneDirs: when set, a directory that itself matches the ignore patterns
+//     is skipped entirely instead of descended into, so an ignored
+//     node_modules/ with hundreds of thousands of entries costs one match
+//     instead of a full walk. Callers must clear it when the patterns contain
+//     "!" re-includes, which could re-include files below an otherwise ignored
+//     directory.
+//   - verbose: when non-nil, gets one line per ignore decision (which pattern
+//     excluded which file or directory), the detail needed to debug patterns.
+//   - manifestName: the effective sync manifest file name; a local file by that
+//     name is never uploaded, so a target's own manifest can't be clobbered.
+type planOptions struct {
+	matcher      *ignore.GitIgnore
+	pruneDirs    bool
+	verbose      Logger
+	manifestName string
+}
+
 // buildPlan walks the local side of an upload pair and computes the remote
 // file and directory layout, honoring the ignore patterns. It does not touch
 // the network, so config/path errors surface before a connection is made.
 // Content hashing for the sync strategy happens later, once connected: see
 // executeSync.
-//
-// With pruneDirs set, a directory that itself matches the ignore patterns is
-// skipped entirely instead of descended into, so an ignored node_modules/ with
-// hundreds of thousands of entries costs one match instead of a full walk.
-// Callers must clear it when the patterns contain "!" re-includes, which could
-// re-include files below an otherwise ignored directory.
-//
-// verbose, when non-nil, gets one line per ignore decision (which pattern
-// excluded which file or directory), the level of detail needed to debug
-// ignore patterns.
-//
-// manifestName is the effective sync manifest file name; a local file by that
-// name is never uploaded, so a target's own manifest can't be clobbered.
-func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore.GitIgnore, pruneDirs bool, verbose Logger, manifestName string) (plan, error) {
+func buildPlan(pair config.UploadPair, strategy config.Strategy, opts planOptions) (plan, error) {
+	matcher, verbose := opts.matcher, opts.verbose
 	p := plan{pair: pair, strategy: strategy}
 	remoteBase := normalizeRemote(pair.Remote)
 
@@ -117,7 +129,7 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore
 		rel = filepath.ToSlash(rel)
 		if d.IsDir() {
 			// The trailing slash lets directory-only patterns ("dist/") match.
-			if pruneDirs && rel != "." {
+			if opts.pruneDirs && rel != "." {
 				if matched, pat := matcher.MatchesPathHow(rel + "/"); matched {
 					if verbose != nil {
 						verbose.Infof("skip %s/ and everything below it (ignore pattern %q)", rel, pat.Line)
@@ -127,7 +139,7 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore
 			}
 			return nil
 		}
-		if rel == manifestName {
+		if rel == opts.manifestName {
 			return nil
 		}
 		if matched, pat := matcher.MatchesPathHow(rel); matched {

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -78,7 +78,12 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		if cfg.Verbose() {
 			verbose = log
 		}
-		p, err := buildPlan(pair, st, matcher, !hasNegation(lines), verbose, cfg.SyncManifestName())
+		p, err := buildPlan(pair, st, planOptions{
+			matcher:      matcher,
+			pruneDirs:    !hasNegation(lines),
+			verbose:      verbose,
+			manifestName: cfg.SyncManifestName(),
+		})
 		if err != nil {
 			return stats, err
 		}

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -827,7 +827,7 @@ func TestIgnoredDirectoryIsPruned(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(filepath.Join(local, "node_modules"), 0o755) })
 
 	matcher := ignore.CompileIgnoreLines("node_modules/")
-	p, err := buildPlan(config.UploadPair{Local: local, Remote: "/www"}, config.StrategyOverlay, matcher, true, nil, manifestName)
+	p, err := buildPlan(config.UploadPair{Local: local, Remote: "/www"}, config.StrategyOverlay, planOptions{matcher: matcher, pruneDirs: true, manifestName: manifestName})
 	if err != nil {
 		t.Fatalf("walk descended into the pruned directory: %v", err)
 	}
@@ -899,7 +899,7 @@ func BenchmarkBuildPlanIgnoredTree(b *testing.B) {
 	}{{"pruned", true}, {"unpruned", false}} {
 		b.Run(bench.name, func(b *testing.B) {
 			for b.Loop() {
-				if _, err := buildPlan(pair, config.StrategyOverlay, matcher, bench.prune, nil, manifestName); err != nil {
+				if _, err := buildPlan(pair, config.StrategyOverlay, planOptions{matcher: matcher, pruneDirs: bench.prune, manifestName: manifestName}); err != nil {
 					b.Fatal(err)
 				}
 			}


### PR DESCRIPTION
Closes #103.

## Problem

Three PRs merged in sequence (#93 directory pruning, #96 log-level, #97 manifest-name) each added a parameter to `buildPlan`, which had grown to six positional arguments:

```go
func buildPlan(pair config.UploadPair, strategy config.Strategy, matcher *ignore.GitIgnore, pruneDirs bool, verbose Logger, manifestName string) (plan, error)
```

The `bool` (`pruneDirs`) and the nil-able `Logger` (`verbose`) sitting adjacent were especially easy to transpose at a call site, and the test call sites passed `true, nil, manifestName` positionally.

## Change

Group the ignore/walk-shaping inputs into a `planOptions` struct:

```go
type planOptions struct {
	matcher      *ignore.GitIgnore
	pruneDirs    bool
	verbose      Logger
	manifestName string
}

func buildPlan(pair config.UploadPair, strategy config.Strategy, opts planOptions) (plan, error)
```

`pair` and `strategy` stay positional (they are the subject being planned, not walk-shaping knobs). The `bool` and `Logger` are now named struct fields, so the transposition is impossible by construction. The three call sites (one production, two test) read as keyed literals.

## Verification

No behavior change intended. `go build`, `go vet`, `gofmt` and `go test ./...` all pass; `TestIgnoredDirectoryIsPruned`, `TestVerboseExplainsIgnoreDecisions` and `TestSyncCustomManifestName` pin the three behaviors involved.

Companion to #111 (the transfer call chain's parameter creep), addressed separately in #119 per one-issue-one-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)