### PR TITLE
feat!: v3 configuration model (inline vs config file, no mixed mode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,14 +105,14 @@ jobs:
       - name: Dry run
         uses: ./
         with:
-          build-mode: source
-          server: localhost
+          host: localhost
           port: 2222
           username: demo
           password: demopass
-          host-key-fingerprint: ${{ steps.hostkey.outputs.fingerprints }}
-          uploads: ./selftest-site/ => /upload/
-          ignore: "*.log"
+          host-key: ${{ steps.hostkey.outputs.fingerprints }}
+          source: ./selftest-site/
+          target: /upload/
+          exclude: "*.log"
           dry-run: true
 
       - name: Verify dry run changed nothing
@@ -126,14 +126,14 @@ jobs:
         id: upload
         uses: ./
         with:
-          build-mode: source
-          server: localhost
+          host: localhost
           port: 2222
           username: demo
           password: demopass
-          host-key-fingerprint: ${{ steps.hostkey.outputs.fingerprints }}
-          uploads: ./selftest-site/ => /upload/
-          ignore: "*.log"
+          host-key: ${{ steps.hostkey.outputs.fingerprints }}
+          source: ./selftest-site/
+          target: /upload/
+          exclude: "*.log"
 
       - name: Verify upload
         run: |
@@ -149,68 +149,73 @@ jobs:
       - name: Plant stale remote file
         run: docker exec sftp sh -c 'echo stale > /home/demo/upload/stale.html && chown demo /home/demo/upload/stale.html'
 
-      - name: Upload with clean strategy
+      - name: Upload with clean mode
         id: clean-upload
         uses: ./
         with:
-          build-mode: source
-          server: localhost
+          host: localhost
           port: 2222
           username: demo
           password: demopass
-          host-key-fingerprint: ${{ steps.hostkey.outputs.fingerprints }}
-          uploads: ./selftest-site/ => /upload/
-          ignore: "*.log"
-          strategy: clean
+          host-key: ${{ steps.hostkey.outputs.fingerprints }}
+          source: ./selftest-site/
+          target: /upload/
+          exclude: "*.log"
+          mode: clean
 
-      - name: Verify clean strategy
+      - name: Verify clean mode
         run: |
           if docker exec sftp test -e /home/demo/upload/stale.html; then
-            echo "::error::stale file survived the clean strategy"
+            echo "::error::stale file survived the clean mode"
             exit 1
           fi
           docker exec sftp test -f /home/demo/upload/index.html
           [ "${{ steps.clean-upload.outputs.files-deleted }}" -ge 1 ]
 
-      # config-file end-to-end: unit tests set EASYSFTP_* variables directly
+      # config-mode end-to-end: unit tests set EASYSFTP_* variables directly
       # and never see action.yml's declared defaults; only a real composite
-      # run does. This is how #62 (a declared default tripping the config-file
+      # run does. This is how #62 (a declared default tripping the config
       # mutual-exclusion check) shipped despite green CI.
-      - name: Create config-file deployment
+      - name: Create config-mode deployment
         run: |
           mkdir -p selftest-docs
           echo "# docs" > selftest-docs/readme.md
-          cat > selftest-config.yml <<'EOF'
-          version: 1
-          ignore:
-            - "*.log"
-          targets:
-            - local: ./selftest-site/
-              remote: /upload/cfg-site/
-            - local: ./selftest-docs/
-              remote: /upload/cfg-docs/
-              strategy: clean
-          EOF
+          {
+            echo 'version: 3'
+            echo 'connection:'
+            echo '  host: localhost'
+            echo '  port: 2222'
+            echo '  username: demo'
+            echo '  host_key: |'
+            echo "${{ steps.hostkey.outputs.fingerprints }}" | sed 's/^/    /'
+            echo 'defaults:'
+            echo '  exclude:'
+            echo '    - "*.log"'
+            echo 'deployments:'
+            echo '  site:'
+            echo '    source: ./selftest-site/'
+            echo '    target: /upload/cfg-site/'
+            echo '  docs:'
+            echo '    source: ./selftest-docs/'
+            echo '    target: /upload/cfg-docs/'
+            echo '    mode: clean'
+          } > selftest-config.yml
+          cat selftest-config.yml
 
-      - name: Deploy via config-file
+      - name: Deploy via config file
         id: cfgfile
         uses: ./
         with:
-          build-mode: source
-          server: localhost
-          port: 2222
-          username: demo
           password: demopass
-          host-key-fingerprint: ${{ steps.hostkey.outputs.fingerprints }}
-          config-file: selftest-config.yml
+          config: selftest-config.yml
 
-      - name: Verify config-file deploy
+      - name: Verify config-mode deploy
         run: |
           docker exec sftp test -f /home/demo/upload/cfg-site/index.html
           docker exec sftp test -f /home/demo/upload/cfg-site/assets/style.css
           docker exec sftp test -f /home/demo/upload/cfg-docs/readme.md
           if docker exec sftp test -e /home/demo/upload/cfg-site/debug.log; then
-            echo "::error::config-file global ignore was not applied"
+            echo "::error::config-file default exclude was not applied"
             exit 1
           fi
           [ "${{ steps.cfgfile.outputs.files-uploaded }}" = "3" ]
@@ -221,15 +226,15 @@ jobs:
         id: sync1
         uses: ./
         with:
-          build-mode: source
-          server: localhost
+          host: localhost
           port: 2222
           username: demo
           password: demopass
-          host-key-fingerprint: ${{ steps.hostkey.outputs.fingerprints }}
-          uploads: ./selftest-site/ => /upload/sync/
-          ignore: "*.log"
-          strategy: sync
+          host-key: ${{ steps.hostkey.outputs.fingerprints }}
+          source: ./selftest-site/
+          target: /upload/sync/
+          exclude: "*.log"
+          mode: sync
 
       - name: Verify first sync wrote the manifest
         run: |
@@ -245,15 +250,15 @@ jobs:
         id: sync2
         uses: ./
         with:
-          build-mode: source
-          server: localhost
+          host: localhost
           port: 2222
           username: demo
           password: demopass
-          host-key-fingerprint: ${{ steps.hostkey.outputs.fingerprints }}
-          uploads: ./selftest-site/ => /upload/sync/
-          ignore: "*.log"
-          strategy: sync
+          host-key: ${{ steps.hostkey.outputs.fingerprints }}
+          source: ./selftest-site/
+          target: /upload/sync/
+          exclude: "*.log"
+          mode: sync
 
       - name: Verify second sync deleted the removed file and skipped the rest
         run: |
@@ -271,14 +276,54 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          build-mode: source
-          server: localhost
+          host: localhost
           port: 2222
           username: demo
           password: demopass
-          host-key-fingerprint: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          host-key: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          source: ./selftest-site/
+          target: /upload/
+
+      - name: Verify missing host key is rejected without opt-in
+        id: nokey
+        continue-on-error: true
+        uses: ./
+        with:
+          host: localhost
+          port: 2222
+          username: demo
+          password: demopass
+          source: ./selftest-site/
+          target: /upload/
+
+      - name: Verify allow-any-host-key opt-in connects
+        id: anykey
+        uses: ./
+        with:
+          host: localhost
+          port: 2222
+          username: demo
+          password: demopass
+          allow-any-host-key: "true"
+          source: ./selftest-site/
+          target: /upload/anykey/
+          exclude: "*.log"
+          dry-run: true
+
+      - name: Verify removed v2 input fails with a migration hint
+        id: v2input
+        continue-on-error: true
+        uses: ./
+        with:
+          host: localhost
+          port: 2222
+          username: demo
+          password: demopass
+          host-key: ${{ steps.hostkey.outputs.fingerprints }}
           uploads: ./selftest-site/ => /upload/
 
-      - name: Assert wrong host key failed
+      - name: Assert the failure cases failed
         run: |
           [ "${{ steps.badkey.outcome }}" = "failure" ]
+          [ "${{ steps.nokey.outcome }}" = "failure" ]
+          [ "${{ steps.v2input.outcome }}" = "failure" ]

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
           mkdir -p _site/content
           cp -r site/. _site/
           cp docs/configuration.md docs/strategies.md docs/examples.md \
-             docs/security.md docs/troubleshooting.md _site/content/
+             docs/security.md docs/troubleshooting.md docs/migration-v3.md _site/content/
           cp CONTRIBUTING.md _site/content/contributing.md
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -3,30 +3,52 @@
 [![CI](https://github.com/eiserv/easySFTP/actions/workflows/ci.yml/badge.svg)](https://github.com/eiserv/easySFTP/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Fast, secure and simple SFTP uploads for GitHub Actions.**
+**Fast, secure and boring SFTP deploys for GitHub Actions.**
 
-Deploy your build output to any SFTP server, from a three-line workflow step
-up to fully configured multi-target deployments.
+easySFTP uploads your build output to any SFTP server. The common case is a
+few self-explanatory lines; complex, professional setups stay fully
+configurable through one optional config file.
 
-- ⚡ **Fast**: release tags use a prebuilt, checksum-verified Go binary by
-  default, and files are transferred in parallel with concurrent SFTP write
-  requests per file.
-- 🔒 **Secure**: optional host key pinning verifies the server's identity;
-  atomic per-file uploads never leave half-written files; credentials are only
-  ever read from environment variables.
-- 🧩 **Simple, but configurable**: sensible defaults for the simple case;
-  gitignore-style excludes, sync/clean strategies, delete guards, dry runs,
-  retries and outputs for the complex ones.
-- 🖥️ **Cross-platform**: native amd64 and arm64 binaries for Linux, macOS and
-  Windows, with no Docker required.
+## Quick start
+
+Add two secrets to your repository (`SFTP_USERNAME`, `SFTP_PASSWORD`), pin the
+server's host key, and deploy a directory:
+
+```yaml
+- name: Deploy via SFTP
+  uses: eiserv/easySFTP@v3
+  with:
+    host: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    password: ${{ secrets.SFTP_PASSWORD }}
+    host-key: ${{ secrets.SFTP_HOST_KEY }}
+    source: dist
+    target: /var/www/html
+```
+
+That's the whole thing. You only need to understand four things: where the
+server is, how to authenticate, what to upload, and where to put it.
+
+Get the host key once with `ssh-keyscan sftp.example.com | ssh-keygen -lf -`
+and store the `SHA256:...` line(s) as the `SFTP_HOST_KEY` secret. (Without it,
+the deploy fails rather than trusting an unverified server; you can opt out
+with `allow-any-host-key: true`, but that allows man-in-the-middle attacks.)
+
+> **Not just simple deploys.** easySFTP is boring on purpose for the common
+> case, but complex and professional setups are fully supported through an
+> optional [config file](#need-more-multiple-deployments-and-advanced-control):
+> multiple deployment targets, per-target modes, proxy/bastion connections,
+> delete guards, advanced excludes, permissions, retries and timeouts,
+> performance tuning, and sync-manifest configuration. Start inline; add a
+> config file when you actually need one.
 
 ## Table of contents
 
-- [Why easySFTP?](#why-easysftp)
 - [Quick start](#quick-start)
+- [Why easySFTP?](#why-easysftp)
 - [Inputs & outputs](#inputs--outputs)
-- [Strategies](#strategies)
-- [Config file for multiple targets](#config-file-for-multiple-targets)
+- [Deployment modes](#deployment-modes)
+- [Need more? Multiple deployments and advanced control](#need-more-multiple-deployments-and-advanced-control)
 - [Security](#security)
 - [Documentation](#documentation)
 - [Versioning](#versioning)
@@ -55,7 +77,7 @@ job:
 | Skip unchanged files | yes (SHA256 manifest) | no | yes (state file) | partial (rsync) | yes (MD5 hashes) |
 | Delete removed files | yes (tracked, via sync) | yes (full wipe) | yes | yes (full wipe) | yes (tracked) |
 | Delete safety guards | yes (root refusal, max_deletes) | no | no | no | no |
-| Multiple targets / strategies | yes (config file) | multiple mappings | single directory | single directory | single directory |
+| Multiple targets / modes | yes (config file) | multiple mappings | single directory | single directory | single directory |
 | Dry run | yes | no | yes | no | no |
 | Actively maintained | yes | last release 2024 | yes | yes | yes |
 
@@ -80,51 +102,33 @@ no-longer-maintained [Dylan700/sftp-upload-action][dylan]:
 [wlixcc]: https://github.com/wlixcc/SFTP-Deploy-Action
 [wang]: https://github.com/wangyucode/sftp-upload-action
 
-## Quick start
-
-```yaml
-- name: Deploy via SFTP
-  uses: eiserv/easySFTP@v2
-  with:
-    server: sftp.example.com
-    username: ${{ secrets.SFTP_USERNAME }}
-    password: ${{ secrets.SFTP_PASSWORD }}
-    uploads: ./dist/ => /var/www/html/
-```
-
-That's it. Everything else is optional. More recipes (key auth, multi-target
-deploys, PR previews, `.sftpignore`) live in [docs/examples.md](docs/examples.md).
-
-Upgrading from v1? The only breaking change is that `delete: true` became
-`strategy: clean`; everything else works unchanged.
-
 ## Inputs & outputs
 
-The most used inputs:
+Inline mode uses a small, self-explanatory set of inputs:
 
 | Input | Default | Description |
 |---|---|---|
-| `build-mode` | `prebuilt` | `prebuilt` downloads and verifies the release binary; `source` installs Go and compiles this checkout. |
-| `server` / `port` / `username` | - / `22` / - | Where and as whom to connect. |
+| `host` / `port` / `username` | - / `22` / - | Where and as whom to connect. |
 | `password` / `private-key` / `passphrase` | - | Authentication, at least one of password/key. **Use secrets.** |
-| `host-key-fingerprint` | - | Pin the server's SHA256 host key(s). **Strongly recommended.** |
-| `uploads` | - | One `local => remote` mapping per line; directories are recursive. |
-| `strategy` | `overlay` | How the remote side is reconciled: `overlay`, `sync` or `clean`. |
-| `ignore` / `ignore-from` | - | Gitignore-style excludes (inline / from a file). |
+| `host-key` / `known-hosts` | - | Pin the server's host key. **Required** (or opt out with `allow-any-host-key`). |
+| `source` / `target` | - | Local path to upload, and where it goes on the server. |
+| `mode` | `overlay` | How the remote side is reconciled: `overlay`, `sync` or `clean`. |
+| `exclude` | - | Gitignore-style excludes, one per line. |
+| `config` | - | Path to a YAML config file (replaces all inline connection/deployment inputs). |
 | `dry-run` | `false` | Log what would happen, change nothing. |
-| `concurrency` / `retries` / `timeout` | `4` / `2` / `30` | Parallelism, per-file retries, connection timeout (s). |
+| `log-level` | `normal` | `normal`, `verbose` (per-file lines) or `debug` (exclude decisions). |
 
 Outputs: `files-uploaded`, `files-deleted`, `files-skipped`, `bytes-uploaded`,
 `duration-ms`, plus a summary table in the job summary. If a transfer fails
 partway, the outputs contain the progress completed before the failure and the
 summary is marked as failed.
 
-➡ Full reference with every input, output and rule:
+➡ Full reference with every input, the config file, and every rule:
 [docs/configuration.md](docs/configuration.md)
 
-## Strategies
+## Deployment modes
 
-| Strategy | Uploads | Deletes | Use for |
+| Mode | Uploads | Deletes | Use for |
 |---|---|---|---|
 | `overlay` (default) | all files | nothing | adding/updating files, leaving everything else in place |
 | `sync` | new & changed files | files a previous sync uploaded but that are now gone locally | keeping a directory an exact mirror of your build, safely |
@@ -132,41 +136,67 @@ summary is marked as failed.
 
 `sync` is manifest-based: it only ever deletes files it uploaded itself, skips
 unchanged files by content hash, and only transfers what changed on re-deploys.
-Destructive strategies are protected by [delete guards](docs/strategies.md#delete-guards):
+Destructive modes are protected by [delete guards](docs/strategies.md#delete-guards):
 the remote root is always refused, and `max_deletes` caps how much a single run
 may delete. Preview anything with `dry-run: true`.
 
 ➡ Details, manifest semantics and guard rules: [docs/strategies.md](docs/strategies.md)
 
-## Config file for multiple targets
+## Need more? Multiple deployments and advanced control
 
-Multiple targets with different strategies? Point `config-file` at a YAML file
-(connection settings stay in inputs/secrets):
+Point `config` at a YAML file. In config mode **every** non-secret setting
+lives in that one file (connection included); only credentials, `dry-run` and
+`log-level` stay in the workflow. There is no mixed mode and no precedence to
+reason about.
+
+```yaml
+- uses: eiserv/easySFTP@v3
+  with:
+    config: .github/easysftp.yml
+    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
+```
 
 ```yaml
 # .github/easysftp.yml
-version: 1
-guards:
-  max_deletes: 200
-targets:
-  - local: ./dist/
-    remote: /var/www/html/
-    strategy: sync
-  - local: ./docs/
-    remote: /var/www/docs/
-    strategy: clean
+version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: |
+    SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+defaults:
+  mode: sync
+  exclude:
+    - "*.map"
+safety:
+  max_deletes: 500
+deployments:
+  website:
+    source: dist
+    target: /var/www/html
+  documentation:
+    source: docs/build
+    target: /var/www/docs
+    mode: clean
 ```
 
-A JSON Schema for editor autocomplete/validation is bundled. See
-[docs/configuration.md](docs/configuration.md#the-yaml-config-file) and the
+The config file supports named deployments, per-target modes and excludes,
+proxy/bastion connections, delete guards, permissions, retries/timeouts,
+performance tuning and sync-manifest settings. A JSON Schema for editor
+autocomplete/validation is bundled. See
+[docs/configuration.md](docs/configuration.md#the-config-file) and the
 commented [example config](docs/easysftp.example.yml).
+
+**Upgrading from v2?** The inputs were renamed and the advanced knobs moved
+into the config file. See the [v3 migration guide](docs/migration-v3.md).
 
 ## Security
 
 Two rules cover most of it:
 
-1. **Pin the host key.** Without `host-key-fingerprint`, any server is
-   accepted. Set it so a man-in-the-middle fails the deploy instead:
+1. **Pin the host key.** `host-key` is required in v3: without it (and without
+   the explicit `allow-any-host-key` opt-out), the deploy fails instead of
+   trusting an unverified server. Get the fingerprints with:
 
    ```console
    $ ssh-keyscan sftp.example.com | ssh-keygen -lf -
@@ -180,45 +210,38 @@ Vulnerability reports: [SECURITY.md](SECURITY.md)
 
 ## Documentation
 
+Structured from quick start to full reference:
+
 | | |
 |---|---|
-| [Configuration reference](docs/configuration.md) | All inputs, outputs, mappings, ignore rules, config file. |
-| [Strategies](docs/strategies.md) | `overlay`/`sync`/`clean`, manifest, delete guards, dry runs. |
+| [Configuration reference](docs/configuration.md) | Quick start, common config, multiple/advanced deployments, the config file, full reference. |
+| [Deployment modes](docs/strategies.md) | `overlay`/`sync`/`clean`, manifest, delete guards, dry runs. |
 | [Examples & use cases](docs/examples.md) | Copy-paste recipes for common deployments. |
 | [Security guide](docs/security.md) | Host key pinning, credentials, supply chain. |
 | [Troubleshooting & FAQ](docs/troubleshooting.md) | Common errors and fixes. |
+| [v3 migration guide](docs/migration-v3.md) | Moving a v2 (or v1) setup to v3. |
 
 ## Versioning
 
 easySFTP follows [Semantic Versioning](https://semver.org):
 
 ```yaml
-uses: eiserv/easySFTP@v2        # latest 2.x, recommended, gets fixes & features
-uses: eiserv/easySFTP@v2.0.0    # exact, immutable pin
+uses: eiserv/easySFTP@v3        # latest 3.x, recommended, gets fixes & features
+uses: eiserv/easySFTP@v3.0.0    # exact, immutable pin
 ```
 
-`v2`, `v2.0` and `v2.0.0` use the exact version recorded in
+`v3`, `v3.0` and `v3.0.0` use the exact version recorded in
 `.easysftp-version` and download the corresponding asset only from this
 repository's GitHub Release. The asset's SHA-256 digest is checked against
-`checksums.txt` before it is executed. `v2`/`v2.0` are rolling tags; exact tags
+`checksums.txt` before it is executed. `v3`/`v3.0` are rolling tags; exact tags
 never move.
 
-An exact release-commit SHA is accepted after it is matched against the exact
-tag recorded in `.easysftp-version`. Development refs such as `@main`, local
-`uses: ./`, and commit SHAs that do not match that release do not silently reuse
-the last binary. Select the source fallback explicitly for those checkouts:
-
-```yaml
-- uses: eiserv/easySFTP@<commit-sha>
-  with:
-    build-mode: source
-    # connection and upload inputs...
-```
-
-Source mode installs the Go version from `go.mod` and builds that exact
-checkout with `CGO_ENABLED=0`, `-trimpath`, and stripped symbols. Releases and
-the changelog remain managed by Release Please and Conventional Commits. See
-[docs/RELEASING.md](docs/RELEASING.md).
+The build mode is selected automatically from the action ref: release tags
+(and the exact release commit SHA) download the verified prebuilt binary;
+development refs (`@main`, other commit SHAs, local `uses: ./`) build the
+checked-out source with `CGO_ENABLED=0`, `-trimpath`, and stripped symbols.
+Releases and the changelog remain managed by Release Please and Conventional
+Commits. See [docs/RELEASING.md](docs/RELEASING.md).
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ or contact the maintainer directly. You will receive a response as soon as possi
 
 ## Hardening recommendations for users
 
-- Always set the `host-key-fingerprint` input so the server's identity is verified
+- Always set the `host-key` input (or `known-hosts`) so the server's identity is verified. In v3 a run without a pinned key fails unless you explicitly opt out with `allow-any-host-key: true`, which is not recommended
 - Store all credentials (`password`, `private-key`, `passphrase`) as encrypted GitHub Actions secrets
 - Prefer key-based authentication over passwords
 - Release refs download only this repository's platform binary and verify it against the release's `checksums.txt`
-- Prebuilt mode accepts a commit SHA only if it matches the exact release tag in `.easysftp-version`; use `build-mode: source` for all other SHAs
+- The build mode is selected automatically from the action ref: release tags and the exact release commit SHA use the verified prebuilt binary; every other ref builds from source, so a stale release binary is never substituted for newer source

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: easySFTP
 description: >-
-  Fast, secure SFTP uploads for GitHub Actions with parallel transfers, host key pinning and rsync-like strategies.
+  Fast, secure SFTP uploads for GitHub Actions with parallel transfers, host key pinning and rsync-like deployment modes.
 author: eiserv
 
 branding:
@@ -8,138 +8,113 @@ branding:
   color: blue
 
 inputs:
-  build-mode:
+  # --- Connection (inline mode) ---
+  host:
     description: >-
-      How to obtain easySFTP: "prebuilt" downloads and verifies the matching
-      release binary (default); "source" installs Go and builds this checkout.
+      Hostname or IP address of the SFTP server (e.g. sftp.example.com).
+      Required in inline mode; in config mode it comes from the config file
+      (connection.host).
     required: false
-    default: prebuilt
-  server:
-    description: Hostname or IP address of the SFTP server (e.g. sftp.example.com).
-    required: true
   port:
-    description: SSH port of the server.
+    description: >-
+      SSH port of the server. Defaults to 22. Deliberately has no declared
+      default value: the runner exports declared defaults unconditionally,
+      which would wrongly trip the config-mode mutual-exclusion check.
     required: false
-    default: "22"
   username:
-    description: Username used for authentication.
-    required: true
+    description: >-
+      Username used for authentication. Required in inline mode; in config
+      mode it comes from the config file (connection.username).
+    required: false
   password:
     description: >-
       Password used for authentication. Provide this or private-key (or both).
-      Always store this in a GitHub Actions secret.
+      Always store this in a GitHub Actions secret. As a credential, this
+      input is used in both inline and config mode.
     required: false
   private-key:
     description: >-
       SSH private key (PEM/OpenSSH format) used for authentication. Always
-      store this in a GitHub Actions secret.
+      store this in a GitHub Actions secret. As a credential, this input is
+      used in both inline and config mode.
     required: false
   passphrase:
     description: Passphrase for the private key, if it is encrypted.
     required: false
-  host-key-fingerprint:
+  host-key:
     description: >-
       Expected SHA256 fingerprint(s) of the server's host key, one per line
       (format "SHA256:..."). The connection is accepted if the server presents
       a key matching any of them, so you can simply pin all of your server's
-      keys. Strongly recommended: without this input, the server's identity is
-      not verified. Obtain the fingerprints with:
-      ssh-keyscan <server> | ssh-keygen -lf -
+      keys. Obtain the fingerprints with: ssh-keyscan <server> | ssh-keygen -lf -
+      Without this input or known-hosts, the run fails unless
+      allow-any-host-key is explicitly set.
     required: false
   known-hosts:
     description: >-
       Expected host key(s) in OpenSSH known_hosts format, e.g. the verbatim
       output of "ssh-keyscan <server>", or the server's lines from your own
-      ~/.ssh/known_hosts. An alternative to host-key-fingerprint (no
-      ssh-keygen conversion step); if both are set, a key matching either is
-      accepted. Hashed entries and "[host]:port" entries for non-standard
-      ports are supported.
+      ~/.ssh/known_hosts. An alternative to host-key (no ssh-keygen conversion
+      step); if both are set, a key matching either is accepted. Hashed
+      entries and "[host]:port" entries for non-standard ports are supported.
     required: false
-  proxy-server:
+  allow-any-host-key:
     description: >-
-      Hostname or IP address of an optional jump host (bastion) through which
-      the SFTP server is reached, like OpenSSH's ProxyJump. When set,
-      easySFTP connects to the jump host first (with its own proxy-*
-      credentials and host key verification) and tunnels the SFTP connection
-      to "server" through it. Leave empty to connect directly.
+      Set to "true" to explicitly skip host key verification. NOT recommended:
+      without verification, a man-in-the-middle can intercept the deployment
+      and the credentials. In v3 an unverified connection is no longer the
+      silent default; this opt-in (or a pinned key) is required.
     required: false
-  proxy-port:
-    description: SSH port of the jump host.
-    required: false
-  proxy-username:
-    description: Username used for authenticating against the jump host.
-    required: false
-  proxy-password:
+
+  # --- Deployment (inline mode) ---
+  source:
     description: >-
-      Password for the jump host. Provide this or proxy-private-key (or
-      both). Always store this in a GitHub Actions secret.
+      Local path to upload: a directory (uploaded recursively) or a single
+      file. Required in inline mode, together with target.
     required: false
-  proxy-private-key:
+  target:
     description: >-
-      SSH private key (PEM/OpenSSH format) for the jump host. Always store
-      this in a GitHub Actions secret.
+      Remote destination path, e.g. /var/www/html. Required in inline mode,
+      together with source.
     required: false
-  proxy-passphrase:
-    description: Passphrase for the jump host's private key, if it is encrypted.
-    required: false
-  proxy-host-key-fingerprint:
+  mode:
     description: >-
-      Expected SHA256 fingerprint(s) of the jump host's host key, one per
-      line (format "SHA256:..."). Host key verification applies to each hop
-      independently; without this input (or proxy-known-hosts) the jump
-      host's identity is not verified, and a warning is printed for this hop.
-    required: false
-  proxy-known-hosts:
-    description: >-
-      Expected host key(s) of the jump host in OpenSSH known_hosts format
-      (e.g. verbatim "ssh-keyscan <jump-host>" output). Alternative to
-      proxy-host-key-fingerprint; if both are set, a key matching either is
-      accepted.
-    required: false
-  uploads:
-    description: >-
-      One "local => remote" mapping per line, e.g. "./dist/ => /var/www/html/".
-      Local paths may be directories (uploaded recursively) or single files.
-      Lines starting with "#" are ignored. Required unless config-file is set.
-    required: false
-  config-file:
-    description: >-
-      Path to an optional YAML config file describing the deployment targets,
-      their strategy and delete guards (see docs/configuration.md). When set, it
-      replaces the uploads/strategy/ignore inputs. Connection settings
-      always come from the inputs above.
-    required: false
-  strategy:
-    description: >-
-      Reconciliation strategy for every target: "overlay" (upload only, never
+      How the remote target is reconciled: "overlay" (upload only, never
       delete; the default), "sync" (upload changed files and delete files no
       longer present locally, tracked via a manifest) or "clean" (wipe the
       remote target directory, then upload).
     required: false
-  ignore:
+  exclude:
     description: >-
       Gitignore-style exclude patterns, one per line (e.g. "*.log" or
       "node_modules/"). Prefix with "!" to re-include files.
     required: false
-  ignore-from:
-    description: Path to a file containing gitignore-style exclude patterns.
-    required: false
-  max-deletes:
+
+  # --- Config mode ---
+  config:
     description: >-
-      Refuse the run if the "sync" or "clean" strategy would delete more than
-      this many remote files. Unset or 0 means unlimited. Only valid
-      without config-file; with a config file, set "guards.max_deletes"
-      there instead. Deliberately has no declared default: a default value
-      would always be exported and wrongly trip the config-file
-      mutual-exclusion check.
+      Path to a YAML config file (version 3) that holds every non-secret
+      setting: connection (including proxy), named deployments, safety limits
+      and advanced tuning. Mutually exclusive with the inline connection and
+      deployment inputs above; only credentials, dry-run and log-level may be
+      combined with it. See docs/configuration.md.
     required: false
-  delete:
+  proxy-password:
     description: >-
-      Removed in v2; use "strategy: clean" instead. Still declared so that a
-      workflow passing it fails loudly rather than silently degrading to the
-      "overlay" default. Will be deleted in v3.
+      Password for the jump host defined as connection.proxy in the config
+      file. Always store this in a GitHub Actions secret.
     required: false
-    default: "false"
+  proxy-private-key:
+    description: >-
+      SSH private key (PEM/OpenSSH format) for the jump host defined as
+      connection.proxy in the config file. Always store this in a GitHub
+      Actions secret.
+    required: false
+  proxy-passphrase:
+    description: Passphrase for the jump host's private key, if it is encrypted.
+    required: false
+
+  # --- Run-wide switches (both modes) ---
   dry-run:
     description: >-
       If "true", connect and log everything that would be uploaded or deleted
@@ -148,131 +123,114 @@ inputs:
     default: "false"
   log-level:
     description: >-
-      How chatty the log output is. "normal" (the default) logs one line per
-      uploaded or deleted file. "quiet" suppresses those per-file lines and
-      keeps connection info, per-target summaries, warnings and errors, so a
-      20,000-file deploy produces a readable log. "verbose" additionally
-      explains every ignore decision (which pattern excluded which file),
-      useful when debugging ignore patterns. A dry run always logs per-file
-      lines regardless of this input, since inspecting the plan is its whole
-      point.
+      How chatty the log output is. "normal" (the default) logs connection
+      status, one compact summary per deployment, warnings and errors.
+      "verbose" additionally logs one line per uploaded, deleted or skipped
+      file. "debug" additionally explains every exclude decision (which
+      pattern excluded which file). A dry run always logs per-file lines
+      regardless of this input, since inspecting the plan is its whole point.
     required: false
     default: "normal"
+
+  # --- Removed in v3 (tombstones) ---
+  # These inputs are still declared, without defaults, so a v2 workflow that
+  # passes them fails with a migration hint instead of the runner silently
+  # dropping them. See docs/migration-v3.md.
+  build-mode:
+    description: >-
+      Removed in v3. The build mode is now selected automatically: release
+      tags download the verified prebuilt binary, development refs build from
+      source.
+    required: false
+  server:
+    description: "Removed in v3: renamed to 'host'. See docs/migration-v3.md."
+    required: false
+  host-key-fingerprint:
+    description: "Removed in v3: renamed to 'host-key'. See docs/migration-v3.md."
+    required: false
+  uploads:
+    description: >-
+      Removed in v3: use 'source' and 'target' for a single deployment, or a
+      config file for multiple deployments. See docs/migration-v3.md.
+    required: false
+  config-file:
+    description: "Removed in v3: renamed to 'config' (new file format, version 3). See docs/migration-v3.md."
+    required: false
+  strategy:
+    description: "Removed in v3: renamed to 'mode'. See docs/migration-v3.md."
+    required: false
+  ignore:
+    description: "Removed in v3: renamed to 'exclude'. See docs/migration-v3.md."
+    required: false
+  ignore-from:
+    description: "Removed in v3: put the patterns in 'exclude' or in the config file. See docs/migration-v3.md."
+    required: false
+  max-deletes:
+    description: "Removed in v3: moved to 'safety.max_deletes' in the config file. See docs/migration-v3.md."
+    required: false
+  delete:
+    description: "Removed in v2: use 'mode: clean'. See docs/migration-v3.md."
+    required: false
   concurrency:
-    description: >-
-      Number of files uploaded in parallel. Also bounds the worker pool that
-      hashes local files for the sync strategy.
+    description: "Removed in v3: moved to 'advanced.concurrency' in the config file. See docs/migration-v3.md."
     required: false
-    default: "4"
   sftp-request-concurrency:
-    description: >-
-      Advanced. Maximum number of in-flight SFTP requests per file (pipelining
-      within a single file's transfer, independent of "concurrency" which
-      controls how many files are transferred at once). Lower it if a small
-      or resource-constrained SFTP server struggles under load; raise it to
-      push more throughput per file on a fast link to a capable server.
+    description: "Removed in v3: moved to 'advanced.request_concurrency' in the config file. See docs/migration-v3.md."
     required: false
-    default: "16"
+  retries:
+    description: "Removed in v3: moved to 'advanced.retries' in the config file. See docs/migration-v3.md."
+    required: false
+  timeout:
+    description: "Removed in v3: moved to 'advanced.timeout' in the config file. See docs/migration-v3.md."
+    required: false
+  stall-timeout:
+    description: "Removed in v3: moved to 'advanced.stall_timeout' in the config file. See docs/migration-v3.md."
+    required: false
   sync-fast-path:
-    description: >-
-      If "true", the sync strategy skips re-hashing a file whose size and
-      modification time still match its last-synced manifest entry, reusing
-      the stored hash instead. This is faster on large trees but, like
-      rsync's quick check, can miss a same-size edit made within the same
-      second as the previous one; see docs/strategies.md. Off by default,
-      since content-hash comparison is what "sync" advertises. Only helps
-      when local modification times are meaningful across runs (e.g. a
-      restored build cache); a fresh "actions/checkout" gives every file a
-      new modification time on every run, so this has no effect there.
-    required: false
-    default: "false"
-  manifest-name:
-    description: >-
-      File name of the manifest the "sync" strategy keeps in each remote
-      target (default ".easysftp-manifest.json"). In a web-root deployment
-      the manifest is served like any other file and discloses the full file
-      list plus content hashes; an unguessable name (e.g. a generated suffix
-      stored in a secret) mitigates that, and a web-server deny rule removes
-      it entirely (see docs/security.md). Must be a bare file name, no path.
-      Changing it mid-life starts a fresh manifest: the next sync re-uploads
-      everything, tracks deletions from scratch, and leaves the old manifest
-      file behind on the server; delete it manually.
+    description: "Removed in v3: moved to 'sync.fast_path' in the config file. See docs/migration-v3.md."
     required: false
   skip-unchanged:
-    description: >-
-      If "true", the overlay strategy skips uploading a file when the remote
-      file already exists with the same size (one stat per file, performed
-      inside the parallel workers). Cheap but deliberately coarse: an edit
-      that keeps the file size identical is missed; use the sync strategy for
-      exact content-hash comparison. Ignored (with a warning) by the sync and
-      clean strategies.
+    description: "Removed in v3: moved to 'advanced.skip_unchanged' in the config file. See docs/migration-v3.md."
     required: false
-    default: "false"
-  retries:
-    description: >-
-      How often a failed file upload is retried (with backoff). Also covers
-      the initial connection (a transient dial failure is retried with the
-      same backoff; host key mismatches and authentication failures are not)
-      and bounds how often a connection that drops mid-run is redialed; the
-      failed operation (an upload, a remote scan, a delete, a sync manifest
-      read/write) is then retried against the fresh connection instead of
-      the dead one. 0 disables all of these.
+  manifest-name:
+    description: "Removed in v3: moved to 'sync.manifest' in the config file. See docs/migration-v3.md."
     required: false
-    default: "2"
-  timeout:
-    description: Connection timeout in seconds. 0 disables the timeout entirely.
-    required: false
-    default: "30"
-  stall-timeout:
-    description: >-
-      Abort the run when active remote operations (file transfers, remote
-      scans, delete sweeps, sync manifest reads and writes) make no progress
-      for this many seconds. 0 (the default) disables the check. Catches
-      servers that accept the connection and then hang (hung storage backend,
-      half-open connection that still answers keepalives), which would
-      otherwise block the job until the job-level timeout, 6 hours by
-      default. On a stall the connection is closed and the run fails with a
-      clear error. Pick a value comfortably above the longest pause a healthy
-      transfer to your server may hit; 60 to 300 is a reasonable range.
-    required: false
-    default: "0"
   dir-mode:
-    description: >-
-      Octal permission (e.g. "755") applied to every remote directory the run
-      creates or touches, overriding the server's umask default. Off by
-      default. Best-effort: a server that rejects the chmod produces one
-      warning per run, not a failure.
+    description: "Removed in v3: moved to 'permissions.directories' in the config file. See docs/migration-v3.md."
     required: false
   file-mode:
-    description: >-
-      Octal permission (e.g. "644") applied to every uploaded file, overriding
-      the default of mirroring the local file's permission bits. Off by
-      default. Best-effort: a server that rejects the chmod produces one
-      warning per run, not a failure.
+    description: "Removed in v3: moved to 'permissions.files' in the config file. See docs/migration-v3.md."
     required: false
   preserve-times:
-    description: >-
-      If "true", every uploaded file keeps its local modification time on the
-      server instead of "now". Useful when the server derives Last-Modified
-      or ETag headers from file mtimes, or when server-side tooling compares
-      timestamps. Off by default. A server that rejects the request produces
-      one warning per run, not a failure. Note that a fresh actions/checkout
-      gives every file the checkout time; combine with something that restores
-      real mtimes (e.g. a build, or git-restore-mtime) if that matters.
+    description: "Removed in v3: moved to 'permissions.preserve_times' in the config file. See docs/migration-v3.md."
     required: false
-    default: "false"
+  proxy-server:
+    description: "Removed in v3: moved to 'connection.proxy.host' in the config file. See docs/migration-v3.md."
+    required: false
+  proxy-port:
+    description: "Removed in v3: moved to 'connection.proxy.port' in the config file. See docs/migration-v3.md."
+    required: false
+  proxy-username:
+    description: "Removed in v3: moved to 'connection.proxy.username' in the config file. See docs/migration-v3.md."
+    required: false
+  proxy-host-key-fingerprint:
+    description: "Removed in v3: moved to 'connection.proxy.host_key' in the config file. See docs/migration-v3.md."
+    required: false
+  proxy-known-hosts:
+    description: "Removed in v3: moved to 'connection.proxy.known_hosts' in the config file. See docs/migration-v3.md."
+    required: false
 
 outputs:
   files-uploaded:
     description: Number of files that were uploaded (or would be, in dry-run mode).
     value: ${{ steps.easysftp.outputs.files-uploaded }}
   files-deleted:
-    description: Number of remote files deleted by the clean/sync strategy.
+    description: Number of remote files deleted by the clean/sync mode.
     value: ${{ steps.easysftp.outputs.files-deleted }}
   files-skipped:
     description: >-
-      Number of unchanged files skipped (by the sync strategy, or by overlay
-      with skip-unchanged).
+      Number of unchanged files skipped (by the sync mode, or by overlay
+      with advanced.skip_unchanged).
     value: ${{ steps.easysftp.outputs.files-skipped }}
   bytes-uploaded:
     description: Total number of bytes transferred.
@@ -318,22 +276,29 @@ runs:
       run: '"$BINARY"'
       env:
         BINARY: ${{ steps.prepare.outputs.binary }}
-        EASYSFTP_SERVER: ${{ inputs.server }}
+        # v3 inputs
+        EASYSFTP_HOST: ${{ inputs.host }}
         EASYSFTP_PORT: ${{ inputs.port }}
         EASYSFTP_USERNAME: ${{ inputs.username }}
         EASYSFTP_PASSWORD: ${{ inputs.password }}
         EASYSFTP_PRIVATE_KEY: ${{ inputs.private-key }}
         EASYSFTP_PASSPHRASE: ${{ inputs.passphrase }}
-        EASYSFTP_HOST_KEY_FINGERPRINT: ${{ inputs.host-key-fingerprint }}
+        EASYSFTP_HOST_KEY: ${{ inputs.host-key }}
         EASYSFTP_KNOWN_HOSTS: ${{ inputs.known-hosts }}
-        EASYSFTP_PROXY_SERVER: ${{ inputs.proxy-server }}
-        EASYSFTP_PROXY_PORT: ${{ inputs.proxy-port }}
-        EASYSFTP_PROXY_USERNAME: ${{ inputs.proxy-username }}
+        EASYSFTP_ALLOW_ANY_HOST_KEY: ${{ inputs.allow-any-host-key }}
+        EASYSFTP_SOURCE: ${{ inputs.source }}
+        EASYSFTP_TARGET: ${{ inputs.target }}
+        EASYSFTP_MODE: ${{ inputs.mode }}
+        EASYSFTP_EXCLUDE: ${{ inputs.exclude }}
+        EASYSFTP_CONFIG: ${{ inputs.config }}
         EASYSFTP_PROXY_PASSWORD: ${{ inputs.proxy-password }}
         EASYSFTP_PROXY_PRIVATE_KEY: ${{ inputs.proxy-private-key }}
         EASYSFTP_PROXY_PASSPHRASE: ${{ inputs.proxy-passphrase }}
-        EASYSFTP_PROXY_HOST_KEY_FINGERPRINT: ${{ inputs.proxy-host-key-fingerprint }}
-        EASYSFTP_PROXY_KNOWN_HOSTS: ${{ inputs.proxy-known-hosts }}
+        EASYSFTP_DRY_RUN: ${{ inputs.dry-run }}
+        EASYSFTP_LOG_LEVEL: ${{ inputs.log-level }}
+        # Removed-input tombstones: any non-empty value fails with a hint.
+        EASYSFTP_SERVER: ${{ inputs.server }}
+        EASYSFTP_HOST_KEY_FINGERPRINT: ${{ inputs.host-key-fingerprint }}
         EASYSFTP_UPLOADS: ${{ inputs.uploads }}
         EASYSFTP_CONFIG_FILE: ${{ inputs.config-file }}
         EASYSFTP_STRATEGY: ${{ inputs.strategy }}
@@ -341,16 +306,19 @@ runs:
         EASYSFTP_IGNORE_FROM: ${{ inputs.ignore-from }}
         EASYSFTP_MAX_DELETES: ${{ inputs.max-deletes }}
         EASYSFTP_DELETE: ${{ inputs.delete }}
-        EASYSFTP_DRY_RUN: ${{ inputs.dry-run }}
-        EASYSFTP_LOG_LEVEL: ${{ inputs.log-level }}
         EASYSFTP_CONCURRENCY: ${{ inputs.concurrency }}
         EASYSFTP_SFTP_REQUEST_CONCURRENCY: ${{ inputs.sftp-request-concurrency }}
-        EASYSFTP_SYNC_FAST_PATH: ${{ inputs.sync-fast-path }}
-        EASYSFTP_SKIP_UNCHANGED: ${{ inputs.skip-unchanged }}
-        EASYSFTP_MANIFEST_NAME: ${{ inputs.manifest-name }}
         EASYSFTP_RETRIES: ${{ inputs.retries }}
         EASYSFTP_TIMEOUT: ${{ inputs.timeout }}
         EASYSFTP_STALL_TIMEOUT: ${{ inputs.stall-timeout }}
+        EASYSFTP_SYNC_FAST_PATH: ${{ inputs.sync-fast-path }}
+        EASYSFTP_SKIP_UNCHANGED: ${{ inputs.skip-unchanged }}
+        EASYSFTP_MANIFEST_NAME: ${{ inputs.manifest-name }}
         EASYSFTP_DIR_MODE: ${{ inputs.dir-mode }}
         EASYSFTP_FILE_MODE: ${{ inputs.file-mode }}
         EASYSFTP_PRESERVE_TIMES: ${{ inputs.preserve-times }}
+        EASYSFTP_PROXY_SERVER: ${{ inputs.proxy-server }}
+        EASYSFTP_PROXY_PORT: ${{ inputs.proxy-port }}
+        EASYSFTP_PROXY_USERNAME: ${{ inputs.proxy-username }}
+        EASYSFTP_PROXY_HOST_KEY_FINGERPRINT: ${{ inputs.proxy-host-key-fingerprint }}
+        EASYSFTP_PROXY_KNOWN_HOSTS: ${{ inputs.proxy-known-hosts }}

--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -63,8 +63,25 @@ func run() error {
 			mode, stats.FilesUploaded, stats.BytesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.Duration.Round(time.Millisecond))
 	}
 
-	reportStats(stats, mode, runErr)
+	reportStats(cfg, stats, mode, runErr)
 	return runErr
+}
+
+// hostKeyStatus describes how the run verified the server's identity, for
+// the job summary.
+func hostKeyStatus(cfg *config.Config) string {
+	status := "❌ NOT verified (allow-any-host-key)"
+	if cfg.HostKeyPinned() {
+		status = "✅ pinned"
+	}
+	if p := cfg.Proxy; p != nil {
+		proxyStatus := "❌ NOT verified (allow_any_host_key)"
+		if len(p.HostKeyFingerprints) > 0 || p.KnownHosts != "" {
+			proxyStatus = "✅ pinned"
+		}
+		status += ", proxy: " + proxyStatus
+	}
+	return status
 }
 
 func logBuildInfo() {
@@ -103,7 +120,7 @@ func buildInfoLine(info *debug.BuildInfo, version string) string {
 	return ""
 }
 
-func reportStats(stats *uploader.Stats, mode string, runErr error) {
+func reportStats(cfg *config.Config, stats *uploader.Stats, mode string, runErr error) {
 	status := "✅ Succeeded"
 	if runErr != nil {
 		status = fmt.Sprintf("❌ Failed after %d file(s), %d byte(s)", stats.FilesUploaded, stats.BytesUploaded)
@@ -115,34 +132,45 @@ func reportStats(stats *uploader.Stats, mode string, runErr error) {
 	gha.SetOutput("bytes-uploaded", fmt.Sprintf("%d", stats.BytesUploaded))
 	gha.SetOutput("duration-ms", fmt.Sprintf("%d", stats.Duration.Milliseconds()))
 
+	configSource := "inline inputs"
+	if cfg.ConfigPath != "" {
+		configSource = fmt.Sprintf("`%s` (version 3)", cfg.ConfigPath)
+	}
 	summary := fmt.Sprintf(
-		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %d |\n| Duration | %s |\n",
-		status, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.BytesUploaded, stats.Duration.Round(time.Millisecond))
-	summary += targetBreakdown(stats.Targets)
+		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Host key | %s |\n| Configuration | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %d |\n| Duration | %s |\n",
+		status, hostKeyStatus(cfg), configSource, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.BytesUploaded, stats.Duration.Round(time.Millisecond))
+	summary += deploymentBreakdown(stats.Targets)
 	gha.AppendSummary(summary)
 }
 
-// targetBreakdown renders a per-target table for multi-target deploys, or ""
-// when there is only one target (its row would just repeat the totals above).
-func targetBreakdown(targets []uploader.TargetStats) string {
-	if len(targets) < 2 {
+// deploymentBreakdown renders a per-deployment table, or "" when there is
+// only one unnamed deployment (its row would just repeat the totals above).
+func deploymentBreakdown(targets []uploader.TargetStats) string {
+	if len(targets) < 2 && (len(targets) == 0 || targets[0].Name == "") {
 		return ""
 	}
 
 	var b strings.Builder
-	b.WriteString("\n#### Per-target breakdown\n\n| Target | Strategy | Uploaded | Deleted | Skipped | Bytes |\n|---|---|---|---|---|---|\n")
+	b.WriteString("\n#### Deployments\n\n| Deployment | Source | Target | Mode | Uploaded | Deleted | Skipped | Bytes | Duration |\n|---|---|---|---|---|---|---|---|---|\n")
 
 	var totalUploaded, totalDeleted, totalSkipped int
 	var totalBytes int64
 	for _, t := range targets {
-		fmt.Fprintf(&b, "| `%s` => `%s` | %s | %d | %d | %d | %d |\n",
-			t.Local, t.Remote, t.Strategy, t.FilesUploaded, t.FilesDeleted, t.FilesSkipped, t.BytesUploaded)
+		name := t.Name
+		if name == "" {
+			name = "(inline)"
+		}
+		fmt.Fprintf(&b, "| %s | `%s` | `%s` | %s | %d | %d | %d | %d | %s |\n",
+			name, t.Local, t.Remote, t.Strategy, t.FilesUploaded, t.FilesDeleted, t.FilesSkipped, t.BytesUploaded,
+			t.Duration.Round(time.Millisecond))
 		totalUploaded += t.FilesUploaded
 		totalDeleted += t.FilesDeleted
 		totalSkipped += t.FilesSkipped
 		totalBytes += t.BytesUploaded
 	}
-	fmt.Fprintf(&b, "| **Total** | | **%d** | **%d** | **%d** | **%d** |\n",
-		totalUploaded, totalDeleted, totalSkipped, totalBytes)
+	if len(targets) > 1 {
+		fmt.Fprintf(&b, "| **Total** | | | | **%d** | **%d** | **%d** | **%d** | |\n",
+			totalUploaded, totalDeleted, totalSkipped, totalBytes)
+	}
 	return b.String()
 }

--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eiserv/easySFTP/internal/config"
 	"github.com/eiserv/easySFTP/internal/uploader"
 )
 
@@ -103,7 +104,8 @@ func TestReportStatsOnFailure(t *testing.T) {
 		BytesUploaded: 2048,
 		Duration:      1500 * time.Millisecond,
 	}
-	reportStats(stats, "uploaded", errors.New("upload failed"))
+	cfg := &config.Config{HostKeyFingerprints: []string{"SHA256:abc"}}
+	reportStats(cfg, stats, "uploaded", errors.New("upload failed"))
 
 	output, err := os.ReadFile(outputPath)
 	if err != nil {
@@ -128,6 +130,8 @@ func TestReportStatsOnFailure(t *testing.T) {
 	}
 	for _, want := range []string{
 		"| Status | ❌ Failed after 3 file(s), 2048 byte(s) |",
+		"| Host key | ✅ pinned |",
+		"| Configuration | inline inputs |",
 		"| Files uploaded | 3 |",
 		"| Files deleted | 1 |",
 		"| Files skipped (unchanged) | 4 |",
@@ -151,22 +155,24 @@ func TestReportStatsMultiTargetBreakdown(t *testing.T) {
 		BytesUploaded: 17_825_792,
 		Duration:      2*time.Minute + 13*time.Second,
 		Targets: []uploader.TargetStats{
-			{Local: "./dist/", Remote: "/var/www/html/", Strategy: "sync", FilesUploaded: 12, FilesDeleted: 3, FilesSkipped: 1988, BytesUploaded: 4_297_523},
-			{Local: "./docs/", Remote: "/var/www/docs/", Strategy: "clean", FilesUploaded: 240, FilesDeleted: 214, FilesSkipped: 0, BytesUploaded: 13_528_269},
+			{Name: "website", Local: "./dist/", Remote: "/var/www/html/", Strategy: "sync", FilesUploaded: 12, FilesDeleted: 3, FilesSkipped: 1988, BytesUploaded: 4_297_523, Duration: time.Second},
+			{Name: "documentation", Local: "./docs/", Remote: "/var/www/docs/", Strategy: "clean", FilesUploaded: 240, FilesDeleted: 214, FilesSkipped: 0, BytesUploaded: 13_528_269, Duration: 2 * time.Second},
 		},
 	}
-	reportStats(stats, "uploaded", nil)
+	cfg := &config.Config{ConfigPath: ".github/easysftp.yml", KnownHosts: "line"}
+	reportStats(cfg, stats, "uploaded", nil)
 
 	summary, err := os.ReadFile(summaryPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, want := range []string{
-		"#### Per-target breakdown",
-		"| Target | Strategy | Uploaded | Deleted | Skipped | Bytes |",
-		"| `./dist/` => `/var/www/html/` | sync | 12 | 3 | 1988 | 4297523 |",
-		"| `./docs/` => `/var/www/docs/` | clean | 240 | 214 | 0 | 13528269 |",
-		"| **Total** | | **252** | **217** | **1988** | **17825792** |",
+		"| Configuration | `.github/easysftp.yml` (version 3) |",
+		"#### Deployments",
+		"| Deployment | Source | Target | Mode | Uploaded | Deleted | Skipped | Bytes | Duration |",
+		"| website | `./dist/` | `/var/www/html/` | sync | 12 | 3 | 1988 | 4297523 | 1s |",
+		"| documentation | `./docs/` | `/var/www/docs/` | clean | 240 | 214 | 0 | 13528269 | 2s |",
+		"| **Total** | | | | **252** | **217** | **1988** | **17825792** | |",
 	} {
 		if !strings.Contains(string(summary), want) {
 			t.Errorf("summary does not contain %q:\n%s", want, summary)
@@ -174,20 +180,46 @@ func TestReportStatsMultiTargetBreakdown(t *testing.T) {
 	}
 }
 
-func TestReportStatsSingleTargetHasNoBreakdown(t *testing.T) {
+func TestReportStatsSingleInlineTargetHasNoBreakdown(t *testing.T) {
 	summaryPath := filepath.Join(t.TempDir(), "summary")
 	t.Setenv("GITHUB_OUTPUT", filepath.Join(t.TempDir(), "output"))
 	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
 
-	stats := &uploader.Stats{FilesUploaded: 3, BytesUploaded: 2048, Duration: time.Second}
-	reportStats(stats, "uploaded", nil)
+	stats := &uploader.Stats{
+		FilesUploaded: 3, BytesUploaded: 2048, Duration: time.Second,
+		Targets: []uploader.TargetStats{{Local: "./dist/", Remote: "/www/", Strategy: "overlay", FilesUploaded: 3, BytesUploaded: 2048}},
+	}
+	reportStats(&config.Config{AllowAnyHostKey: true}, stats, "uploaded", nil)
 
 	summary, err := os.ReadFile(summaryPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(summary), "Per-target breakdown") {
-		t.Errorf("expected no per-target breakdown for a single target:\n%s", summary)
+	if strings.Contains(string(summary), "#### Deployments") {
+		t.Errorf("expected no per-deployment breakdown for a single inline target:\n%s", summary)
+	}
+	if !strings.Contains(string(summary), "| Host key | ❌ NOT verified (allow-any-host-key) |") {
+		t.Errorf("expected the unverified host key status in the summary:\n%s", summary)
+	}
+}
+
+func TestReportStatsSingleNamedDeploymentGetsBreakdown(t *testing.T) {
+	summaryPath := filepath.Join(t.TempDir(), "summary")
+	t.Setenv("GITHUB_OUTPUT", filepath.Join(t.TempDir(), "output"))
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	stats := &uploader.Stats{
+		FilesUploaded: 3, BytesUploaded: 2048, Duration: time.Second,
+		Targets: []uploader.TargetStats{{Name: "website", Local: "./dist/", Remote: "/www/", Strategy: "sync", FilesUploaded: 3, BytesUploaded: 2048}},
+	}
+	reportStats(&config.Config{ConfigPath: "x.yml", KnownHosts: "line"}, stats, "uploaded", nil)
+
+	summary, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(summary), "| website | `./dist/` | `/www/` | sync | 3 | 0 | 0 | 2048 | 0s |") {
+		t.Errorf("expected the named deployment row in the summary:\n%s", summary)
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,258 +1,333 @@
 # Configuration reference
 
-Everything easySFTP accepts: action inputs, outputs and the YAML config file.
+easySFTP has exactly two configuration modes, and never mixes them:
 
-- [Inputs](#inputs)
+1. **Inline mode** for the common single-target deploy: connection and one
+   deployment in the workflow's `with:`.
+2. **Config mode** for everything complex: `config` points at a YAML file
+   that holds every non-secret setting. Only credentials, `dry-run` and
+   `log-level` may be combined with it.
+
+Every non-secret setting has exactly one home, so there is never a precedence
+question between the workflow and the config file.
+
+- [Quick start (inline mode)](#quick-start-inline-mode)
+- [Common configuration](#common-configuration)
+- [Config mode (multiple and advanced deployments)](#config-mode-multiple-and-advanced-deployments)
+- [The config file](#the-config-file)
+- [The `source` / `target` mapping](#the-source--target-mapping)
+- [Exclude patterns](#exclude-patterns)
 - [Outputs](#outputs)
-- [The `uploads` mapping](#the-uploads-mapping)
-- [Ignore patterns](#ignore-patterns)
-- [The YAML config file](#the-yaml-config-file)
+- [Complete input reference](#complete-input-reference)
 
-## Inputs
+## Quick start (inline mode)
 
-### Connection
+```yaml
+- uses: eiserv/easySFTP@v3
+  with:
+    host: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    password: ${{ secrets.SFTP_PASSWORD }}
+    host-key: ${{ secrets.SFTP_HOST_KEY }}
+    source: dist
+    target: /var/www/html
+```
+
+The four things you have to understand are `host` (where), `username` +
+`password`/`private-key` (who), `source` (what) and `target` (where to).
+Everything else has a sensible default.
+
+## Common configuration
+
+### Connection (inline mode)
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `server` | ✅ | - | Hostname or IP of the SFTP server. |
+| `host` | ✅ | - | Hostname or IP of the SFTP server. |
 | `port` | | `22` | SSH port. |
 | `username` | ✅ | - | Username for authentication. |
 | `password` | ¹ | - | Password. **Use a secret.** |
 | `private-key` | ¹ | - | SSH private key (OpenSSH/PEM format). **Use a secret.** |
 | `passphrase` | | - | Passphrase of the private key, if encrypted. |
-| `host-key-fingerprint` | | - | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). **Strongly recommended**, see [Security](security.md). |
-| `known-hosts` | | - | Expected host key(s) in OpenSSH `known_hosts` format (verbatim `ssh-keyscan` output). Alternative to `host-key-fingerprint`; a key matching either is accepted. Hashed entries and `[host]:port` lines are supported. See [Security](security.md). |
-| `timeout` | | `30` | Connection timeout in seconds. `0` disables the timeout entirely. Covers the dial and SSH handshake only; for hangs after that, see `stall-timeout`. |
-| `stall-timeout` | | `0` (off) | Abort the run when active remote operations make no progress for this many seconds. Covers file transfers and the other remote phases (remote scans, delete sweeps, sync manifest reads and writes). Catches servers that accept the connection and then hang, which would otherwise block the job until the job-level timeout (6 hours by default). On a stall the connection is closed and the run fails with a clear error. Pick a value comfortably above the longest pause a healthy transfer to your server may hit; 60 to 300 is a reasonable range. |
+| `host-key` | ² | - | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). See [Security](security.md). |
+| `known-hosts` | ² | - | Expected host key(s) in OpenSSH `known_hosts` format (verbatim `ssh-keyscan` output). Alternative to `host-key`; a key matching either is accepted. |
+| `allow-any-host-key` | ² | `false` | Explicitly skip host key verification. **Not recommended** (allows man-in-the-middle attacks). |
 
 ¹ At least one of `password` / `private-key` is required. If both are set, the key is tried first.
+² You must set `host-key` **or** `known-hosts`, **or** explicitly opt out with `allow-any-host-key: true`. A run with none of the three fails. This is the one behavior change v3 makes on purpose; see [Security](security.md).
 
-### Jump host (bastion)
-
-If the SFTP server is only reachable through a bastion (OpenSSH's
-`ssh -J jump.example.com target`), set the `proxy-*` inputs. easySFTP then
-connects to the jump host first, with its own credentials and its own host
-key verification, and tunnels the SFTP connection to `server` through it.
-All inputs mirror the primary connection settings:
+### Deployment (inline mode)
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `proxy-server` | ² | - | Hostname or IP of the jump host. Setting any other `proxy-*` input without this one fails the run. |
-| `proxy-port` | | `22` | SSH port of the jump host. |
-| `proxy-username` | ² | - | Username for the jump host. |
-| `proxy-password` | ³ | - | Password for the jump host. **Use a secret.** |
-| `proxy-private-key` | ³ | - | SSH private key for the jump host. **Use a secret.** |
-| `proxy-passphrase` | | - | Passphrase of the jump host key, if encrypted. |
-| `proxy-host-key-fingerprint` | | - | SHA256 fingerprint(s) of the jump host's key, one per line. **Strongly recommended.** |
-| `proxy-known-hosts` | | - | Jump host key(s) in `known_hosts` format; alternative to the fingerprint input. |
+| `source` | ✅ | - | Local path (file or directory) to upload. |
+| `target` | ✅ | - | Remote destination path. |
+| `mode` | | `overlay` | [Reconciliation mode](strategies.md): `overlay`, `sync` or `clean`. |
+| `exclude` | | - | Gitignore-style exclude patterns, one per line. `!` re-includes. |
 
-² Required when using a jump host. ³ At least one of `proxy-password` /
-`proxy-private-key` is required when `proxy-server` is set.
+### Run-wide switches (both modes)
 
-Host key verification applies to **each hop independently**: pinning the
-target but not the jump host (or vice versa) prints the unverified-host-key
-warning for the open hop. The `timeout` input covers each hop's dial. The
-`retries` reconnect logic re-establishes the whole chain (jump host and
-tunnel) when the connection drops mid-run, and the initial-connection retry
-covers either hop: a transient failure reaching the bastion is retried just
-like one reaching the target, while a host key mismatch or an authentication
-failure on either hop fails immediately.
+| Input | Default | Description |
+|---|---|---|
+| `dry-run` | `false` | Connect and log what would happen, change nothing. |
+| `log-level` | `normal` | `normal` logs connection status, one summary per deployment, warnings and errors. `verbose` additionally logs one line per uploaded/deleted/skipped file. `debug` additionally explains every exclude decision. A dry run always logs per-file lines regardless: inspecting the plan is its whole point. |
+
+These two are the only non-secret settings valid in both modes: they change
+how a run reports, not what it deploys, so they never belong to "one source of
+truth" for a deployment.
+
+## Config mode (multiple and advanced deployments)
+
+When `config` is set, all non-secret settings come from the file. The workflow
+step shrinks to the config path plus credentials:
 
 ```yaml
-- uses: eiserv/easySFTP@v2
+- uses: eiserv/easySFTP@v3
   with:
-    server: sftp.internal.example.com
-    username: ${{ secrets.SFTP_USERNAME }}
+    config: .github/easysftp.yml
     private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
-    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-    proxy-server: bastion.example.com
-    proxy-username: ${{ secrets.JUMP_USERNAME }}
-    proxy-private-key: ${{ secrets.JUMP_PRIVATE_KEY }}
-    proxy-host-key-fingerprint: ${{ secrets.JUMP_HOST_KEY_FINGERPRINT }}
-    uploads: |
-      ./dist/ => /var/www/html/
+    # optional, only for a jump host:
+    # proxy-private-key: ${{ secrets.JUMP_PRIVATE_KEY }}
 ```
 
-### What to upload
+Setting any inline connection/deployment input (`host`, `port`, `username`,
+`host-key`, `known-hosts`, `allow-any-host-key`, `source`, `target`, `mode`,
+`exclude`) alongside `config` fails the run: there is no mixed mode.
 
-| Input | Required | Default | Description |
-|---|---|---|---|
-| `uploads` | ² | - | One `local => remote` mapping per line. Directories are uploaded recursively; single files are supported too. |
-| `config-file` | | - | Path to a [YAML config file](#the-yaml-config-file) with per-target strategies and delete guards. Mutually exclusive with `uploads`/`strategy`/`ignore`/`ignore-from`/`max-deletes`. |
-| `strategy` | | `overlay` | [Reconciliation strategy](strategies.md): `overlay`, `sync` or `clean`. |
-| `ignore` | | - | Gitignore-style exclude patterns, one per line. `!` re-includes. |
-| `ignore-from` | | - | Path to a file with exclude patterns (e.g. `.sftpignore`). |
-| `max-deletes` | | `0` | Abort a `sync`/`clean` run that would delete more files than this (`0` = unlimited). See [delete guards](strategies.md#delete-guards). |
+The only inputs that combine with `config` are the credentials (`password`,
+`private-key`, `passphrase`, and the `proxy-*` credential counterparts) and
+the run-wide switches (`dry-run`, `log-level`).
 
-² Required unless `config-file` is set.
+## The config file
 
-> **Removed in v2:** the `delete` input is gone; use `strategy: clean`.
-> Passing `delete: true` now fails the run with a migration hint instead of
-> silently falling back to `overlay`. The declaration disappears in v3.
-
-### Behavior
-
-| Input | Required | Default | Description |
-|---|---|---|---|
-| `build-mode` | | `prebuilt` | `prebuilt` downloads the platform-specific release binary and verifies its SHA-256 digest. `source` installs Go and compiles the selected action checkout. |
-| `dry-run` | | `false` | Connect and log what would happen, change nothing. |
-| `log-level` | | `normal` | `normal` logs one line per uploaded/deleted file. `quiet` suppresses per-file lines (connection info, per-target summaries, warnings and errors remain), keeping the log readable on huge deploys. `verbose` additionally explains every ignore decision (which pattern excluded which file). A dry run always logs per-file lines regardless: inspecting the plan is its whole point. |
-| `concurrency` | | `4` | Number of files uploaded in parallel. Also bounds the worker pool that hashes local files for the `sync` strategy. |
-| `sftp-request-concurrency` | | `16` | Advanced. Maximum in-flight SFTP requests *per file*: pipelining within one file's transfer, independent of `concurrency` (which controls how many files transfer at once). The two multiply: with the defaults, a single large file can have up to 16 requests in flight, and up to `concurrency` files transfer at a time. Lower it for a small or resource-constrained server; raise it for more throughput per file on a fast link to a capable server. |
-| `sync-fast-path` | | `false` | For the `sync` strategy, reuse a file's manifest hash instead of re-reading it when size and modification time still match. See [the sync-fast-path trade-off](strategies.md#sync-fast-path-skip-re-hashing-unchanged-files). |
-| `skip-unchanged` | | `false` | For the `overlay` strategy, skip uploading a file when the remote file already exists with the same size (one stat per file). Deliberately coarse but manifest-free; see [the skip-unchanged trade-off](strategies.md#skip-unchanged-skip-same-size-files). Ignored (with a warning) by `sync` and `clean`. |
-| `manifest-name` | | `.easysftp-manifest.json` | File name of the `sync` strategy's per-target manifest. Must be a bare file name (no path). An unguessable name mitigates [the manifest being publicly downloadable](security.md#the-sync-manifest-in-web-roots) from web roots. Changing it mid-life starts a fresh manifest and leaves the old file behind on the server. |
-| `retries` | | `2` | Retries per file on transient upload errors (exponential backoff). Also covers the initial connection: a transient dial failure (DNS hiccup, restarting sshd) is retried with the same backoff, while host key mismatches and authentication failures fail immediately. Additionally bounds how often a connection that drops mid-run is redialed: when a remote operation fails because the connection died (an upload, but also a remote scan, a delete or a sync manifest read/write), easySFTP reconnects (up to `retries` times per run) and retries the operation against the fresh connection. Completed files stay completed. `0` disables all of these. |
-| `dir-mode` | | - | Octal permission (e.g. `755`) applied to every remote directory the run creates or touches, instead of whatever the server's umask produces. |
-| `file-mode` | | - | Octal permission (e.g. `644`) applied to every uploaded file, instead of mirroring the local file's permission bits. |
-| `preserve-times` | | `false` | Keep each uploaded file's local modification time on the server instead of "now". Useful when the server derives `Last-Modified`/ETag headers from mtimes or server-side tooling compares timestamps. Best-effort like the modes: a refusing server produces one warning per run, not a failure. Does not interact with the `sync` strategy's change detection, which compares content hashes, never remote timestamps. Note that a fresh `actions/checkout` stamps every file with the checkout time; combine with e.g. `git-restore-mtime` if the original times matter. |
-
-`dir-mode` and `file-mode` are best-effort: some servers reject the chmod
-(`SETSTAT`) request outright. A failure produces one warning per run, not a
-failed deploy, so a restrictive server doesn't turn an otherwise-successful
-deploy red. On shared hosting where the web server runs as a different user,
-these are useful to force freshly created directories/files to a mode the web
-server can actually read (see [troubleshooting.md](troubleshooting.md)).
-
-Like `retries` or `concurrency`, these are run-wide behavior settings, not
-per-target deployment shape; they apply the same way with or without
-`config-file` and have no per-target override.
-
-Prebuilt binaries support Linux, macOS, and Windows on both x64 and arm64
-GitHub-hosted runners. Release refs `@vX`, `@vX.Y`, and `@vX.Y.Z` resolve via
-the exact version in `.easysftp-version`. A commit SHA is accepted in prebuilt
-mode only when it is the commit behind that exact release tag. Development
-refs (`@main`, other commit SHAs, and local `uses: ./`) require
-`build-mode: source`; prebuilt mode fails clearly instead of running an older
-release.
-
-## Outputs
-
-| Output | Description |
-|---|---|
-| `files-uploaded` | Number of uploaded files (planned files in dry-run mode). |
-| `files-deleted` | Number of remote files removed by the `clean`/`sync` strategy. |
-| `files-skipped` | Number of unchanged files skipped (by the `sync` strategy, or by `overlay` with `skip-unchanged`). |
-| `bytes-uploaded` | Total bytes transferred (planned bytes in dry-run mode). |
-| `duration-ms` | Total runtime in milliseconds. |
-
-A summary table is also written to the job summary of every run. Outputs and
-the summary are populated even if a transfer fails partway: the values reflect
-the progress completed before the failure, and the summary is clearly marked
-as failed. Use `if: ${{ always() }}` when a later reporting or rollback step
-must consume these partial results. See [examples](examples.md#using-the-outputs)
-for how to consume outputs in later steps.
-
-When `uploads` (or a `config-file`) defines more than one target, the job
-summary also breaks the totals down per target (local path, remote path,
-strategy, and that target's own uploaded/deleted/skipped/bytes counts), so a
-number that looks off in the totals can be traced to the target that produced
-it. The `files-*`/`bytes-uploaded` outputs stay run-wide totals; there is no
-per-target output.
-
-## The `uploads` mapping
-
-One mapping per line, `local => remote`. Lines starting with `#` are ignored.
+A commented, ready-to-copy example lives at
+[easysftp.example.yml](easysftp.example.yml). The full structure:
 
 ```yaml
-uploads: |
-  # directory => directory (recursive)
-  ./dist/ => /var/www/html/
+# yaml-language-server: $schema=https://raw.githubusercontent.com/eiserv/easySFTP/main/schema/easysftp.schema.json
+version: 3
 
-  # single file => exact remote path (rename on the fly)
-  ./config/prod.json => /etc/app/config.json
+connection:
+  host: sftp.example.com
+  port: 22                     # optional
+  username: deploy
+  host_key: |
+    SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+  # known_hosts: |             # alternative to host_key
+  #   sftp.example.com ssh-ed25519 AAAA...
+  # allow_any_host_key: true   # explicit opt-out (not recommended)
+  # proxy:                     # optional jump host / bastion
+  #   host: bastion.example.com
+  #   username: jumper
+  #   host_key: |
+  #     SHA256:...
 
-  # single file => into a remote directory (note the trailing slash)
-  ./robots.txt => /var/www/html/
+defaults:
+  mode: overlay                # default mode for every deployment
+  exclude:
+    - "*.map"
+
+deployments:                   # at least one named deployment
+  website:
+    source: dist
+    target: /var/www/html
+    mode: sync
+    exclude:
+      - node_modules/
+  documentation:
+    source: docs/build
+    target: /var/www/docs
+    mode: clean
+
+safety:
+  max_deletes: 500             # 0 = unlimited
+
+advanced:
+  retries: 2
+  timeout: 30
+  stall_timeout: 0
+  concurrency: auto            # or a number
+  request_concurrency: auto
+  skip_unchanged: false
+
+permissions:
+  files: "0644"
+  directories: "0755"
+  preserve_times: false
+
+sync:
+  fast_path: false
+  manifest: .easysftp-manifest.json
 ```
 
-Rules:
+### Sections
 
-- **Directories** are uploaded recursively. Remote directories are created automatically.
-- **Single files** map onto the exact remote path, unless the remote side ends
-  with `/`, which means "into this directory" keeping the original file name.
-- Single files only support the `overlay` strategy (`sync`/`clean` reconcile a
+| Section | Required | Description |
+|---|---|---|
+| `version` | ✅ | Must be `3`. |
+| `connection` | ✅ | Where and as whom to connect. Credentials are **not** here; they stay inputs. |
+| `defaults` | | `mode` and `exclude` defaults applied to every deployment. |
+| `deployments` | ✅ | A **map** of named deployments (at least one). The name appears in logs and the job summary. |
+| `safety` | | `max_deletes` (0 = unlimited); see [delete guards](strategies.md#delete-guards). |
+| `advanced` | | Transfer tuning; the defaults suit most deploys. |
+| `permissions` | | Remote file/dir modes and `preserve_times` (all best-effort). |
+| `sync` | | The sync mode's manifest name and fast-path. |
+
+#### `connection`
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `host` | ✅ | - | Hostname or IP of the SFTP server. |
+| `port` | | `22` | SSH port. |
+| `username` | ✅ | - | Username for authentication. |
+| `host_key` | ³ | - | SHA256 fingerprint(s), one per line. |
+| `known_hosts` | ³ | - | `known_hosts`-format host key(s); alternative to `host_key`. |
+| `allow_any_host_key` | ³ | `false` | Explicit opt-out of host key verification. |
+| `proxy` | | - | Optional jump host; same fields (`host`, `port`, `username`, `host_key`, `known_hosts`, `allow_any_host_key`). |
+
+³ As in inline mode, exactly one of `host_key`/`known_hosts`/`allow_any_host_key` is required, per hop.
+
+#### `deployments.<name>`
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `source` | ✅ | - | Local file or directory to upload. |
+| `target` | ✅ | - | Remote path. |
+| `mode` | | `defaults.mode` | Per-deployment mode override. |
+| `exclude` | | - | Per-deployment excludes, additive to `defaults.exclude`. |
+
+#### `advanced`
+
+| Field | Default | Description |
+|---|---|---|
+| `retries` | `2` | Retries per file on transient errors, and the reconnect budget for dropped connections. `0` disables. |
+| `timeout` | `30` | Connection timeout in seconds. `0` disables. |
+| `stall_timeout` | `0` (off) | Abort when active remote operations make no progress for this many seconds. |
+| `concurrency` | `auto` (4) | Files uploaded in parallel. Also bounds the sync hashing worker pool. `auto` uses the built-in default. |
+| `request_concurrency` | `auto` (16) | Max in-flight SFTP requests per file (pipelining within one transfer). |
+| `skip_unchanged` | `false` | For `overlay`, skip a file whose remote counterpart has the same size (coarse; `sync` compares content hashes). |
+
+#### `permissions`
+
+| Field | Default | Description |
+|---|---|---|
+| `files` | mirror local | Octal permission (e.g. `"0644"`) for every uploaded file. |
+| `directories` | server umask | Octal permission (e.g. `"0755"`) for every remote directory the run creates or touches. |
+| `preserve_times` | `false` | Keep each uploaded file's local modification time on the server. |
+
+All three are best-effort: a server that rejects the `SETSTAT` request
+produces one warning per run, not a failure.
+
+#### `sync`
+
+| Field | Default | Description |
+|---|---|---|
+| `fast_path` | `false` | Reuse a file's manifest hash when size+mtime still match (rsync-style quick check). See [strategies](strategies.md#syncfast_path-skip-re-hashing-unchanged-files). |
+| `manifest` | `.easysftp-manifest.json` | Manifest file name (bare, no path). An unguessable name mitigates [the manifest being publicly downloadable](security.md#the-sync-manifest-in-web-roots). |
+
+### Validation
+
+Unknown keys are rejected with a location and a suggestion:
+
+```text
+config ".github/easysftp.yml": unknown option "concurency" at "advanced.concurency"; did you mean "concurrency"?
+```
+
+A `version: 1` file (or a `targets` list) is rejected with a pointer to the
+[migration guide](migration-v3.md). The bundled
+[JSON Schema](../schema/easysftp.schema.json) gives the same validation live
+in editors that honor the `# yaml-language-server` modeline.
+
+## The `source` / `target` mapping
+
+In inline mode, `source` is one local path and `target` its remote
+destination:
+
+- **Directories** are uploaded recursively. Remote directories are created
+  automatically.
+- **Single files** map onto the exact remote path, unless `target` ends with
+  `/`, which means "into this directory" keeping the original file name.
+- Single files only support the `overlay` mode (`sync`/`clean` reconcile a
   directory tree and are rejected for single-file targets).
 - Symlinks, sockets and other non-regular files are skipped.
 
-## Ignore patterns
+```yaml
+    source: ./config/prod.json
+    target: /etc/app/config.json     # rename on the fly
+```
 
-`ignore` (inline) and `ignore-from` (a file, e.g. `.sftpignore`) use
+For more than one mapping, use a config file with multiple named
+[deployments](#deploymentsname).
+
+## Exclude patterns
+
+`exclude` (inline, one pattern per line) and `defaults.exclude` /
+per-deployment `exclude` (config file) use
 [gitignore syntax](https://git-scm.com/docs/gitignore):
 
 ```yaml
-ignore: |
+exclude: |
   *.map
   *.log
   node_modules/
   !important.log
 ```
 
-- Patterns are matched against the path **relative to the local root** of each target.
+- Patterns are matched against the path **relative to the local root** of each
+  deployment.
 - `!pattern` re-includes files excluded by an earlier pattern.
-- `ignore` and `ignore-from` are additive; in the config file, per-target
-  `ignore` lists add to the global one.
+- In the config file, per-deployment `exclude` lists add to `defaults.exclude`.
 - An ignored directory (e.g. `node_modules/`) is skipped without being walked
   at all, so huge excluded trees cost nothing during planning. This pruning is
   automatically disabled as soon as any pattern is a `!` re-include, because a
   re-include may point below an ignored directory; results are identical either
   way, only planning speed differs.
 
-## The YAML config file
+## Outputs
 
-For multiple targets with different strategies, point `config-file` at a YAML
-file. Connection settings (server, credentials, host key) always stay in the
-action inputs. **Never put credentials in this file**.
+| Output | Description |
+|---|---|
+| `files-uploaded` | Number of uploaded files (planned files in dry-run mode). |
+| `files-deleted` | Number of remote files removed by the `clean`/`sync` mode. |
+| `files-skipped` | Number of unchanged files skipped (by `sync`, or by `overlay` with `advanced.skip_unchanged`). |
+| `bytes-uploaded` | Total bytes transferred (planned bytes in dry-run mode). |
+| `duration-ms` | Total runtime in milliseconds. |
 
-```yaml
-- uses: eiserv/easySFTP@v2
-  with:
-    server: sftp.example.com
-    username: ${{ secrets.SFTP_USERNAME }}
-    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
-    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-    config-file: .github/easysftp.yml
-```
+A summary is also written to the job summary of every run: status, host-key
+verification status, the configuration source (inline or the config path), the
+run totals, and, when there is more than one deployment (or one named
+deployment), a per-deployment breakdown with each deployment's name, source,
+target, mode and its own counts. Outputs and the summary are populated even if
+a transfer fails partway; the values reflect progress before the failure and
+the summary is marked as failed. Use `if: ${{ always() }}` when a later
+reporting or rollback step must consume these partial results. See
+[examples](examples.md#using-the-outputs).
 
-```yaml
-# .github/easysftp.yml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/eiserv/easySFTP/main/schema/easysftp.schema.json
-version: 1
-strategy: overlay          # default for all targets
-ignore:
-  - "*.map"
-guards:
-  max_deletes: 200         # 0 = unlimited
-targets:
-  - local: ./dist/
-    remote: /var/www/html/
-    strategy: sync
-  - local: ./docs/
-    remote: /var/www/docs/
-    strategy: clean
-```
+The `files-*`/`bytes-uploaded` outputs stay run-wide totals; there is no
+per-deployment output.
 
-### Fields
+## Complete input reference
 
-| Field | Required | Default | Description |
-|---|---|---|---|
-| `version` | ✅ | - | Config format version. Must be `1`. |
-| `strategy` | | `overlay` | Default strategy for all targets. |
-| `ignore` | | - | Global gitignore-style excludes, applied to every target. |
-| `guards.max_deletes` | | `0` | Abort a run that would delete more files than this (0 = unlimited). See [delete guards](strategies.md#delete-guards). |
-| `targets` | ✅ | - | List of upload targets (at least one). |
-| `targets[].local` | ✅ | - | Local file or directory. |
-| `targets[].remote` | ✅ | - | Remote path. |
-| `targets[].strategy` | | global | Per-target strategy override. |
-| `targets[].ignore` | | - | Per-target excludes, additive to the global list. |
+Every action input, for reference. In v3 the action surface is deliberately
+small; the advanced knobs moved into the config file (see
+[the config file](#the-config-file)).
 
-Unknown keys are rejected with an error (they are never silently ignored), and
-`config-file` cannot be combined with the `uploads`, `strategy`, `ignore`,
-`ignore-from` or `max-deletes` inputs.
+| Input | Mode | Description |
+|---|---|---|
+| `host`, `port`, `username` | inline | Connection target. |
+| `password`, `private-key`, `passphrase` | both | Credentials (always from secrets). |
+| `host-key`, `known-hosts`, `allow-any-host-key` | inline | Host key verification. |
+| `source`, `target`, `mode`, `exclude` | inline | The single deployment. |
+| `config` | config | Path to the version-3 config file. |
+| `proxy-password`, `proxy-private-key`, `proxy-passphrase` | config | Jump-host credentials (the rest of the proxy config is in the file). |
+| `dry-run`, `log-level` | both | Run-wide switches. |
 
-### Editor support
-
-The `# yaml-language-server` modeline at the top of the file enables
-autocomplete and validation in editors from the bundled
-[JSON Schema](../schema/easysftp.schema.json). A fully commented example lives
-at [easysftp.example.yml](easysftp.example.yml).
+Removed v2 inputs (`server`, `uploads`, `strategy`, `ignore`, `ignore-from`,
+`config-file`, `host-key-fingerprint`, `max-deletes`, `concurrency`,
+`sftp-request-concurrency`, `retries`, `timeout`, `stall-timeout`,
+`sync-fast-path`, `skip-unchanged`, `manifest-name`, `dir-mode`, `file-mode`,
+`preserve-times`, the `proxy-server`/`proxy-port`/`proxy-username`/
+`proxy-host-key-fingerprint`/`proxy-known-hosts` connection inputs,
+`build-mode`, and the `delete` tombstone) still fail loudly with a migration
+hint rather than being silently ignored. See the
+[migration guide](migration-v3.md) for the full mapping.

--- a/docs/easysftp.example.yml
+++ b/docs/easysftp.example.yml
@@ -1,40 +1,88 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/eiserv/easySFTP/main/schema/easysftp.schema.json
 #
-# Example easySFTP config file. Point the action at it with:
-#   config-file: .github/easysftp.yml
+# Example easySFTP config file (version 3). Point the action at it with:
+#   config: .github/easysftp.yml
 #
-# Connection settings (server, username, password/private-key, host key) stay
-# in the action inputs / GitHub secrets; never put credentials in this file.
+# The config file holds every non-secret setting. Credentials (password,
+# private-key, passphrase and the proxy-* counterparts) stay in GitHub
+# Secrets and are passed as action inputs; never put them in this file.
 
-version: 1
+version: 3
 
-# Default strategy for every target unless overridden per target:
-#   overlay – upload only, never delete (default)
-#   sync    – upload changed files, delete files no longer present locally
-#   clean   – wipe the remote target directory, then upload
-strategy: overlay
+connection:
+  host: sftp.example.com
+  port: 22 # optional, 22 is the default
+  username: deploy
+  # Pin the server's host key(s): SHA256 fingerprints, one per line.
+  # Get them with: ssh-keyscan sftp.example.com | ssh-keygen -lf -
+  host_key: |
+    SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+  # Alternative (or addition): raw ssh-keyscan output.
+  # known_hosts: |
+  #   sftp.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...
+  #
+  # Without host_key or known_hosts the run fails. To explicitly accept any
+  # host key instead (NOT recommended, allows man-in-the-middle attacks):
+  # allow_any_host_key: true
+  #
+  # Optional jump host (bastion), like OpenSSH's ProxyJump. Credentials come
+  # from the proxy-password / proxy-private-key action inputs.
+  # proxy:
+  #   host: bastion.example.com
+  #   username: jumper
+  #   host_key: |
+  #     SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM
 
-# Global excludes applied to every target (gitignore syntax).
-ignore:
-  - "*.map"
-  - "*.log"
+# Defaults for every deployment unless overridden per deployment.
+defaults:
+  # overlay - upload only, never delete (default)
+  # sync    - upload changed files, delete files no longer present locally
+  # clean   - wipe the remote target directory, then upload
+  mode: overlay
+  exclude:
+    - "*.map"
+    - "*.log"
 
-guards:
+# Named deployments. The names appear in logs and the job summary.
+deployments:
+  website:
+    source: ./dist/
+    target: /var/www/html/
+    mode: sync
+    exclude:
+      - node_modules/
+
+  documentation:
+    source: ./docs/build/
+    target: /var/www/docs/
+    mode: clean
+
+  robots:
+    source: ./robots.txt
+    target: /var/www/html/robots.txt
+    # single files only support the overlay mode
+
+safety:
   # Abort if a run would delete more than this many files (0 = unlimited).
   # Deleting the remote root ("/") is always refused, independent of this.
   max_deletes: 200
 
-targets:
-  - local: ./dist/
-    remote: /var/www/html/
-    strategy: sync
-    ignore:
-      - node_modules/
+# Transfer tuning; the defaults suit most deployments.
+advanced:
+  retries: 2 # per-file retries and reconnect budget; 0 disables
+  timeout: 30 # connection timeout in seconds; 0 disables
+  stall_timeout: 0 # abort after this many seconds without progress; 0 = off
+  concurrency: auto # files uploaded in parallel ("auto" = built-in default)
+  request_concurrency: auto # in-flight SFTP requests per file
+  skip_unchanged: false # overlay only: skip same-size remote files
 
-  - local: ./docs/
-    remote: /var/www/docs/
-    strategy: clean
+# Remote permission and timestamp handling (all best-effort).
+permissions:
+  files: "0644" # chmod every uploaded file; omit to mirror local modes
+  directories: "0755" # chmod every created/touched remote directory
+  preserve_times: false # keep local modification times on the server
 
-  - local: ./robots.txt
-    remote: /var/www/html/robots.txt
-    # single files only support the overlay strategy
+# Sync-mode manifest settings.
+sync:
+  fast_path: false # reuse manifest hashes when size+mtime still match
+  manifest: .easysftp-manifest.json # bare file name, no path

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,13 +5,13 @@ stored as [encrypted secrets](https://docs.github.com/en/actions/security-guides
 
 - [Deploy a static site](#deploy-a-static-site)
 - [Mirror a build with sync](#mirror-a-build-with-sync)
-- [Multiple targets with a config file](#multiple-targets-with-a-config-file)
+- [Multiple deployments with a config file](#multiple-deployments-with-a-config-file)
 - [Key-based authentication](#key-based-authentication)
 - [Deploy through a jump host (bastion)](#deploy-through-a-jump-host-bastion)
 - [Upload a single file (with rename)](#upload-a-single-file-with-rename)
 - [Preview a deploy in pull requests](#preview-a-deploy-in-pull-requests)
 - [Using the outputs](#using-the-outputs)
-- [Excludes via .sftpignore](#excludes-via-sftpignore)
+- [Excludes](#excludes)
 - [Windows and macOS runners](#windows-and-macos-runners)
 
 ## Deploy a static site
@@ -32,13 +32,14 @@ jobs:
       - run: npm ci && npm run build
 
       - name: Deploy via SFTP
-        uses: eiserv/easySFTP@v2
+        uses: eiserv/easySFTP@v3
         with:
-          server: sftp.example.com
+          host: sftp.example.com
           username: ${{ secrets.SFTP_USERNAME }}
           password: ${{ secrets.SFTP_PASSWORD }}
-          host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-          uploads: ./dist/ => /var/www/html/
+          host-key: ${{ secrets.SFTP_HOST_KEY }}
+          source: ./dist/
+          target: /var/www/html/
 ```
 
 ## Mirror a build with sync
@@ -49,97 +50,128 @@ only files easySFTP itself uploaded ([manifest-based](strategies.md#sync), so
 user uploads and server-generated files survive):
 
 ```yaml
-- uses: eiserv/easySFTP@v2
+- uses: eiserv/easySFTP@v3
   with:
-    server: sftp.example.com
+    host: sftp.example.com
     username: ${{ secrets.SFTP_USERNAME }}
     password: ${{ secrets.SFTP_PASSWORD }}
-    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-    uploads: ./dist/ => /var/www/html/
-    strategy: sync
+    host-key: ${{ secrets.SFTP_HOST_KEY }}
+    source: ./dist/
+    target: /var/www/html/
+    mode: sync
 ```
 
-## Multiple targets with a config file
+## Multiple deployments with a config file
 
-Different directories, different strategies, one connection:
+Different directories, different modes, one connection. In config mode every
+non-secret setting lives in the file; the workflow step carries only the
+config path and credentials:
 
 ```yaml
-- uses: eiserv/easySFTP@v2
+- uses: eiserv/easySFTP@v3
   with:
-    server: sftp.example.com
-    username: ${{ secrets.SFTP_USERNAME }}
+    config: .github/easysftp.yml
     private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
-    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-    config-file: .github/easysftp.yml
 ```
 
 ```yaml
 # .github/easysftp.yml
-version: 1
-strategy: overlay
-ignore:
-  - "*.map"
-guards:
+version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: |
+    SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+defaults:
+  mode: overlay
+  exclude:
+    - "*.map"
+safety:
   max_deletes: 200
-targets:
-  - local: ./dist/
-    remote: /var/www/html/
-    strategy: sync
-  - local: ./docs/
-    remote: /var/www/docs/
-    strategy: clean
-  - local: ./robots.txt
-    remote: /var/www/html/robots.txt
+deployments:
+  website:
+    source: ./dist/
+    target: /var/www/html/
+    mode: sync
+  documentation:
+    source: ./docs/
+    target: /var/www/docs/
+    mode: clean
+  robots:
+    source: ./robots.txt
+    target: /var/www/html/robots.txt
 ```
 
-Full field reference: [configuration.md](configuration.md#the-yaml-config-file).
+Full field reference: [configuration.md](configuration.md#the-config-file).
 
 ## Key-based authentication
 
 Preferred over passwords, see the [security guide](security.md#credentials):
 
 ```yaml
-- uses: eiserv/easySFTP@v2
+- uses: eiserv/easySFTP@v3
   with:
-    server: sftp.example.com
+    host: sftp.example.com
     username: ${{ secrets.SFTP_USERNAME }}
     private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
     passphrase: ${{ secrets.SFTP_PASSPHRASE }}   # only if the key is encrypted
-    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-    uploads: ./dist/ => /var/www/html/
+    host-key: ${{ secrets.SFTP_HOST_KEY }}
+    source: ./dist/
+    target: /var/www/html/
 ```
 
 ## Deploy through a jump host (bastion)
 
 For servers that are not reachable from the public internet, connect through
-a bastion like OpenSSH's `ProxyJump`. Each hop has its own credentials and
-its own host key verification (see
-[configuration](configuration.md#jump-host-bastion)):
+a bastion like OpenSSH's `ProxyJump`. In v3 the jump host's connection lives
+in the config file (`connection.proxy`); only its credentials stay inputs.
+Each hop has its own credentials and its own host key verification (see
+[configuration](configuration.md#connection)):
 
 ```yaml
-- uses: eiserv/easySFTP@v2
+- uses: eiserv/easySFTP@v3
   with:
-    server: sftp.internal.example.com
-    username: ${{ secrets.SFTP_USERNAME }}
+    config: .github/easysftp.yml
     private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
-    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-    proxy-server: bastion.example.com
-    proxy-username: ${{ secrets.JUMP_USERNAME }}
     proxy-private-key: ${{ secrets.JUMP_PRIVATE_KEY }}
-    proxy-host-key-fingerprint: ${{ secrets.JUMP_HOST_KEY_FINGERPRINT }}
-    uploads: ./dist/ => /var/www/html/
+```
+
+```yaml
+# .github/easysftp.yml
+version: 3
+connection:
+  host: sftp.internal.example.com
+  username: deploy
+  host_key: |
+    SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+  proxy:
+    host: bastion.example.com
+    username: jumper
+    host_key: |
+      SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM
+deployments:
+  website:
+    source: ./dist/
+    target: /var/www/html/
 ```
 
 ## Upload a single file (with rename)
 
 A single file maps onto the exact remote path, so you can rename on the fly.
-A trailing `/` on the remote side means "into this directory" instead:
+A trailing `/` on the target means "into this directory" instead:
 
 ```yaml
-uploads: |
-  ./config/prod.json => /etc/app/config.json
-  ./robots.txt => /var/www/html/
+- uses: eiserv/easySFTP@v3
+  with:
+    host: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    password: ${{ secrets.SFTP_PASSWORD }}
+    host-key: ${{ secrets.SFTP_HOST_KEY }}
+    source: ./config/prod.json
+    target: /etc/app/config.json
 ```
+
+For more than one file, use a config file with multiple named deployments.
 
 ## Preview a deploy in pull requests
 
@@ -158,14 +190,15 @@ jobs:
       - run: npm ci && npm run build
 
       - name: What would deploy?
-        uses: eiserv/easySFTP@v2
+        uses: eiserv/easySFTP@v3
         with:
-          server: sftp.example.com
+          host: sftp.example.com
           username: ${{ secrets.SFTP_USERNAME }}
           password: ${{ secrets.SFTP_PASSWORD }}
-          host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-          uploads: ./dist/ => /var/www/html/
-          strategy: sync
+          host-key: ${{ secrets.SFTP_HOST_KEY }}
+          source: ./dist/
+          target: /var/www/html/
+          mode: sync
           dry-run: true
 ```
 
@@ -176,7 +209,7 @@ Give the step an `id` and read the outputs in later steps:
 ```yaml
 - name: Deploy via SFTP
   id: deploy
-  uses: eiserv/easySFTP@v2
+  uses: eiserv/easySFTP@v3
   with:
     # ...
 
@@ -188,24 +221,36 @@ Give the step an `id` and read the outputs in later steps:
     echo "${{ steps.deploy.outputs.bytes-uploaded }} bytes in ${{ steps.deploy.outputs.duration-ms }} ms"
 ```
 
-## Excludes via .sftpignore
+## Excludes
 
-Keep the exclude list out of the workflow file:
+Keep noise out of the upload. Inline, one pattern per line:
 
 ```yaml
-- uses: eiserv/easySFTP@v2
+- uses: eiserv/easySFTP@v3
   with:
     # ...
-    uploads: ./dist/ => /var/www/html/
-    ignore-from: .sftpignore
+    source: ./dist/
+    target: /var/www/html/
+    exclude: |
+      *.map
+      *.log
+      node_modules/
+      !keep-this.log
 ```
 
-```gitignore
-# .sftpignore, gitignore syntax
-*.map
-*.log
-node_modules/
-!keep-this.log
+In a config file, split them into a global `defaults.exclude` and
+per-deployment `exclude` lists (they add up):
+
+```yaml
+defaults:
+  exclude:
+    - "*.map"
+deployments:
+  website:
+    source: ./dist/
+    target: /var/www/html/
+    exclude:
+      - node_modules/
 ```
 
 ## Windows and macOS runners
@@ -219,11 +264,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: eiserv/easySFTP@v2
+      - uses: eiserv/easySFTP@v3
         with:
-          server: sftp.example.com
+          host: sftp.example.com
           username: ${{ secrets.SFTP_USERNAME }}
           password: ${{ secrets.SFTP_PASSWORD }}
-          host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
-          uploads: .\build\ => /var/www/html/
+          host-key: ${{ secrets.SFTP_HOST_KEY }}
+          source: .\build\
+          target: /var/www/html/
 ```

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -1,0 +1,344 @@
+# Migrating from v2 to v3
+
+v3 simplifies easySFTP's configuration model around one rule:
+
+> Inline inputs for an ordinary single-target deployment. One config file for
+> everything complex. GitHub Secrets only for secret values. No mixed mode.
+
+Every non-secret setting now has exactly one home. There is no precedence
+between workflow inputs and the config file, because the two can no longer
+overlap. Old v2 inputs fail with a migration hint instead of being silently
+ignored.
+
+- [The two v3 modes](#the-two-v3-modes)
+- [Breaking changes at a glance](#breaking-changes-at-a-glance)
+- [Renamed and removed inputs](#renamed-and-removed-inputs)
+- [Migrating a simple v2 workflow](#migrating-a-simple-v2-workflow)
+- [Migrating multiple upload mappings](#migrating-multiple-upload-mappings)
+- [Migrating a v1 config file](#migrating-a-v1-config-file)
+- [Migrating advanced settings](#migrating-advanced-settings)
+- [Migrating a jump host (bastion) setup](#migrating-a-jump-host-bastion-setup)
+- [Host key verification is now required](#host-key-verification-is-now-required)
+- [Logging changes](#logging-changes)
+
+## The two v3 modes
+
+**Inline mode**: one deployment, configured entirely in `with:`.
+
+```yaml
+- uses: eiserv/easySFTP@v3
+  with:
+    host: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    password: ${{ secrets.SFTP_PASSWORD }}
+    host-key: ${{ secrets.SFTP_HOST_KEY }}
+    source: dist
+    target: /var/www/html
+```
+
+**Config mode**: `config` points at a YAML file (version 3) that holds every
+non-secret setting, including the connection. Only credentials, `dry-run` and
+`log-level` may be combined with it.
+
+```yaml
+- uses: eiserv/easySFTP@v3
+  with:
+    config: .github/easysftp.yml
+    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
+```
+
+## Breaking changes at a glance
+
+- `server` was renamed to `host`, `uploads` was replaced by `source` +
+  `target`, `strategy` is now `mode`, `ignore` is now `exclude`,
+  `host-key-fingerprint` is now `host-key`, `config-file` is now `config`.
+- Multiple upload mappings require a config file; inline mode supports
+  exactly one deployment.
+- All advanced/tuning inputs (`concurrency`, `retries`, `timeout`,
+  `stall-timeout`, `sftp-request-concurrency`, `sync-fast-path`,
+  `skip-unchanged`, `manifest-name`, `dir-mode`, `file-mode`,
+  `preserve-times`, `max-deletes`) moved into the config file.
+- All proxy/bastion connection inputs moved into the config file
+  (`connection.proxy`); only the proxy credentials remain inputs.
+- The config file format changed: `version: 3`, connection settings live in
+  the file, and targets became **named deployments**.
+- **Host key verification is required.** A run without `host-key` /
+  `known-hosts` fails unless `allow-any-host-key: true` is set explicitly
+  (v2 printed a warning and accepted any key).
+- `build-mode` was removed; the build mode is selected automatically from
+  the action ref (release tags download the verified prebuilt binary,
+  development refs build from source).
+- The default log no longer prints one line per file; per-file output moved
+  to `log-level: verbose` (see [Logging changes](#logging-changes)).
+- The `delete` tombstone input from v1 was finally removed.
+
+What did **not** change: the three reconciliation behaviors (`overlay`,
+`sync`, `clean`, now under the name "mode"), the manifest format (a v2 sync
+manifest is picked up seamlessly), delete guards, atomic uploads, retries and
+reconnects, outputs, and the job summary outputs' names.
+
+## Renamed and removed inputs
+
+| v2 input | v3 replacement |
+|---|---|
+| `server` | `host` input, or `connection.host` in the config file |
+| `port` | `port` input, or `connection.port` |
+| `username` | `username` input, or `connection.username` |
+| `password`, `private-key`, `passphrase` | unchanged (credentials stay inputs) |
+| `host-key-fingerprint` | `host-key` input, or `connection.host_key` |
+| `known-hosts` | `known-hosts` input, or `connection.known_hosts` |
+| `uploads` | `source` + `target` inputs, or `deployments` in the config file |
+| `strategy` | `mode` input, or `defaults.mode` / per-deployment `mode` |
+| `ignore` | `exclude` input, or `defaults.exclude` / per-deployment `exclude` |
+| `ignore-from` | removed; put the patterns in `exclude` or the config file |
+| `config-file` | `config` (new file format, version 3) |
+| `max-deletes` | `safety.max_deletes` in the config file |
+| `concurrency` | `advanced.concurrency` in the config file |
+| `sftp-request-concurrency` | `advanced.request_concurrency` in the config file |
+| `retries` | `advanced.retries` in the config file |
+| `timeout` | `advanced.timeout` in the config file |
+| `stall-timeout` | `advanced.stall_timeout` in the config file |
+| `skip-unchanged` | `advanced.skip_unchanged` in the config file |
+| `sync-fast-path` | `sync.fast_path` in the config file |
+| `manifest-name` | `sync.manifest` in the config file |
+| `dir-mode` | `permissions.directories` in the config file |
+| `file-mode` | `permissions.files` in the config file |
+| `preserve-times` | `permissions.preserve_times` in the config file |
+| `proxy-server` | `connection.proxy.host` in the config file |
+| `proxy-port` | `connection.proxy.port` in the config file |
+| `proxy-username` | `connection.proxy.username` in the config file |
+| `proxy-host-key-fingerprint` | `connection.proxy.host_key` in the config file |
+| `proxy-known-hosts` | `connection.proxy.known_hosts` in the config file |
+| `proxy-password`, `proxy-private-key`, `proxy-passphrase` | unchanged (credentials stay inputs) |
+| `build-mode` | removed; selected automatically from the action ref |
+| `delete` | removed in v2 already; use `mode: clean` |
+| `dry-run`, `log-level` | unchanged (run-wide switches, valid in both modes) |
+
+## Migrating a simple v2 workflow
+
+Before (v2):
+
+```yaml
+- uses: eiserv/easySFTP@v2
+  with:
+    server: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    password: ${{ secrets.SFTP_PASSWORD }}
+    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+    uploads: ./dist/ => /var/www/html/
+    strategy: sync
+    ignore: "*.map"
+```
+
+After (v3):
+
+```yaml
+- uses: eiserv/easySFTP@v3
+  with:
+    host: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    password: ${{ secrets.SFTP_PASSWORD }}
+    host-key: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+    source: ./dist/
+    target: /var/www/html/
+    mode: sync
+    exclude: "*.map"
+```
+
+## Migrating multiple upload mappings
+
+Multiple `uploads` lines become named deployments in a config file:
+
+Before (v2):
+
+```yaml
+- uses: eiserv/easySFTP@v2
+  with:
+    server: sftp.example.com
+    username: ${{ secrets.SFTP_USERNAME }}
+    password: ${{ secrets.SFTP_PASSWORD }}
+    host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINT }}
+    uploads: |
+      ./dist/ => /var/www/html/
+      ./docs/build/ => /var/www/docs/
+```
+
+After (v3):
+
+```yaml
+- uses: eiserv/easySFTP@v3
+  with:
+    config: .github/easysftp.yml
+    password: ${{ secrets.SFTP_PASSWORD }}
+```
+
+```yaml
+# .github/easysftp.yml
+version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: ${SFTP_HOST_KEY}   # or paste the SHA256:... fingerprints
+deployments:
+  website:
+    source: ./dist/
+    target: /var/www/html/
+  documentation:
+    source: ./docs/build/
+    target: /var/www/docs/
+```
+
+Note that the username and host key are not secrets; committing them to the
+config file is fine (and keeps the workflow step minimal). If you prefer to
+keep the host key in a secret anyway, inline mode is the way to do that.
+
+## Migrating a v1 config file
+
+The v1 file (`version: 1`, `targets` list, connection in the workflow) is
+rejected by v3 with a clear error. Convert it:
+
+Before (v1 format):
+
+```yaml
+version: 1
+strategy: overlay
+ignore:
+  - "*.map"
+guards:
+  max_deletes: 200
+targets:
+  - local: ./dist/
+    remote: /var/www/html/
+    strategy: sync
+```
+
+After (v3 format):
+
+```yaml
+version: 3
+connection:
+  host: sftp.example.com        # moved out of the workflow
+  username: deploy
+  host_key: |
+    SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+defaults:
+  mode: overlay
+  exclude:
+    - "*.map"
+safety:
+  max_deletes: 200
+deployments:
+  website:                      # targets got names
+    source: ./dist/             # local  -> source
+    target: /var/www/html/      # remote -> target
+    mode: sync                  # strategy -> mode
+```
+
+## Migrating advanced settings
+
+Advanced inputs moved into structured config sections. A v2 step like:
+
+```yaml
+    retries: 4
+    timeout: 60
+    stall-timeout: 120
+    concurrency: 8
+    sftp-request-concurrency: 8
+    dir-mode: "755"
+    file-mode: "644"
+    preserve-times: "true"
+    manifest-name: .deploy-manifest.json
+    sync-fast-path: "true"
+    max-deletes: 500
+```
+
+becomes, in the config file:
+
+```yaml
+advanced:
+  retries: 4
+  timeout: 60
+  stall_timeout: 120
+  concurrency: 8
+  request_concurrency: 8
+permissions:
+  directories: "0755"
+  files: "0644"
+  preserve_times: true
+sync:
+  manifest: .deploy-manifest.json
+  fast_path: true
+safety:
+  max_deletes: 500
+```
+
+If you tuned these in a single-target v2 workflow, you now need a (small)
+config file; the automatic defaults cover the common case without any of
+them.
+
+## Migrating a jump host (bastion) setup
+
+The proxy connection moved into the config file; only the credentials stay
+inputs:
+
+```yaml
+- uses: eiserv/easySFTP@v3
+  with:
+    config: .github/easysftp.yml
+    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
+    proxy-private-key: ${{ secrets.JUMP_PRIVATE_KEY }}
+```
+
+```yaml
+# .github/easysftp.yml
+version: 3
+connection:
+  host: sftp.internal.example.com
+  username: deploy
+  host_key: |
+    SHA256:...
+  proxy:
+    host: bastion.example.com
+    username: jumper
+    host_key: |
+      SHA256:...
+deployments:
+  website:
+    source: ./dist/
+    target: /var/www/html/
+```
+
+## Host key verification is now required
+
+In v2, a run without `host-key-fingerprint`/`known-hosts` printed a warning
+and accepted **any** host key. In v3 such a run fails. Either pin the key
+(recommended, takes one command):
+
+```console
+$ ssh-keyscan sftp.example.com | ssh-keygen -lf -
+```
+
+```yaml
+    host-key: ${{ secrets.SFTP_HOST_KEY }}
+```
+
+or opt out explicitly, accepting that a man-in-the-middle can intercept the
+deployment and the credentials:
+
+```yaml
+    allow-any-host-key: "true"
+```
+
+The opt-out still logs a warning on every run. In the config file the
+equivalents are `connection.host_key`, `connection.known_hosts` and
+`connection.allow_any_host_key` (and the same fields under
+`connection.proxy` for the jump-host hop).
+
+## Logging changes
+
+The default log is compact in v3: connection status, one summary line per
+deployment, warnings, errors and the final totals. What v2 logged by default
+(one line per uploaded/deleted file) moved to `log-level: verbose`; v2's
+`verbose` (exclude-pattern explanations) is now `log-level: debug`; v2's
+`quiet` is gone because `normal` now covers it. Dry runs still always log
+the full per-file plan.

--- a/docs/security.md
+++ b/docs/security.md
@@ -3,12 +3,15 @@
 How to run easySFTP safely. See also the project's
 [security policy](../SECURITY.md) for reporting vulnerabilities.
 
-## Pin the host key (strongly recommended)
+## Pin the host key (required)
 
-Without `host-key-fingerprint` or `known-hosts`, easySFTP prints a warning
-and accepts **any** host key. Convenient for a first test, but vulnerable to
-man-in-the-middle attacks. Pin your server's keys once, in whichever format
-you already have:
+In v3, host key verification is **required**: a run without `host-key` or
+`known-hosts` fails, instead of silently trusting whatever key the server
+presents (v2 only warned). To connect anyway without verification, you must
+opt out explicitly with `allow-any-host-key: true` (in the config file:
+`connection.allow_any_host_key: true`), which still logs a warning on every
+run and leaves you open to man-in-the-middle attacks. Pinning is the safe
+default; do it once, in whichever format you already have:
 
 **Option A: `known-hosts`** takes raw OpenSSH `known_hosts` lines, exactly
 what `ssh-keyscan` prints (or the server's lines from your own
@@ -28,7 +31,7 @@ known-hosts: ${{ secrets.SFTP_KNOWN_HOSTS }}
 Hashed entries (`|1|...`) and `[host]:port` entries for non-standard ports
 (what `ssh-keyscan -p 2222` prints) work too.
 
-**Option B: `host-key-fingerprint`** takes SHA256 fingerprints, one per line:
+**Option B: `host-key`** takes SHA256 fingerprints, one per line:
 
 ```console
 $ ssh-keyscan sftp.example.com | ssh-keygen -lf -
@@ -38,7 +41,7 @@ $ ssh-keyscan sftp.example.com | ssh-keygen -lf -
 ```
 
 ```yaml
-host-key-fingerprint: ${{ secrets.SFTP_HOST_KEY_FINGERPRINTS }}
+host-key: ${{ secrets.SFTP_HOST_KEY }}
 ```
 
 Either way, the connection is accepted if the server presents a key matching
@@ -91,17 +94,26 @@ Apache (vhost or `.htaccess`):
 </Files>
 ```
 
-If you use a custom `manifest-name`, adjust the path/name accordingly.
+If you use a custom `sync.manifest` name, adjust the path/name accordingly.
 
-**Give it an unguessable name** with the `manifest-name` input, e.g. a random
-suffix stored as a repository secret:
+**Give it an unguessable name** with the `sync.manifest` config field, e.g. a
+random suffix:
 
 ```yaml
-- uses: eiserv/easySFTP@v2
-  with:
-    # ...
-    strategy: sync
-    manifest-name: ${{ secrets.EASYSFTP_MANIFEST_NAME }}  # e.g. .manifest-c4f81b52.json
+# .github/easysftp.yml
+version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: |
+    SHA256:...
+deployments:
+  website:
+    source: ./dist/
+    target: /var/www/html/
+    mode: sync
+sync:
+  manifest: .manifest-c4f81b52.json
 ```
 
 This mitigates casual discovery, but the file is still served if its name
@@ -119,28 +131,19 @@ behind; delete the old file manually.
 
 ## Supply-chain safety
 
-- Release refs use `build-mode: prebuilt` by default. The launcher validates
-  `.easysftp-version`, maps only the supported OS/architecture pairs, downloads
-  only the matching binary and `checksums.txt` from
+- Release refs download a verified prebuilt binary automatically. The launcher
+  validates `.easysftp-version`, maps only the supported OS/architecture pairs,
+  downloads only the matching binary and `checksums.txt` from
   `eiserv/easySFTP`'s exact GitHub Release, and verifies SHA-256 before
   execution. Release downloads may follow GitHub's HTTPS redirect to its own
   release-asset CDN; no third-party download source is configured.
-- Pin the action to a major tag for convenience (`eiserv/easySFTP@v2`) or to
-  the full commit SHA of an exact release. Prebuilt mode verifies that a SHA is
-  the commit behind the version file's release tag. For any development SHA,
-  explicitly build that checkout from source so a stale release binary can
-  never be substituted:
-
-  ```yaml
-  - uses: eiserv/easySFTP@<commit-sha>
-    with:
-      build-mode: source
-  ```
-
-- Exact version tags (`v1.2.3`) are immutable once published; `v1` and `v1.2`
+- Pin the action to a major tag for convenience (`eiserv/easySFTP@v3`) or to
+  the full commit SHA of an exact release; both use the verified prebuilt
+  binary. Any development ref (`@main`, a non-release commit SHA, or local
+  `uses: ./`) builds the checked-out source from scratch instead, so a stale
+  release binary can never be substituted. The build mode is selected
+  automatically from the ref; there is no `build-mode` input to get wrong.
+- Exact version tags (`v3.0.0`) are immutable once published; `v3` and `v3.0`
   are rolling tags, see [RELEASING.md](RELEASING.md#tag-policy).
-- `build-mode: source` installs Go and compiles the selected action checkout.
-  Use it for `@main`, local actions, non-release commit SHAs, or source-level
-  debugging.
 - Grant the deploy job only the permissions it needs
   (`permissions: contents: read` is enough for easySFTP itself).

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,16 +1,21 @@
-# Strategies
+# Deployment modes
 
-A *strategy* decides how each target's remote directory is reconciled with
+A *mode* decides how each deployment's remote directory is reconciled with
 your local files.
 
-| Strategy | Uploads | Deletes | Use for |
+| Mode | Uploads | Deletes | Use for |
 |---|---|---|---|
 | `overlay` (default) | all files | nothing | adding/updating files, leaving everything else in place |
 | `sync` | new & changed files | files a previous sync uploaded but that are now gone locally | keeping a directory an exact mirror of your build, safely |
 | `clean` | all files | **everything** in the remote target first | a guaranteed-fresh deploy |
 
-Set the strategy globally with the `strategy` input, or per target in the
-[config file](configuration.md#the-yaml-config-file).
+Set the mode inline with the `mode` input, or in the
+[config file](configuration.md#the-config-file) as `defaults.mode` (global)
+or a per-deployment `mode`.
+
+> **Renamed in v3.** What v2 called the `strategy` input (and `strategy:` in
+> the config file) is the `mode` input and `mode:` field in v3. The three
+> behaviors are unchanged. See the [migration guide](migration-v3.md).
 
 ## `overlay`
 
@@ -23,26 +28,27 @@ two planned transfers never share a temp name) and renamed over the target
 only once the transfer fully succeeded. A broken connection never leaves a
 half-written file where the live one was.
 
-### `skip-unchanged`: skip same-size files
+### `advanced.skip_unchanged`: skip same-size files
 
 By default, `overlay` re-uploads **every** file on every deploy. Setting
-`skip-unchanged: true` stats each remote file first and skips the upload when
-the remote file already exists with the same size, which turns a re-deploy of
-a mostly-unchanged tree from "transfer everything" into "one cheap stat per
-unchanged file". Skipped files count into the `files-skipped` output and are
-left completely untouched (no permission change either).
+`advanced.skip_unchanged: true` in the config file stats each remote file
+first and skips the upload when the remote file already exists with the same
+size, which turns a re-deploy of a mostly-unchanged tree from "transfer
+everything" into "one cheap stat per unchanged file". Skipped files count into
+the `files-skipped` output and are left completely untouched (no permission
+change either).
 
 **The trade-off, precisely:** the comparison is size-only. An edit that keeps
 the file size identical is invisible to it and will *not* be uploaded. Remote
 modification times are not compared; without controlling them at upload time
 they mean nothing. If you need exact change detection, use the `sync`
-strategy, whose manifest compares content hashes; `skip-unchanged` is for
+mode, whose manifest compares content hashes; `skip_unchanged` is for
 targets where you want cheap incremental behavior *without* easySFTP writing
 any state (like the sync manifest) to the server.
 
-`skip-unchanged` only applies to `overlay` targets. `sync` already skips
+`skip_unchanged` only applies to `overlay` deployments. `sync` already skips
 unchanged files exactly, and `clean` wipes the target first, so both ignore
-the input (with a warning).
+the setting (with a warning).
 
 ## `sync`
 
@@ -69,12 +75,12 @@ Notes:
   manifest (best effort), so a retried deploy resumes where it left off
   instead of re-uploading files that already made it.
 - Local files are hashed in parallel through a worker pool bounded by
-  `concurrency`, so planning a large tree uses the available runner CPU.
+  `advanced.concurrency`, so planning a large tree uses the available runner CPU.
 - Remote directories are only created (or confirmed) for files actually being
   uploaded, so a sync with nothing to do costs just the manifest read and
-  rewrite, no per-directory round-trips. Exception: with `dir-mode` set, every
-  directory of the plan is still chmod'd, per its documented "creates or
-  touches" semantics.
+  rewrite, no per-directory round-trips. Exception: with `permissions.directories`
+  set, every directory of the plan is still chmod'd, per its documented
+  "creates or touches" semantics.
 
 > **⚠️ The manifest is publicly downloadable in web-root deployments.** The
 > manifest lives *inside* the deploy target, so when that target is a public
@@ -85,42 +91,42 @@ Notes:
 > configs do **not** block it (Apache's stock `.ht*` rule does not cover it).
 > Mitigations, strongest first: deny it in the web server config (copy-paste
 > snippets in [security.md](security.md#the-sync-manifest-in-web-roots)), or
-> give it an unguessable name with the `manifest-name` input.
+> give it an unguessable name with the `sync.manifest` config field.
 
-### `sync-fast-path`: skip re-hashing unchanged files
+### `sync.fast_path`: skip re-hashing unchanged files
 
 By default, `sync` re-reads and re-hashes **every** local file on every run to
 decide what changed; that's what makes its "unchanged" comparison exact. For
 a large tree where almost nothing changes, that's still a lot of local I/O.
 
-Setting `sync-fast-path: true` adds a cheaper check first: if a file's size
-and modification time still match what the manifest recorded for it last
-time, its stored hash is reused and the file is never re-read. This is the
-same trade rsync's "quick check" makes.
+Setting `sync.fast_path: true` in the config file adds a cheaper check first:
+if a file's size and modification time still match what the manifest recorded
+for it last time, its stored hash is reused and the file is never re-read.
+This is the same trade rsync's "quick check" makes.
 
 **The trade-off, precisely:** a file whose content changed *without* its size
 or modification time changing is invisible to this check and will be missed;
 for example, two edits that happen to produce the same file size within the
 same mtime second (mtimes have one-second resolution on most filesystems).
-Without `sync-fast-path`, `sync` never misses a content change, because it
+Without `fast_path`, `sync` never misses a content change, because it
 always compares actual content hashes; this is what you give up in exchange
 for skipping local reads.
 
 **When it actually helps:** local modification times need to be meaningful
 across runs for the check to ever hit. A fresh `actions/checkout` gives every
-file a brand-new modification time on every run; `sync-fast-path` has
+file a brand-new modification time on every run; `fast_path` has
 nothing to skip there and degrades gracefully to full hashing. It pays off
 when the local tree is a restored build cache (`actions/cache`, a persisted
 runner, `git restore-timestamps`, …) whose unchanged files keep their old
 modification times between runs.
 
 If you suspect a stale hash was reused for the wrong reason, delete the
-target's `.easysftp-manifest.json` (or run `strategy: clean` once) to force a
+target's `.easysftp-manifest.json` (or run `mode: clean` once) to force a
 full re-hash on the next sync.
 
 Manifests written before this option existed have no recorded modification
 time; the first sync after upgrading re-hashes everything once and then
-starts recording it.
+starts recording it. (A v2 manifest is read seamlessly.)
 
 ## `clean`
 
@@ -128,22 +134,19 @@ Deletes **everything** inside the remote target directory first, then uploads
 all local files. Use it when you want a guaranteed-fresh deploy and nothing in
 the target directory needs to survive.
 
-The `delete: true` input was removed in v2; `strategy: clean` replaces it.
-
 ## Delete guards
 
 Two safety nets apply before `sync` or `clean` delete anything:
 
 - **Remote root is always refused.** A target that resolves to `/` (or `.`)
-  is rejected outright. No strategy will ever wipe a server root.
+  is rejected outright. No mode will ever wipe a server root.
 - **`max_deletes`** aborts a run that would delete more files than the limit,
   catching a misconfiguration before it does damage. `0` means unlimited. Set
-  it via the `max-deletes` input, or `guards.max_deletes` in the
-  [config file](configuration.md#fields) when using one.
+  it via `safety.max_deletes` in the [config file](configuration.md#sections).
 
 ## Dry runs
 
-Preview any strategy without touching the server:
+Preview any mode without touching the server:
 
 ```yaml
 dry-run: true

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,12 +6,21 @@ with the log of a `dry-run: true` run.
 
 ## Action startup problems
 
-### `prebuilt mode requires a release tag ref ... Use build-mode: source`
+### `the '<x>' input was ... in easySFTP v3`
 
-Prebuilt mode accepts `@vX`, `@vX.Y`, `@vX.Y.Z`, or the full commit SHA behind
-that exact release. For `@main`, other commit SHAs, or local `uses: ./`, add
-`build-mode: source`. This avoids silently running the last published binary
-for newer source code.
+You are passing a v2 input that was renamed or moved in v3 (e.g. `server`,
+`uploads`, `strategy`, `ignore`, `host-key-fingerprint`, `config-file`, or an
+advanced/proxy input). The error names the v3 replacement; the full mapping is
+in the [migration guide](migration-v3.md).
+
+### The build takes longer than expected on `@main` or a commit SHA
+
+The build mode is chosen automatically from the action ref. Release tags
+(`@v3`, `@v3.0`, `@v3.0.0`) and the exact release commit SHA download the
+verified prebuilt binary; every other ref (`@main`, other commit SHAs, local
+`uses: ./`) builds from source, which installs Go first. This is intended: it
+avoids silently running the last published binary for newer source code. There
+is no `build-mode` input in v3; setting it fails with a migration hint.
 
 ### `SHA-256 mismatch` or `checksums.txt has no SHA-256 entry`
 
@@ -25,12 +34,12 @@ release; do not bypass checksum verification.
 
 The runner cannot reach the server.
 
-- Check `server` and `port`.
+- Check `host` and `port`.
 - Many hosters firewall SSH to allowlisted IPs. GitHub-hosted runners use
   [changing IP ranges](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#ip-addresses),
   so an IP allowlist usually requires a self-hosted runner or a relaxed rule.
-- Raise `timeout` (default 30 s) if the server is just slow to accept
-  connections.
+- Raise the timeout (`advanced.timeout` in the config file, default 30 s) if
+  the server is just slow to accept connections.
 
 ### A large deploy dies partway through with an EOF or "connection lost"
 
@@ -65,7 +74,16 @@ The server presented a key that matches none of your pinned fingerprints.
 - You can pin multiple fingerprints (one per line); the connection is accepted
   if any matches.
 
-### `host-key-fingerprint must be a SHA256 fingerprint like 'SHA256:...'`
+### `the identity of <host> cannot be verified: no host-key or known-hosts configured`
+
+New in v3: a run without a pinned host key now fails instead of warning and
+connecting anyway. Set `host-key` (SHA256 fingerprints) or `known-hosts`
+(`ssh-keyscan` output). To connect without verification anyway (**not
+recommended**, allows man-in-the-middle attacks), set `allow-any-host-key:
+true`. In the config file the fields are `connection.host_key`,
+`connection.known_hosts` and `connection.allow_any_host_key`.
+
+### `host-key must be a SHA256 fingerprint like 'SHA256:...'`
 
 Pass the fingerprint (`SHA256:nThbg...`), not the raw `ssh-keyscan` line and
 not an MD5 fingerprint. Get the right format with:
@@ -87,9 +105,10 @@ relative to the chroot: `/upload/...`, not `/home/user/upload/...`.
 Directories created by the run get whatever the server's umask produces, and
 uploaded files mirror their local permission bits. On shared hosting where the
 web server runs as a different user than your SFTP account, that default can
-produce directories the web server can't read. Set `dir-mode` (and, if needed,
-`file-mode`) to force a known-good permission, e.g. `dir-mode: "755"` and
-`file-mode: "644"`. Both are best-effort; see [configuration.md](configuration.md#behavior).
+produce directories the web server can't read. Set `permissions.directories`
+(and, if needed, `permissions.files`) in the config file to force a known-good
+permission, e.g. `directories: "0755"` and `files: "0644"`. Both are
+best-effort; see [configuration.md](configuration.md#permissions).
 
 ### `replacing "<path>": ...` or leftover `.easysftp-tmp` files
 
@@ -130,8 +149,8 @@ No warning is logged when there is nothing to skip.
 
 `sync` only deletes files listed in its manifest: files it uploaded itself.
 Files that were already on the server before your first sync are never
-touched. Run `strategy: clean` once for a fresh start, then continue with
-`sync`. See [strategies](strategies.md#sync).
+touched. Run `mode: clean` once for a fresh start, then continue with
+`sync`. See [deployment modes](strategies.md#sync).
 
 ### What is `.easysftp-manifest.json` on my server?
 
@@ -140,7 +159,7 @@ hashes) the last sync uploaded. Leave it in place. Without it, the next sync
 re-uploads everything and deletes nothing. It is excluded from uploads and
 never deleted by `sync` itself.
 
-### `refusing a destructive strategy on remote root`
+### `refusing a destructive mode on remote root`
 
 `sync` and `clean` refuse to operate on `/` (or `.`) as the remote target,
 always. Deploy into a specific subdirectory instead. This guard cannot be
@@ -148,30 +167,38 @@ disabled; see [delete guards](strategies.md#delete-guards).
 
 ### `refusing to delete N files: exceeds guards.max_deletes`
 
-Your run would delete more files than `guards.max_deletes` allows. Inspect the
+Your run would delete more files than `safety.max_deletes` allows. Inspect the
 plan with `dry-run: true`; if the deletions are intended, raise (or remove)
 the limit in the config file.
 
 ## Configuration errors
 
-### `when 'config-file' is set, put targets/strategy/ignore/guards in the file`
+### `when 'config' is set, all non-secret settings come from the config file`
 
-`config-file` replaces the `uploads`, `strategy`, `ignore` and `ignore-from`
-inputs. Remove them from the step. Connection inputs stay.
+You set `config` and also an inline connection/deployment input (like `host`,
+`source`, `target`, `mode` or `exclude`). v3 has no mixed mode: remove the
+inline input, or drop `config` and configure everything inline. Only
+credentials, `dry-run` and `log-level` may be combined with `config`.
 
-### `the 'delete' input was removed in v2; use 'strategy: clean' instead`
+### `easySFTP could not determine what to deploy`
 
-Replace `delete: true` with `strategy: clean` in your step. The inputs are
-equivalent; `delete` only remains declared so that this error fires instead of
-the run silently degrading to the `overlay` default.
+Inline mode needs both `source` and `target`. Add them, or switch to a config
+file (`config`) for multiple deployments; the error spells out both fixes.
 
-### `strategy "sync" requires a directory, but local path ... is a single file`
+### `unknown option "<x>" at "<path>"; did you mean "<y>"?`
+
+The config file rejects unknown keys instead of silently ignoring them,
+usually a typo. The error gives the location and, when close enough, a
+suggestion. Enable [editor validation](configuration.md#validation) via the
+JSON Schema to catch these while typing.
+
+### `'version' must be 3` / a v1 config file is rejected
+
+v3 changed the config file format (named deployments, connection in the file).
+Convert your `version: 1` file following the
+[migration guide](migration-v3.md#migrating-a-v1-config-file).
+
+### `mode "sync" requires a directory, but local path ... is a single file`
 
 `sync` and `clean` reconcile a directory tree; for single files use `overlay`
 (the default).
-
-### `config-file "..." is not valid: field <x> not found`
-
-The config file rejects unknown keys instead of silently ignoring them,
-usually a typo. Enable [editor validation](configuration.md#editor-support)
-via the JSON Schema to catch these while typing.

--- a/internal/actionmeta/actionmeta_test.go
+++ b/internal/actionmeta/actionmeta_test.go
@@ -51,28 +51,47 @@ func TestActionMetadata(t *testing.T) {
 	if len(action.Runs.Steps) == 0 {
 		t.Fatal("action has no steps")
 	}
+	// The build-mode tombstone must not have a default: build mode is
+	// selected automatically in v3, and a declared default would trip the
+	// tombstone check on every run.
 	input, ok := action.Inputs["build-mode"]
 	if !ok {
-		t.Fatal("build-mode input is missing")
+		t.Fatal("build-mode input (tombstone) is missing")
 	}
-	if input.Default != "prebuilt" {
-		t.Errorf("build-mode default = %q, want prebuilt", input.Default)
+	if input.Default != "" {
+		t.Errorf("build-mode default = %q, want none (removed in v3)", input.Default)
 	}
 
 	wantInputs := []string{
-		"build-mode", "server", "port", "username", "password", "private-key",
-		"passphrase", "host-key-fingerprint", "known-hosts",
-		"proxy-server", "proxy-port", "proxy-username", "proxy-password",
-		"proxy-private-key", "proxy-passphrase", "proxy-host-key-fingerprint",
-		"proxy-known-hosts", "uploads", "config-file", "strategy",
-		"ignore", "ignore-from", "max-deletes", "delete", "dry-run", "concurrency",
-		"sftp-request-concurrency", "sync-fast-path", "skip-unchanged", "retries",
-		"timeout", "stall-timeout", "dir-mode", "file-mode", "log-level", "manifest-name",
-		"preserve-times",
+		// live v3 inputs
+		"host", "port", "username", "password", "private-key", "passphrase",
+		"host-key", "known-hosts", "allow-any-host-key",
+		"source", "target", "mode", "exclude", "config",
+		"proxy-password", "proxy-private-key", "proxy-passphrase",
+		"dry-run", "log-level",
+		// removed-input tombstones (fail with a migration hint when set)
+		"build-mode", "server", "host-key-fingerprint", "uploads", "config-file",
+		"strategy", "ignore", "ignore-from", "max-deletes", "delete",
+		"concurrency", "sftp-request-concurrency", "retries", "timeout",
+		"stall-timeout", "sync-fast-path", "skip-unchanged", "manifest-name",
+		"dir-mode", "file-mode", "preserve-times",
+		"proxy-server", "proxy-port", "proxy-username",
+		"proxy-host-key-fingerprint", "proxy-known-hosts",
 	}
 	for _, name := range wantInputs {
 		if _, ok := action.Inputs[name]; !ok {
 			t.Errorf("input %q is missing", name)
+		}
+	}
+
+	// Only run-wide switches may declare defaults: the runner exports
+	// declared defaults unconditionally, so a default on any mode-specific
+	// input would wrongly trip the config-mode mutual-exclusion check (the
+	// class of bug behind #62), and one on a tombstone would fail every run.
+	allowedDefaults := map[string]bool{"dry-run": true, "log-level": true}
+	for name, input := range action.Inputs {
+		if input.Default != "" && !allowedDefaults[name] {
+			t.Errorf("input %q declares default %q; only dry-run and log-level may have defaults", name, input.Default)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,14 @@
 // Package config loads and validates the action configuration from
 // environment variables set by action.yml, optionally from a YAML config file.
+//
+// v3 knows exactly two configuration modes and never mixes them:
+//
+//   - Inline mode: the connection and one deployment come from the action
+//     inputs (host, username, source, target, ...).
+//   - Config mode: the 'config' input points at a YAML file that holds every
+//     non-secret setting (connection, deployments, safety, advanced tuning).
+//     Only credentials (password, private-key, passphrase and their proxy-*
+//     counterparts) and run-wide switches (dry-run, log-level) remain inputs.
 package config
 
 import (
@@ -11,16 +20,16 @@ import (
 	"time"
 )
 
-// Strategy selects how a target's remote directory is reconciled with the
-// local files.
+// Strategy selects how a deployment's remote directory is reconciled with the
+// local files. Its user-facing input name in v3 is "mode".
 type Strategy string
 
 const (
 	// StrategyOverlay uploads files on top of whatever is already there and
-	// never deletes anything (the default, backwards-compatible behavior).
+	// never deletes anything (the default).
 	StrategyOverlay Strategy = "overlay"
 	// StrategySync uploads new/changed files and deletes remote files that are
-	// no longer present locally, tracked via a per-target manifest.
+	// no longer present locally, tracked via a per-deployment manifest.
 	StrategySync Strategy = "sync"
 	// StrategyClean wipes the remote target directory, then uploads.
 	StrategyClean Strategy = "clean"
@@ -38,16 +47,16 @@ func (s Strategy) valid() bool {
 type LogLevel string
 
 const (
-	// LogQuiet logs connection info, per-target summaries, warnings and
-	// errors only; per-file operation lines are suppressed (except in
-	// dry-run mode, where inspecting the plan is the whole point).
-	LogQuiet LogLevel = "quiet"
-	// LogNormal is the default: one line per planned file operation,
-	// exactly today's behavior.
+	// LogNormal is the default: connection status, one summary per
+	// deployment, warnings and errors. No per-file lines, so a 20,000-file
+	// deploy produces a readable log.
 	LogNormal LogLevel = "normal"
-	// LogVerbose additionally explains ignore decisions: which pattern
-	// excluded which file during planning.
+	// LogVerbose additionally logs one line per uploaded, deleted or skipped
+	// file (v2's "normal").
 	LogVerbose LogLevel = "verbose"
+	// LogDebug additionally explains internal decisions, most importantly
+	// which exclude pattern excluded which file during planning.
+	LogDebug LogLevel = "debug"
 )
 
 // resolveLogLevel maps the log-level input to a concrete level.
@@ -55,23 +64,36 @@ func resolveLogLevel(input string) (LogLevel, error) {
 	switch l := LogLevel(input); l {
 	case "":
 		return LogNormal, nil
-	case LogQuiet, LogNormal, LogVerbose:
+	case LogNormal, LogVerbose, LogDebug:
 		return l, nil
 	}
-	return "", fmt.Errorf("input 'log-level' must be quiet, normal or verbose, got %q", input)
+	return "", fmt.Errorf("input 'log-level' must be normal, verbose or debug, got %q", input)
 }
 
-// UploadPair maps a local path to a remote path with its own strategy.
+// UploadPair maps a local path to a remote path with its own strategy. In
+// config mode every pair carries its deployment name; inline mode's single
+// pair has an empty name.
 type UploadPair struct {
+	Name     string
 	Local    string
 	Remote   string
 	Strategy Strategy
-	Ignore   []string // target-specific ignore patterns, additive to the global ones
+	Ignore   []string // deployment-specific exclude patterns, additive to the global ones
+}
+
+// Label names the pair in logs and summaries: the deployment name from the
+// config file, or the mapping itself in inline mode.
+func (p UploadPair) Label() string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return fmt.Sprintf("%s => %s", p.Local, p.Remote)
 }
 
 // Proxy holds the connection settings of an optional jump host (bastion)
-// through which the SFTP server is reached, mirroring the primary connection
-// settings. Host key verification applies to this hop independently.
+// through which the SFTP server is reached. In v3 the non-secret parts come
+// exclusively from the config file (connection.proxy); the credentials come
+// from the proxy-password / proxy-private-key / proxy-passphrase inputs.
 type Proxy struct {
 	Server              string
 	Port                int
@@ -81,8 +103,11 @@ type Proxy struct {
 	Passphrase          string
 	HostKeyFingerprints []string
 	// KnownHosts holds raw OpenSSH known_hosts lines for the jump host, an
-	// alternative to fingerprints, exactly like the primary input.
+	// alternative to fingerprints.
 	KnownHosts string
+	// AllowAnyHostKey explicitly opts out of host key verification for this
+	// hop. Without pinned keys and without this opt-in, the run fails.
+	AllowAnyHostKey bool
 }
 
 // Guards holds the safety limits applied before any destructive operation.
@@ -105,6 +130,10 @@ type Config struct {
 	// output), an alternative to SHA256 fingerprints. When both are set, a
 	// key matching either is accepted.
 	KnownHosts string
+	// AllowAnyHostKey explicitly opts out of host key verification. Without
+	// pinned keys and without this opt-in, the run fails instead of talking
+	// to an unverified server.
+	AllowAnyHostKey bool
 
 	// Proxy, if non-nil, routes the connection through a jump host.
 	Proxy *Proxy
@@ -112,6 +141,10 @@ type Config struct {
 	Uploads     []UploadPair
 	IgnoreLines []string
 	Guards      Guards
+
+	// ConfigPath is the path of the loaded YAML config file, or "" in inline
+	// mode. It drives config-mode error message wording and the job summary.
+	ConfigPath string
 
 	// DirMode, if set, chmods every remote directory the run creates or
 	// touches to this permission, overriding the server's umask default.
@@ -139,8 +172,7 @@ type Config struct {
 	SkipUnchanged bool
 
 	// LogLevel controls per-file log output; see the LogLevel constants.
-	// The zero value behaves like LogNormal, so directly constructed configs
-	// keep today's behavior.
+	// The zero value behaves like LogNormal.
 	LogLevel LogLevel
 
 	// ManifestName is the file name the sync strategy uses for its manifest
@@ -159,17 +191,23 @@ type Config struct {
 // should be logged. A dry run always logs them: inspecting the plan is its
 // whole point, regardless of log-level.
 func (c *Config) LogPerFile() bool {
-	return c.LogLevel != LogQuiet || c.DryRun
+	return c.LogLevel == LogVerbose || c.LogLevel == LogDebug || c.DryRun
 }
 
-// Verbose reports whether verbose-only diagnostics (ignore decisions)
-// should be logged.
-func (c *Config) Verbose() bool {
-	return c.LogLevel == LogVerbose
+// Debug reports whether debug-only diagnostics (exclude decisions) should be
+// logged.
+func (c *Config) Debug() bool {
+	return c.LogLevel == LogDebug
 }
 
-// DefaultManifestName is the sync manifest file name used when the
-// manifest-name input is not set.
+// HostKeyPinned reports whether the primary connection verifies the server's
+// host key against pinned keys.
+func (c *Config) HostKeyPinned() bool {
+	return len(c.HostKeyFingerprints) > 0 || c.KnownHosts != ""
+}
+
+// DefaultManifestName is the sync manifest file name used when sync.manifest
+// is not configured.
 const DefaultManifestName = ".easysftp-manifest.json"
 
 // SyncManifestName returns the effective sync manifest file name, falling
@@ -183,121 +221,140 @@ func (c *Config) SyncManifestName() string {
 
 const envPrefix = "EASYSFTP_"
 
+// Run-wide defaults, applied in inline mode and overridable per config file.
+const (
+	defaultConcurrency        = 4
+	defaultRequestConcurrency = 16
+	defaultRetries            = 2
+	defaultTimeoutSec         = 30
+)
+
+// removedInput maps a v2 input's environment variable to its migration hint.
+// The inputs stay declared in action.yml (without defaults) so a workflow
+// still passing them fails loudly here instead of being silently ignored by
+// the runner.
+type removedInput struct{ env, hint string }
+
+var removedInputs = []removedInput{
+	{"SERVER", "the 'server' input was renamed to 'host'"},
+	{"HOST_KEY_FINGERPRINT", "the 'host-key-fingerprint' input was renamed to 'host-key'"},
+	{"UPLOADS", "the 'uploads' input was removed; replace a single 'local => remote' mapping with the 'source' and 'target' inputs, and move multiple mappings into a config file ('config' input)"},
+	{"CONFIG_FILE", "the 'config-file' input was renamed to 'config', and the file format changed (version: 3, named deployments, connection settings in the file)"},
+	{"STRATEGY", "the 'strategy' input was renamed to 'mode'"},
+	{"IGNORE", "the 'ignore' input was renamed to 'exclude'"},
+	{"IGNORE_FROM", "the 'ignore-from' input was removed; put the patterns in the 'exclude' input or in the config file"},
+	{"MAX_DELETES", "the 'max-deletes' input moved to 'safety.max_deletes' in the config file"},
+	{"DELETE", "the 'delete' input was removed in v2 already; use 'mode: clean'"},
+	{"CONCURRENCY", "the 'concurrency' input moved to 'advanced.concurrency' in the config file"},
+	{"SFTP_REQUEST_CONCURRENCY", "the 'sftp-request-concurrency' input moved to 'advanced.request_concurrency' in the config file"},
+	{"RETRIES", "the 'retries' input moved to 'advanced.retries' in the config file"},
+	{"TIMEOUT", "the 'timeout' input moved to 'advanced.timeout' in the config file"},
+	{"STALL_TIMEOUT", "the 'stall-timeout' input moved to 'advanced.stall_timeout' in the config file"},
+	{"SYNC_FAST_PATH", "the 'sync-fast-path' input moved to 'sync.fast_path' in the config file"},
+	{"MANIFEST_NAME", "the 'manifest-name' input moved to 'sync.manifest' in the config file"},
+	{"SKIP_UNCHANGED", "the 'skip-unchanged' input moved to 'advanced.skip_unchanged' in the config file"},
+	{"DIR_MODE", "the 'dir-mode' input moved to 'permissions.directories' in the config file"},
+	{"FILE_MODE", "the 'file-mode' input moved to 'permissions.files' in the config file"},
+	{"PRESERVE_TIMES", "the 'preserve-times' input moved to 'permissions.preserve_times' in the config file"},
+	{"PROXY_SERVER", "the 'proxy-server' input moved to 'connection.proxy.host' in the config file"},
+	{"PROXY_PORT", "the 'proxy-port' input moved to 'connection.proxy.port' in the config file"},
+	{"PROXY_USERNAME", "the 'proxy-username' input moved to 'connection.proxy.username' in the config file"},
+	{"PROXY_HOST_KEY_FINGERPRINT", "the 'proxy-host-key-fingerprint' input moved to 'connection.proxy.host_key' in the config file"},
+	{"PROXY_KNOWN_HOSTS", "the 'proxy-known-hosts' input moved to 'connection.proxy.known_hosts' in the config file"},
+}
+
+// checkRemovedInputs fails the run with a migration hint when a v2 input is
+// still set.
+func checkRemovedInputs() error {
+	for _, r := range removedInputs {
+		if strings.TrimSpace(os.Getenv(envPrefix+r.env)) != "" {
+			return fmt.Errorf("%s in easySFTP v3; see docs/migration-v3.md", r.hint)
+		}
+	}
+	return nil
+}
+
+// inlineOnlyInputs are the non-secret inputs that must stay empty in config
+// mode: in v3 every non-secret setting has exactly one home, so there is no
+// override or precedence between the workflow and the config file.
+var inlineOnlyInputs = []struct{ env, input string }{
+	{"HOST", "host"},
+	{"PORT", "port"},
+	{"USERNAME", "username"},
+	{"HOST_KEY", "host-key"},
+	{"KNOWN_HOSTS", "known-hosts"},
+	{"ALLOW_ANY_HOST_KEY", "allow-any-host-key"},
+	{"SOURCE", "source"},
+	{"TARGET", "target"},
+	{"MODE", "mode"},
+	{"EXCLUDE", "exclude"},
+}
+
 // Load reads the configuration from the environment and validates it.
 func Load() (*Config, error) {
+	if err := checkRemovedInputs(); err != nil {
+		return nil, err
+	}
+
 	get := func(name string) string {
 		return strings.TrimSpace(os.Getenv(envPrefix + name))
 	}
 
 	cfg := &Config{
-		Server:              get("SERVER"),
-		Username:            get("USERNAME"),
-		Password:            os.Getenv(envPrefix + "PASSWORD"),
-		PrivateKey:          os.Getenv(envPrefix + "PRIVATE_KEY"),
-		Passphrase:          os.Getenv(envPrefix + "PASSPHRASE"),
-		HostKeyFingerprints: splitLines(os.Getenv(envPrefix + "HOST_KEY_FINGERPRINT")),
-		KnownHosts:          strings.TrimSpace(os.Getenv(envPrefix + "KNOWN_HOSTS")),
+		Password:               os.Getenv(envPrefix + "PASSWORD"),
+		PrivateKey:             os.Getenv(envPrefix + "PRIVATE_KEY"),
+		Passphrase:             os.Getenv(envPrefix + "PASSPHRASE"),
+		Concurrency:            defaultConcurrency,
+		SftpRequestConcurrency: defaultRequestConcurrency,
+		Retries:                defaultRetries,
+		Timeout:                defaultTimeoutSec * time.Second,
+		ManifestName:           DefaultManifestName,
 	}
 
 	var err error
-	if cfg.Port, err = parseInt(get("PORT"), 22); err != nil {
-		return nil, fmt.Errorf("invalid port: %w", err)
-	}
-	if cfg.Proxy, err = loadProxy(get); err != nil {
-		return nil, err
-	}
-	if cfg.Concurrency, err = parseInt(get("CONCURRENCY"), 4); err != nil {
-		return nil, fmt.Errorf("invalid concurrency: %w", err)
-	}
-	if cfg.SftpRequestConcurrency, err = parseInt(get("SFTP_REQUEST_CONCURRENCY"), 16); err != nil {
-		return nil, fmt.Errorf("invalid sftp-request-concurrency: %w", err)
-	}
-	if cfg.Retries, err = parseInt(get("RETRIES"), 2); err != nil {
-		return nil, fmt.Errorf("invalid retries: %w", err)
-	}
-	// Tombstone: 'delete' is still declared in action.yml so that a workflow
-	// passing it fails loudly here instead of silently falling back to overlay.
-	if deleted, err := parseBool(get("DELETE"), false); err != nil {
-		return nil, fmt.Errorf("invalid delete: %w", err)
-	} else if deleted {
-		return nil, fmt.Errorf("the 'delete' input was removed in v2; use 'strategy: clean' instead")
-	}
 	if cfg.DryRun, err = parseBool(get("DRY_RUN"), false); err != nil {
 		return nil, fmt.Errorf("invalid dry-run: %w", err)
-	}
-	if cfg.SyncFastPath, err = parseBool(get("SYNC_FAST_PATH"), false); err != nil {
-		return nil, fmt.Errorf("invalid sync-fast-path: %w", err)
-	}
-	if cfg.SkipUnchanged, err = parseBool(get("SKIP_UNCHANGED"), false); err != nil {
-		return nil, fmt.Errorf("invalid skip-unchanged: %w", err)
 	}
 	if cfg.LogLevel, err = resolveLogLevel(get("LOG_LEVEL")); err != nil {
 		return nil, err
 	}
-	if cfg.ManifestName, err = parseManifestName(get("MANIFEST_NAME")); err != nil {
-		return nil, err
-	}
-	if cfg.PreserveTimes, err = parseBool(get("PRESERVE_TIMES"), false); err != nil {
-		return nil, fmt.Errorf("invalid preserve-times: %w", err)
-	}
-	if cfg.DirMode, err = parseMode(get("DIR_MODE"), "dir-mode"); err != nil {
-		return nil, err
-	}
-	if cfg.FileMode, err = parseMode(get("FILE_MODE"), "file-mode"); err != nil {
-		return nil, err
-	}
 
-	timeoutSec, err := parseInt(get("TIMEOUT"), 30)
-	if err != nil {
-		return nil, fmt.Errorf("invalid timeout: %w", err)
-	}
-	cfg.Timeout = time.Duration(timeoutSec) * time.Second
+	proxyPassword := os.Getenv(envPrefix + "PROXY_PASSWORD")
+	proxyPrivateKey := os.Getenv(envPrefix + "PROXY_PRIVATE_KEY")
+	proxyPassphrase := os.Getenv(envPrefix + "PROXY_PASSPHRASE")
+	haveProxyCreds := proxyPassword != "" || strings.TrimSpace(proxyPrivateKey) != "" || proxyPassphrase != ""
 
-	stallSec, err := parseInt(get("STALL_TIMEOUT"), 0)
-	if err != nil {
-		return nil, fmt.Errorf("invalid stall-timeout: %w", err)
-	}
-	cfg.StallTimeout = time.Duration(stallSec) * time.Second
-
-	// The deployment (targets, strategy, ignore, guards) comes either from a
-	// YAML config file or from the plain action inputs, never a mix of both.
-	configFile := get("CONFIG_FILE")
-	strategyInput := get("STRATEGY")
-	uploadsInput := os.Getenv(envPrefix + "UPLOADS")
-	ignoreInput := os.Getenv(envPrefix + "IGNORE")
-	ignoreFrom := get("IGNORE_FROM")
-	maxDeletesInput := get("MAX_DELETES")
-
-	if configFile != "" {
-		if strings.TrimSpace(uploadsInput) != "" || strategyInput != "" ||
-			strings.TrimSpace(ignoreInput) != "" || ignoreFrom != "" || maxDeletesInput != "" {
-			return nil, fmt.Errorf("when 'config-file' is set, put targets/strategy/ignore/guards " +
-				"in the file; do not also set the uploads, strategy, ignore, ignore-from or max-deletes inputs")
+	if configPath := get("CONFIG"); configPath != "" {
+		var set []string
+		for _, in := range inlineOnlyInputs {
+			if strings.TrimSpace(os.Getenv(envPrefix+in.env)) != "" {
+				set = append(set, "'"+in.input+"'")
+			}
 		}
-		if err := loadConfigFile(cfg, configFile); err != nil {
+		if len(set) > 0 {
+			return nil, fmt.Errorf("when 'config' is set, all non-secret settings come from the config file; "+
+				"remove the %s input(s) from the workflow (only credentials, dry-run and log-level may be combined with a config file)",
+				strings.Join(set, ", "))
+		}
+		if err := loadConfigFile(cfg, configPath); err != nil {
 			return nil, err
+		}
+		cfg.ConfigPath = configPath
+		if cfg.Proxy != nil {
+			cfg.Proxy.Password = proxyPassword
+			cfg.Proxy.PrivateKey = proxyPrivateKey
+			cfg.Proxy.Passphrase = proxyPassphrase
+		} else if haveProxyCreds {
+			return nil, fmt.Errorf("proxy credential inputs are set but the config file defines no 'connection.proxy'; " +
+				"add the proxy connection there or remove the proxy-* inputs")
 		}
 	} else {
-		strategy, err := resolveStrategy(strategyInput)
-		if err != nil {
+		if haveProxyCreds {
+			return nil, fmt.Errorf("proxy connections are configured in the config file in easySFTP v3 " +
+				"(connection.proxy, with proxy-password / proxy-private-key as inputs); see docs/migration-v3.md")
+		}
+		if err := loadInline(cfg, get); err != nil {
 			return nil, err
-		}
-		if cfg.Uploads, err = ParseUploads(uploadsInput); err != nil {
-			return nil, err
-		}
-		for i := range cfg.Uploads {
-			cfg.Uploads[i].Strategy = strategy
-		}
-		cfg.IgnoreLines = splitLines(ignoreInput)
-		if ignoreFrom != "" {
-			data, err := os.ReadFile(ignoreFrom)
-			if err != nil {
-				return nil, fmt.Errorf("could not read ignore-from file: %w", err)
-			}
-			cfg.IgnoreLines = append(cfg.IgnoreLines, splitLines(string(data))...)
-		}
-		if cfg.Guards.MaxDeletes, err = parseInt(maxDeletesInput, 0); err != nil {
-			return nil, fmt.Errorf("invalid max-deletes: %w", err)
 		}
 	}
 
@@ -307,101 +364,82 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
-// loadProxy reads the optional proxy-* (jump host) inputs. Without
-// proxy-server, every other proxy input must be empty, so a typo'd or
-// half-configured bastion setup fails loudly instead of silently connecting
-// directly.
-func loadProxy(get func(string) string) (*Proxy, error) {
-	p := &Proxy{
-		Server:              get("PROXY_SERVER"),
-		Username:            get("PROXY_USERNAME"),
-		Password:            os.Getenv(envPrefix + "PROXY_PASSWORD"),
-		PrivateKey:          os.Getenv(envPrefix + "PROXY_PRIVATE_KEY"),
-		Passphrase:          os.Getenv(envPrefix + "PROXY_PASSPHRASE"),
-		HostKeyFingerprints: splitLines(os.Getenv(envPrefix + "PROXY_HOST_KEY_FINGERPRINT")),
-		KnownHosts:          strings.TrimSpace(os.Getenv(envPrefix + "PROXY_KNOWN_HOSTS")),
-	}
-	if p.Server == "" {
-		if p.Username != "" || p.Password != "" || strings.TrimSpace(p.PrivateKey) != "" ||
-			p.Passphrase != "" || len(p.HostKeyFingerprints) > 0 || p.KnownHosts != "" ||
-			get("PROXY_PORT") != "" {
-			return nil, fmt.Errorf("proxy-* inputs are set but 'proxy-server' is empty; set proxy-server or remove the other proxy inputs")
-		}
-		return nil, nil
-	}
-	var err error
-	if p.Port, err = parseInt(get("PROXY_PORT"), 22); err != nil {
-		return nil, fmt.Errorf("invalid proxy-port: %w", err)
-	}
-	return p, nil
-}
+// loadInline reads the single-deployment inline configuration from the
+// action inputs.
+func loadInline(cfg *Config, get func(string) string) error {
+	cfg.Server = get("HOST")
+	cfg.Username = get("USERNAME")
+	cfg.HostKeyFingerprints = splitLines(os.Getenv(envPrefix + "HOST_KEY"))
+	cfg.KnownHosts = strings.TrimSpace(os.Getenv(envPrefix + "KNOWN_HOSTS"))
 
-// resolveStrategy maps the strategy input to a concrete strategy.
-func resolveStrategy(input string) (Strategy, error) {
-	if input == "" {
-		return StrategyOverlay, nil
+	var err error
+	if cfg.Port, err = parseInt(get("PORT"), 22); err != nil {
+		return fmt.Errorf("invalid port: %w", err)
 	}
-	s := Strategy(input)
-	if !s.valid() {
-		return "", fmt.Errorf("input 'strategy' must be overlay, sync or clean, got %q", input)
+	if cfg.AllowAnyHostKey, err = parseBool(get("ALLOW_ANY_HOST_KEY"), false); err != nil {
+		return fmt.Errorf("invalid allow-any-host-key: %w", err)
 	}
-	return s, nil
+
+	strategy := StrategyOverlay
+	if mode := get("MODE"); mode != "" {
+		strategy = Strategy(mode)
+		if !strategy.valid() {
+			return fmt.Errorf("input 'mode' must be overlay, sync or clean, got %q", mode)
+		}
+	}
+
+	source, target := get("SOURCE"), get("TARGET")
+	if source == "" || target == "" {
+		return fmt.Errorf("easySFTP could not determine what to deploy.\n\nAdd both:\n\n  source: dist\n  target: /var/www/html\n\nFor multiple deployments, use a config file:\n\n  config: .github/easysftp.yml")
+	}
+	cfg.Uploads = []UploadPair{{Local: source, Remote: target, Strategy: strategy}}
+	cfg.IgnoreLines = splitLines(os.Getenv(envPrefix + "EXCLUDE"))
+	return nil
 }
 
 func (c *Config) validate() error {
+	// requiredIn phrases a missing required setting for the active mode.
+	requiredIn := func(input, field string) error {
+		if c.ConfigPath != "" {
+			return fmt.Errorf("config %q: '%s' is required", c.ConfigPath, field)
+		}
+		return fmt.Errorf("input '%s' is required", input)
+	}
 	switch {
 	case c.Server == "":
-		return fmt.Errorf("input 'server' is required")
+		return requiredIn("host", "connection.host")
 	case c.Username == "":
-		return fmt.Errorf("input 'username' is required")
+		return requiredIn("username", "connection.username")
 	case c.Password == "" && strings.TrimSpace(c.PrivateKey) == "":
 		return fmt.Errorf("either input 'password' or 'private-key' is required")
 	case len(c.Uploads) == 0:
-		return fmt.Errorf("input 'uploads' is required and must contain at least one 'local => remote' mapping")
+		return fmt.Errorf("no deployments configured")
 	case c.Port < 1 || c.Port > 65535:
-		return fmt.Errorf("input 'port' must be between 1 and 65535, got %d", c.Port)
+		return fmt.Errorf("port must be between 1 and 65535, got %d", c.Port)
 	case c.Concurrency < 1:
-		return fmt.Errorf("input 'concurrency' must be at least 1, got %d", c.Concurrency)
+		return fmt.Errorf("advanced.concurrency must be at least 1, got %d", c.Concurrency)
 	case c.SftpRequestConcurrency < 1:
-		return fmt.Errorf("input 'sftp-request-concurrency' must be at least 1, got %d", c.SftpRequestConcurrency)
+		return fmt.Errorf("advanced.request_concurrency must be at least 1, got %d", c.SftpRequestConcurrency)
 	case c.Retries < 0:
-		return fmt.Errorf("input 'retries' must not be negative, got %d", c.Retries)
+		return fmt.Errorf("advanced.retries must not be negative, got %d", c.Retries)
 	case c.Timeout < 0:
-		return fmt.Errorf("input 'timeout' must not be negative (use 0 to disable the timeout), got %d", int(c.Timeout/time.Second))
+		return fmt.Errorf("advanced.timeout must not be negative (use 0 to disable the timeout), got %d", int(c.Timeout/time.Second))
 	case c.StallTimeout < 0:
-		return fmt.Errorf("input 'stall-timeout' must not be negative (use 0 to disable the check), got %d", int(c.StallTimeout/time.Second))
+		return fmt.Errorf("advanced.stall_timeout must not be negative (use 0 to disable the check), got %d", int(c.StallTimeout/time.Second))
 	case c.Guards.MaxDeletes < 0:
-		return fmt.Errorf("guards.max_deletes must not be negative, got %d", c.Guards.MaxDeletes)
+		return fmt.Errorf("safety.max_deletes must not be negative, got %d", c.Guards.MaxDeletes)
 	}
 	if p := c.Proxy; p != nil {
 		switch {
 		case p.Username == "":
-			return fmt.Errorf("input 'proxy-username' is required when 'proxy-server' is set")
+			return fmt.Errorf("config %q: 'connection.proxy.username' is required", c.ConfigPath)
 		case p.Password == "" && strings.TrimSpace(p.PrivateKey) == "":
-			return fmt.Errorf("either input 'proxy-password' or 'proxy-private-key' is required when 'proxy-server' is set")
+			return fmt.Errorf("either input 'proxy-password' or 'proxy-private-key' is required when the config file defines connection.proxy")
 		case p.Port < 1 || p.Port > 65535:
-			return fmt.Errorf("input 'proxy-port' must be between 1 and 65535, got %d", p.Port)
+			return fmt.Errorf("connection.proxy.port must be between 1 and 65535, got %d", p.Port)
 		}
 	}
 	return nil
-}
-
-// ParseUploads parses the multiline "local => remote" upload mapping.
-// Empty lines and lines starting with '#' are skipped.
-func ParseUploads(s string) ([]UploadPair, error) {
-	var pairs []UploadPair
-	for _, line := range splitLines(s) {
-		parts := strings.SplitN(line, "=>", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid upload mapping %q: expected format 'local/path => remote/path'", line)
-		}
-		local, remote := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
-		if local == "" || remote == "" {
-			return nil, fmt.Errorf("invalid upload mapping %q: local and remote path must not be empty", line)
-		}
-		pairs = append(pairs, UploadPair{Local: local, Remote: remote})
-	}
-	return pairs, nil
 }
 
 // splitLines splits s into trimmed, non-empty, non-comment lines.
@@ -439,7 +477,7 @@ func parseManifestName(s string) (string, error) {
 		return DefaultManifestName, nil
 	}
 	if strings.ContainsAny(s, "/\\") || s == "." || s == ".." {
-		return "", fmt.Errorf("input 'manifest-name' must be a bare file name (no path separators), got %q", s)
+		return "", fmt.Errorf("sync.manifest must be a bare file name (no path separators), got %q", s)
 	}
 	return s, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,105 +6,143 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
-func TestParseUploads(t *testing.T) {
-	t.Run("multiple pairs with comments and blank lines", func(t *testing.T) {
-		got, err := ParseUploads("./dist/ => /var/www/html/\n\n# comment\nassets => /var/www/assets\r\n")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(got) != 2 {
-			t.Fatalf("expected 2 pairs, got %d", len(got))
-		}
-		if got[0].Local != "./dist/" || got[0].Remote != "/var/www/html/" {
-			t.Errorf("unexpected first pair: %+v", got[0])
-		}
-		if got[1].Local != "assets" || got[1].Remote != "/var/www/assets" {
-			t.Errorf("unexpected second pair: %+v", got[1])
-		}
-	})
-
-	t.Run("missing arrow", func(t *testing.T) {
-		if _, err := ParseUploads("./dist/ -> /var/www/"); err == nil {
-			t.Fatal("expected error for invalid mapping")
-		}
-	})
-
-	t.Run("empty side", func(t *testing.T) {
-		if _, err := ParseUploads("./dist/ =>"); err == nil {
-			t.Fatal("expected error for empty remote path")
-		}
-	})
+// v3EnvVars is every EASYSFTP_* variable action.yml wires into the upload
+// step: live inputs and the removed-input tombstones. setBaseEnv clears all
+// of them so config tests stay hermetic when the ambient environment sets
+// EASYSFTP_* variables.
+var v3EnvVars = []string{
+	// live v3 inputs
+	"HOST", "PORT", "USERNAME", "PASSWORD", "PRIVATE_KEY", "PASSPHRASE",
+	"HOST_KEY", "KNOWN_HOSTS", "ALLOW_ANY_HOST_KEY",
+	"SOURCE", "TARGET", "MODE", "EXCLUDE", "CONFIG",
+	"DRY_RUN", "LOG_LEVEL",
+	"PROXY_PASSWORD", "PROXY_PRIVATE_KEY", "PROXY_PASSPHRASE",
+	// removed-input tombstones
+	"SERVER", "HOST_KEY_FINGERPRINT", "UPLOADS", "CONFIG_FILE", "STRATEGY",
+	"IGNORE", "IGNORE_FROM", "MAX_DELETES", "DELETE",
+	"CONCURRENCY", "SFTP_REQUEST_CONCURRENCY", "RETRIES", "TIMEOUT", "STALL_TIMEOUT",
+	"SYNC_FAST_PATH", "MANIFEST_NAME", "SKIP_UNCHANGED",
+	"DIR_MODE", "FILE_MODE", "PRESERVE_TIMES",
+	"PROXY_SERVER", "PROXY_PORT", "PROXY_USERNAME",
+	"PROXY_HOST_KEY_FINGERPRINT", "PROXY_KNOWN_HOSTS",
 }
 
-// setBaseEnv sets the minimal valid configuration.
+// setBaseEnv sets the minimal valid inline configuration.
 func setBaseEnv(t *testing.T) {
-	t.Setenv("EASYSFTP_SERVER", "sftp.example.com")
-	t.Setenv("EASYSFTP_USERNAME", "deploy")
-	t.Setenv("EASYSFTP_PASSWORD", "hunter2")
-	t.Setenv("EASYSFTP_UPLOADS", "./dist/ => /www/")
-	for _, name := range []string{"PORT", "PRIVATE_KEY", "PASSPHRASE", "HOST_KEY_FINGERPRINT", "KNOWN_HOSTS",
-		"IGNORE", "IGNORE_FROM", "DELETE", "DRY_RUN", "CONCURRENCY", "SFTP_REQUEST_CONCURRENCY", "RETRIES", "TIMEOUT", "STALL_TIMEOUT",
-		"SYNC_FAST_PATH", "SKIP_UNCHANGED", "CONFIG_FILE", "STRATEGY", "MAX_DELETES", "DIR_MODE", "FILE_MODE",
-		"LOG_LEVEL", "MANIFEST_NAME", "PRESERVE_TIMES",
-		"PROXY_SERVER", "PROXY_PORT", "PROXY_USERNAME", "PROXY_PASSWORD", "PROXY_PRIVATE_KEY", "PROXY_PASSPHRASE",
-		"PROXY_HOST_KEY_FINGERPRINT", "PROXY_KNOWN_HOSTS"} {
+	for _, name := range v3EnvVars {
 		t.Setenv("EASYSFTP_"+name, "")
 	}
+	t.Setenv("EASYSFTP_HOST", "sftp.example.com")
+	t.Setenv("EASYSFTP_USERNAME", "deploy")
+	t.Setenv("EASYSFTP_PASSWORD", "hunter2")
+	t.Setenv("EASYSFTP_SOURCE", "./dist/")
+	t.Setenv("EASYSFTP_TARGET", "/www/")
+	t.Setenv("EASYSFTP_HOST_KEY", "SHA256:abc")
 }
 
-func TestLoadDefaults(t *testing.T) {
+// writeConfig writes a config file into a temp dir and returns its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "easysftp.yml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const minimalConfigFile = `version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: SHA256:abc
+deployments:
+  website:
+    source: ./dist/
+    target: /www/
+`
+
+// setConfigModeEnv sets the minimal valid config-mode environment.
+func setConfigModeEnv(t *testing.T, fileContent string) string {
+	t.Helper()
+	for _, name := range v3EnvVars {
+		t.Setenv("EASYSFTP_"+name, "")
+	}
+	t.Setenv("EASYSFTP_PASSWORD", "hunter2")
+	path := writeConfig(t, fileContent)
+	t.Setenv("EASYSFTP_CONFIG", path)
+	return path
+}
+
+func TestLoadInlineDefaults(t *testing.T) {
 	setBaseEnv(t)
 	cfg, err := Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Retries != 2 || cfg.DryRun || cfg.SyncFastPath || cfg.SkipUnchanged || cfg.LogLevel != LogNormal {
+	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Retries != 2 ||
+		cfg.DryRun || cfg.SyncFastPath || cfg.SkipUnchanged || cfg.AllowAnyHostKey || cfg.LogLevel != LogNormal {
 		t.Errorf("unexpected defaults: %+v", cfg)
 	}
-	if cfg.Timeout.Seconds() != 30 {
+	if cfg.Timeout != 30*time.Second {
 		t.Errorf("expected 30s default timeout, got %s", cfg.Timeout)
+	}
+	if cfg.Guards.MaxDeletes != 0 {
+		t.Errorf("expected unlimited max deletes by default, got %d", cfg.Guards.MaxDeletes)
 	}
 	if cfg.ManifestName != DefaultManifestName {
 		t.Errorf("expected default manifest name %q, got %q", DefaultManifestName, cfg.ManifestName)
 	}
+	if len(cfg.Uploads) != 1 {
+		t.Fatalf("expected one deployment, got %+v", cfg.Uploads)
+	}
+	up := cfg.Uploads[0]
+	if up.Name != "" || up.Local != "./dist/" || up.Remote != "/www/" || up.Strategy != StrategyOverlay {
+		t.Errorf("unexpected inline deployment: %+v", up)
+	}
+	if cfg.ConfigPath != "" {
+		t.Errorf("expected empty ConfigPath in inline mode, got %q", cfg.ConfigPath)
+	}
 }
 
-func TestLoadValidation(t *testing.T) {
+func TestLoadInlineModeAndExclude(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("EASYSFTP_MODE", "sync")
+	t.Setenv("EASYSFTP_EXCLUDE", "*.map\n# comment\nnode_modules/\n")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Uploads[0].Strategy != StrategySync {
+		t.Errorf("expected sync mode, got %q", cfg.Uploads[0].Strategy)
+	}
+	want := []string{"*.map", "node_modules/"}
+	if len(cfg.IgnoreLines) != len(want) || cfg.IgnoreLines[0] != want[0] || cfg.IgnoreLines[1] != want[1] {
+		t.Errorf("expected exclude lines %v, got %v", want, cfg.IgnoreLines)
+	}
+}
+
+func TestLoadInlineValidation(t *testing.T) {
 	cases := []struct {
 		name    string
 		env     map[string]string
 		wantErr string
 	}{
-		{"missing server", map[string]string{"EASYSFTP_SERVER": ""}, "'server' is required"},
+		{"missing host", map[string]string{"EASYSFTP_HOST": ""}, "'host' is required"},
 		{"missing username", map[string]string{"EASYSFTP_USERNAME": ""}, "'username' is required"},
 		{"missing auth", map[string]string{"EASYSFTP_PASSWORD": ""}, "'password' or 'private-key'"},
-		{"missing uploads", map[string]string{"EASYSFTP_UPLOADS": ""}, "'uploads' is required"},
-		{"bad port", map[string]string{"EASYSFTP_PORT": "99999"}, "'port' must be between"},
-		{"bad bool", map[string]string{"EASYSFTP_DRY_RUN": "yes-please"}, "invalid dry-run"},
-		{"bad sync-fast-path bool", map[string]string{"EASYSFTP_SYNC_FAST_PATH": "yes-please"}, "invalid sync-fast-path"},
-		{"bad skip-unchanged bool", map[string]string{"EASYSFTP_SKIP_UNCHANGED": "yes-please"}, "invalid skip-unchanged"},
-		{"bad max-deletes", map[string]string{"EASYSFTP_MAX_DELETES": "not-a-number"}, "invalid max-deletes"},
-		{"bad sftp-request-concurrency", map[string]string{"EASYSFTP_SFTP_REQUEST_CONCURRENCY": "not-a-number"}, "invalid sftp-request-concurrency"},
-		{"zero sftp-request-concurrency", map[string]string{"EASYSFTP_SFTP_REQUEST_CONCURRENCY": "0"}, "'sftp-request-concurrency' must be at least 1"},
-		{"negative max-deletes", map[string]string{"EASYSFTP_MAX_DELETES": "-1"}, "guards.max_deletes must not be negative"},
-		{"negative timeout", map[string]string{"EASYSFTP_TIMEOUT": "-5"}, "'timeout' must not be negative"},
-		{"bad stall-timeout", map[string]string{"EASYSFTP_STALL_TIMEOUT": "soon"}, "invalid stall-timeout"},
-		{"negative stall-timeout", map[string]string{"EASYSFTP_STALL_TIMEOUT": "-5"}, "'stall-timeout' must not be negative"},
-		{"bad log-level", map[string]string{"EASYSFTP_LOG_LEVEL": "loud"}, "'log-level' must be quiet, normal or verbose"},
-		{"manifest-name with slash", map[string]string{"EASYSFTP_MANIFEST_NAME": "sub/manifest.json"}, "'manifest-name' must be a bare file name"},
-		{"manifest-name with backslash", map[string]string{"EASYSFTP_MANIFEST_NAME": `sub\manifest.json`}, "'manifest-name' must be a bare file name"},
-		{"manifest-name dot-dot", map[string]string{"EASYSFTP_MANIFEST_NAME": ".."}, "'manifest-name' must be a bare file name"},
-		{"proxy inputs without proxy-server", map[string]string{"EASYSFTP_PROXY_USERNAME": "jump"}, "'proxy-server' is empty"},
-		{"proxy-server without username", map[string]string{"EASYSFTP_PROXY_SERVER": "jump.example.com", "EASYSFTP_PROXY_PASSWORD": "pw"}, "'proxy-username' is required"},
-		{"proxy-server without auth", map[string]string{"EASYSFTP_PROXY_SERVER": "jump.example.com", "EASYSFTP_PROXY_USERNAME": "jump"}, "'proxy-password' or 'proxy-private-key'"},
-		{"bad proxy-port", map[string]string{"EASYSFTP_PROXY_SERVER": "jump.example.com", "EASYSFTP_PROXY_USERNAME": "jump", "EASYSFTP_PROXY_PASSWORD": "pw", "EASYSFTP_PROXY_PORT": "99999"}, "'proxy-port' must be between"},
-		{"bad dir-mode", map[string]string{"EASYSFTP_DIR_MODE": "not-octal"}, "invalid dir-mode"},
-		{"dir-mode out of range", map[string]string{"EASYSFTP_DIR_MODE": "1755"}, "invalid dir-mode"},
-		{"bad file-mode", map[string]string{"EASYSFTP_FILE_MODE": "999"}, "invalid file-mode"},
+		{"missing source", map[string]string{"EASYSFTP_SOURCE": ""}, "could not determine what to deploy"},
+		{"missing target", map[string]string{"EASYSFTP_TARGET": ""}, "could not determine what to deploy"},
+		{"bad port", map[string]string{"EASYSFTP_PORT": "99999"}, "port must be between"},
+		{"bad mode", map[string]string{"EASYSFTP_MODE": "mirror"}, "'mode' must be overlay, sync or clean"},
+		{"bad dry-run", map[string]string{"EASYSFTP_DRY_RUN": "yes-please"}, "invalid dry-run"},
+		{"bad allow-any-host-key", map[string]string{"EASYSFTP_ALLOW_ANY_HOST_KEY": "maybe"}, "invalid allow-any-host-key"},
+		{"bad log-level", map[string]string{"EASYSFTP_LOG_LEVEL": "quiet"}, "'log-level' must be normal, verbose or debug"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -120,12 +158,293 @@ func TestLoadValidation(t *testing.T) {
 	}
 }
 
-func TestLoadProxy(t *testing.T) {
+func TestLoadMissingSourceErrorExplainsTheFix(t *testing.T) {
 	setBaseEnv(t)
-	t.Setenv("EASYSFTP_PROXY_SERVER", "jump.example.com")
-	t.Setenv("EASYSFTP_PROXY_USERNAME", "jumper")
+	t.Setenv("EASYSFTP_SOURCE", "")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	for _, want := range []string{"source: dist", "target: /var/www/html", "config: .github/easysftp.yml"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should contain %q, got:\n%v", want, err)
+		}
+	}
+}
+
+func TestLoadRemovedInputsFailWithMigrationHint(t *testing.T) {
+	cases := []struct {
+		env      string
+		wantHint string
+	}{
+		{"SERVER", "'server' input was renamed to 'host'"},
+		{"HOST_KEY_FINGERPRINT", "renamed to 'host-key'"},
+		{"UPLOADS", "'source' and 'target'"},
+		{"CONFIG_FILE", "renamed to 'config'"},
+		{"STRATEGY", "renamed to 'mode'"},
+		{"IGNORE", "renamed to 'exclude'"},
+		{"IGNORE_FROM", "'ignore-from' input was removed"},
+		{"MAX_DELETES", "safety.max_deletes"},
+		{"DELETE", "use 'mode: clean'"},
+		{"CONCURRENCY", "advanced.concurrency"},
+		{"SFTP_REQUEST_CONCURRENCY", "advanced.request_concurrency"},
+		{"RETRIES", "advanced.retries"},
+		{"TIMEOUT", "advanced.timeout"},
+		{"STALL_TIMEOUT", "advanced.stall_timeout"},
+		{"SYNC_FAST_PATH", "sync.fast_path"},
+		{"MANIFEST_NAME", "sync.manifest"},
+		{"SKIP_UNCHANGED", "advanced.skip_unchanged"},
+		{"DIR_MODE", "permissions.directories"},
+		{"FILE_MODE", "permissions.files"},
+		{"PRESERVE_TIMES", "permissions.preserve_times"},
+		{"PROXY_SERVER", "connection.proxy.host"},
+		{"PROXY_PORT", "connection.proxy.port"},
+		{"PROXY_USERNAME", "connection.proxy.username"},
+		{"PROXY_HOST_KEY_FINGERPRINT", "connection.proxy.host_key"},
+		{"PROXY_KNOWN_HOSTS", "connection.proxy.known_hosts"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			setBaseEnv(t)
+			t.Setenv("EASYSFTP_"+tc.env, "something")
+			_, err := Load()
+			if err == nil || !strings.Contains(err.Error(), tc.wantHint) {
+				t.Fatalf("expected migration hint containing %q, got %v", tc.wantHint, err)
+			}
+			if !strings.Contains(err.Error(), "docs/migration-v3.md") {
+				t.Errorf("migration error should point at docs/migration-v3.md, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadAllowAnyHostKey(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("EASYSFTP_HOST_KEY", "")
+	t.Setenv("EASYSFTP_ALLOW_ANY_HOST_KEY", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.AllowAnyHostKey {
+		t.Error("expected AllowAnyHostKey to be true")
+	}
+	if cfg.HostKeyPinned() {
+		t.Error("expected no pinned host keys")
+	}
+}
+
+func TestLoadInlineRejectsProxyCredentials(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("EASYSFTP_PROXY_PASSWORD", "pw")
+	_, err := Load()
+	if err == nil || !strings.Contains(err.Error(), "connection.proxy") {
+		t.Fatalf("expected a proxy-requires-config error, got %v", err)
+	}
+}
+
+func TestLoadConfigMode(t *testing.T) {
+	path := setConfigModeEnv(t, `version: 3
+connection:
+  host: sftp.example.com
+  port: 2222
+  username: deploy
+  host_key: |
+    SHA256:abc
+    SHA256:def
+defaults:
+  mode: sync
+  exclude:
+    - "*.map"
+deployments:
+  website:
+    source: ./dist/
+    target: /var/www/html/
+  documentation:
+    source: ./docs/
+    target: /var/www/docs/
+    mode: clean
+    exclude:
+      - "*.tmp"
+safety:
+  max_deletes: 500
+advanced:
+  retries: 4
+  timeout: 60
+  stall_timeout: 120
+  concurrency: 8
+  request_concurrency: 4
+  skip_unchanged: true
+permissions:
+  files: "0644"
+  directories: "0755"
+  preserve_times: true
+sync:
+  fast_path: true
+  manifest: .deploy-manifest.json
+`)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server != "sftp.example.com" || cfg.Port != 2222 || cfg.Username != "deploy" {
+		t.Errorf("unexpected connection: %+v", cfg)
+	}
+	if cfg.Password != "hunter2" {
+		t.Errorf("expected the password credential input to apply, got %q", cfg.Password)
+	}
+	if len(cfg.HostKeyFingerprints) != 2 {
+		t.Errorf("expected 2 fingerprints, got %v", cfg.HostKeyFingerprints)
+	}
+	if cfg.ConfigPath != path {
+		t.Errorf("expected ConfigPath %q, got %q", path, cfg.ConfigPath)
+	}
+	if len(cfg.Uploads) != 2 {
+		t.Fatalf("expected 2 deployments, got %+v", cfg.Uploads)
+	}
+	website, docs := cfg.Uploads[0], cfg.Uploads[1]
+	if website.Name != "website" || website.Local != "./dist/" || website.Remote != "/var/www/html/" || website.Strategy != StrategySync {
+		t.Errorf("unexpected website deployment: %+v", website)
+	}
+	if docs.Name != "documentation" || docs.Strategy != StrategyClean || len(docs.Ignore) != 1 {
+		t.Errorf("unexpected documentation deployment: %+v", docs)
+	}
+	if len(cfg.IgnoreLines) != 1 || cfg.IgnoreLines[0] != "*.map" {
+		t.Errorf("unexpected global excludes: %v", cfg.IgnoreLines)
+	}
+	if cfg.Guards.MaxDeletes != 500 {
+		t.Errorf("expected max_deletes 500, got %d", cfg.Guards.MaxDeletes)
+	}
+	if cfg.Retries != 4 || cfg.Timeout != 60*time.Second || cfg.StallTimeout != 120*time.Second ||
+		cfg.Concurrency != 8 || cfg.SftpRequestConcurrency != 4 || !cfg.SkipUnchanged {
+		t.Errorf("unexpected advanced settings: %+v", cfg)
+	}
+	if cfg.FileMode == nil || *cfg.FileMode != 0o644 || cfg.DirMode == nil || *cfg.DirMode != 0o755 || !cfg.PreserveTimes {
+		t.Errorf("unexpected permissions: %v %v %v", cfg.FileMode, cfg.DirMode, cfg.PreserveTimes)
+	}
+	if !cfg.SyncFastPath || cfg.ManifestName != ".deploy-manifest.json" {
+		t.Errorf("unexpected sync settings: %v %q", cfg.SyncFastPath, cfg.ManifestName)
+	}
+}
+
+func TestLoadConfigModeDefaults(t *testing.T) {
+	setConfigModeEnv(t, minimalConfigFile)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Retries != 2 ||
+		cfg.Timeout != 30*time.Second || cfg.StallTimeout != 0 || cfg.Guards.MaxDeletes != 0 {
+		t.Errorf("unexpected config-mode defaults: %+v", cfg)
+	}
+	if cfg.Uploads[0].Strategy != StrategyOverlay {
+		t.Errorf("expected overlay default mode, got %q", cfg.Uploads[0].Strategy)
+	}
+}
+
+func TestLoadConfigModeExplicitZeros(t *testing.T) {
+	setConfigModeEnv(t, `version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: SHA256:abc
+deployments:
+  website:
+    source: ./dist/
+    target: /www/
+advanced:
+  retries: 0
+  timeout: 0
+`)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Retries != 0 || cfg.Timeout != 0 {
+		t.Errorf("explicit zeros must win over the defaults, got retries=%d timeout=%s", cfg.Retries, cfg.Timeout)
+	}
+}
+
+func TestLoadConfigModeConcurrencyAuto(t *testing.T) {
+	setConfigModeEnv(t, `version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: SHA256:abc
+deployments:
+  website:
+    source: ./dist/
+    target: /www/
+advanced:
+  concurrency: auto
+`)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Concurrency != 4 {
+		t.Errorf("expected 'auto' to resolve to the default concurrency, got %d", cfg.Concurrency)
+	}
+}
+
+func TestLoadConfigModeRejectsInlineInputs(t *testing.T) {
+	for _, in := range []struct{ env, name string }{
+		{"EASYSFTP_HOST", "host"},
+		{"EASYSFTP_SOURCE", "source"},
+		{"EASYSFTP_TARGET", "target"},
+		{"EASYSFTP_MODE", "mode"},
+		{"EASYSFTP_EXCLUDE", "exclude"},
+		{"EASYSFTP_HOST_KEY", "host-key"},
+		{"EASYSFTP_KNOWN_HOSTS", "known-hosts"},
+		{"EASYSFTP_ALLOW_ANY_HOST_KEY", "allow-any-host-key"},
+		{"EASYSFTP_USERNAME", "username"},
+		{"EASYSFTP_PORT", "port"},
+	} {
+		t.Run(in.name, func(t *testing.T) {
+			setConfigModeEnv(t, minimalConfigFile)
+			t.Setenv(in.env, "something")
+			_, err := Load()
+			if err == nil || !strings.Contains(err.Error(), "'"+in.name+"'") {
+				t.Fatalf("expected a mixed-mode rejection naming %q, got %v", in.name, err)
+			}
+		})
+	}
+}
+
+func TestLoadConfigModeAllowsCredentialsAndRunSwitches(t *testing.T) {
+	setConfigModeEnv(t, minimalConfigFile)
+	t.Setenv("EASYSFTP_PRIVATE_KEY", "-----BEGIN OPENSSH PRIVATE KEY-----")
+	t.Setenv("EASYSFTP_PASSPHRASE", "secret")
+	t.Setenv("EASYSFTP_DRY_RUN", "true")
+	t.Setenv("EASYSFTP_LOG_LEVEL", "verbose")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.DryRun || cfg.LogLevel != LogVerbose || cfg.Passphrase != "secret" {
+		t.Errorf("credentials and run switches must combine with config mode: %+v", cfg)
+	}
+}
+
+func TestLoadConfigModeProxy(t *testing.T) {
+	setConfigModeEnv(t, `version: 3
+connection:
+  host: sftp.internal.example.com
+  username: deploy
+  host_key: SHA256:abc
+  proxy:
+    host: bastion.example.com
+    username: jumper
+    host_key: SHA256:jump
+deployments:
+  website:
+    source: ./dist/
+    target: /www/
+`)
 	t.Setenv("EASYSFTP_PROXY_PASSWORD", "jump-pw")
-	t.Setenv("EASYSFTP_PROXY_HOST_KEY_FINGERPRINT", "SHA256:abc\nSHA256:def")
 
 	cfg, err := Load()
 	if err != nil {
@@ -135,102 +454,52 @@ func TestLoadProxy(t *testing.T) {
 	if p == nil {
 		t.Fatal("expected a proxy config")
 	}
-	if p.Server != "jump.example.com" || p.Username != "jumper" || p.Password != "jump-pw" {
+	if p.Server != "bastion.example.com" || p.Port != 22 || p.Username != "jumper" || p.Password != "jump-pw" {
 		t.Errorf("unexpected proxy config: %+v", p)
 	}
-	if p.Port != 22 {
-		t.Errorf("expected default proxy port 22, got %d", p.Port)
-	}
-	if len(p.HostKeyFingerprints) != 2 {
-		t.Errorf("expected 2 proxy fingerprints, got %v", p.HostKeyFingerprints)
+	if len(p.HostKeyFingerprints) != 1 || p.HostKeyFingerprints[0] != "SHA256:jump" {
+		t.Errorf("unexpected proxy fingerprints: %v", p.HostKeyFingerprints)
 	}
 }
 
-func TestLoadNoProxyByDefault(t *testing.T) {
-	setBaseEnv(t)
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Proxy != nil {
-		t.Errorf("expected no proxy config, got %+v", cfg.Proxy)
-	}
-}
-
-func TestLoadZeroTimeoutDisablesTimeout(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("EASYSFTP_TIMEOUT", "0")
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Timeout != 0 {
-		t.Errorf("expected timeout 0 (disabled), got %s", cfg.Timeout)
-	}
-}
-
-func TestLoadIgnoreFrom(t *testing.T) {
-	setBaseEnv(t)
-	ignoreFile := filepath.Join(t.TempDir(), ".sftpignore")
-	if err := os.WriteFile(ignoreFile, []byte("*.log\n# comment\nnode_modules/\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("EASYSFTP_IGNORE", "*.tmp")
-	t.Setenv("EASYSFTP_IGNORE_FROM", ignoreFile)
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{"*.tmp", "*.log", "node_modules/"}
-	if len(cfg.IgnoreLines) != len(want) {
-		t.Fatalf("expected %v, got %v", want, cfg.IgnoreLines)
-	}
-	for i := range want {
-		if cfg.IgnoreLines[i] != want[i] {
-			t.Errorf("ignore line %d: expected %q, got %q", i, want[i], cfg.IgnoreLines[i])
-		}
-	}
-}
-
-func TestLoadMaxDeletes(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("EASYSFTP_MAX_DELETES", "200")
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Guards.MaxDeletes != 200 {
-		t.Errorf("expected MaxDeletes 200, got %d", cfg.Guards.MaxDeletes)
-	}
-}
-
-func TestLoadMaxDeletesRejectedWithConfigFile(t *testing.T) {
-	setBaseEnv(t)
-	configFile := filepath.Join(t.TempDir(), "easysftp.yml")
-	if err := os.WriteFile(configFile, []byte("version: 1\ntargets:\n  - local: ./dist/\n    remote: /www/\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("EASYSFTP_UPLOADS", "")
-	t.Setenv("EASYSFTP_CONFIG_FILE", configFile)
-	t.Setenv("EASYSFTP_MAX_DELETES", "5")
-
+func TestLoadConfigModeProxyWithoutCredentialsFails(t *testing.T) {
+	setConfigModeEnv(t, `version: 3
+connection:
+  host: sftp.internal.example.com
+  username: deploy
+  host_key: SHA256:abc
+  proxy:
+    host: bastion.example.com
+    username: jumper
+    host_key: SHA256:jump
+deployments:
+  website:
+    source: ./dist/
+    target: /www/
+`)
 	_, err := Load()
-	if err == nil || !strings.Contains(err.Error(), "do not also set") {
-		t.Fatalf("expected rejection error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "'proxy-password' or 'proxy-private-key'") {
+		t.Fatalf("expected a missing proxy credential error, got %v", err)
 	}
 }
 
-// TestLoadConfigFileWithActionDefaults simulates a real composite-action run
-// that only sets connection settings and config-file: every EASYSFTP_* env
-// var wired in action.yml's "Upload via SFTP" step is exported with its
-// declared input default (empty when there is none), exactly as the runner
-// does. Regression test for the max-deletes default "0" tripping the
-// config-file mutual-exclusion check (#62), and a guard against any future
-// input default reintroducing the same class of bug.
-func TestLoadConfigFileWithActionDefaults(t *testing.T) {
+func TestLoadConfigModeProxyCredentialsWithoutProxyFails(t *testing.T) {
+	setConfigModeEnv(t, minimalConfigFile)
+	t.Setenv("EASYSFTP_PROXY_PASSWORD", "pw")
+	_, err := Load()
+	if err == nil || !strings.Contains(err.Error(), "no 'connection.proxy'") {
+		t.Fatalf("expected a proxy-credentials-without-proxy error, got %v", err)
+	}
+}
+
+// TestLoadConfigModeWithActionDefaults simulates a real composite-action run
+// that only sets credentials and config: every EASYSFTP_* env var wired in
+// action.yml's "Upload via SFTP" step is exported with its declared input
+// default (empty when there is none), exactly as the runner does. Regression
+// test for the input-default class of bug (#62): a declared default on a
+// mode-specific input would wrongly trip the mixed-mode check on every
+// config-mode run.
+func TestLoadConfigModeWithActionDefaults(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "action.yml"))
 	if err != nil {
 		t.Fatal(err)
@@ -277,57 +546,15 @@ func TestLoadConfigFileWithActionDefaults(t *testing.T) {
 		t.Setenv(name, input.Default)
 	}
 
-	// What a user's config-file workflow actually sets.
-	t.Setenv("EASYSFTP_SERVER", "sftp.example.com")
-	t.Setenv("EASYSFTP_USERNAME", "deploy")
+	// What a user's config-mode workflow actually sets.
 	t.Setenv("EASYSFTP_PASSWORD", "hunter2")
-	configFile := filepath.Join(t.TempDir(), "easysftp.yml")
-	if err := os.WriteFile(configFile, []byte("version: 1\ntargets:\n  - local: ./dist/\n    remote: /www/\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("EASYSFTP_CONFIG_FILE", configFile)
+	t.Setenv("EASYSFTP_CONFIG", writeConfig(t, minimalConfigFile))
 
 	cfg, err := Load()
 	if err != nil {
-		t.Fatalf("config-file run with action.yml input defaults was rejected: %v", err)
+		t.Fatalf("config-mode run with action.yml input defaults was rejected: %v", err)
 	}
-	if len(cfg.Uploads) != 1 || cfg.Uploads[0].Local != "./dist/" {
-		t.Errorf("unexpected uploads from config file: %+v", cfg.Uploads)
-	}
-}
-
-func TestLoadDirFileMode(t *testing.T) {
-	setBaseEnv(t)
-	if cfg, err := Load(); err != nil {
-		t.Fatal(err)
-	} else if cfg.DirMode != nil || cfg.FileMode != nil {
-		t.Errorf("expected unset dir-mode/file-mode by default, got %v / %v", cfg.DirMode, cfg.FileMode)
-	}
-
-	t.Setenv("EASYSFTP_DIR_MODE", "0755")
-	t.Setenv("EASYSFTP_FILE_MODE", "644")
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.DirMode == nil || *cfg.DirMode != 0o755 {
-		t.Errorf("expected DirMode 0755, got %v", cfg.DirMode)
-	}
-	if cfg.FileMode == nil || *cfg.FileMode != 0o644 {
-		t.Errorf("expected FileMode 0644, got %v", cfg.FileMode)
-	}
-}
-
-func TestLoadSyncFastPath(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("EASYSFTP_SYNC_FAST_PATH", "true")
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !cfg.SyncFastPath {
-		t.Error("expected SyncFastPath to be true")
+	if len(cfg.Uploads) != 1 || cfg.Uploads[0].Name != "website" {
+		t.Errorf("unexpected deployments from config file: %+v", cfg.Uploads)
 	}
 }

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -1,86 +1,365 @@
 package config
 
 import (
-	"bytes"
 	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
-// yamlConfig mirrors the YAML config file. Its JSON Schema lives in
-// schema/easysftp.schema.json (used for editor validation); the checks in
+// yamlConfig mirrors the v3 YAML config file. Its JSON Schema lives in
+// schema/easysftp.schema.json (used for editor validation); checkKeys and
 // applyYAML enforce the same rules at runtime with friendly messages.
 type yamlConfig struct {
-	Version  int          `yaml:"version"`
-	Strategy string       `yaml:"strategy"`
-	Ignore   []string     `yaml:"ignore"`
-	Guards   yamlGuards   `yaml:"guards"`
-	Targets  []yamlTarget `yaml:"targets"`
+	Version    int            `yaml:"version"`
+	Connection yamlConnection `yaml:"connection"`
+	Defaults   yamlDefaults   `yaml:"defaults"`
+	// Deployments stays a raw node so the file's own ordering is preserved
+	// (a Go map would shuffle it) and duplicate names can be detected.
+	Deployments yaml.Node       `yaml:"deployments"`
+	Safety      yamlSafety      `yaml:"safety"`
+	Advanced    yamlAdvanced    `yaml:"advanced"`
+	Permissions yamlPermissions `yaml:"permissions"`
+	Sync        yamlSync        `yaml:"sync"`
 }
 
-type yamlGuards struct {
+type yamlConnection struct {
+	Host            string     `yaml:"host"`
+	Port            int        `yaml:"port"`
+	Username        string     `yaml:"username"`
+	HostKey         string     `yaml:"host_key"`
+	KnownHosts      string     `yaml:"known_hosts"`
+	AllowAnyHostKey bool       `yaml:"allow_any_host_key"`
+	Proxy           *yamlProxy `yaml:"proxy"`
+}
+
+type yamlProxy struct {
+	Host            string `yaml:"host"`
+	Port            int    `yaml:"port"`
+	Username        string `yaml:"username"`
+	HostKey         string `yaml:"host_key"`
+	KnownHosts      string `yaml:"known_hosts"`
+	AllowAnyHostKey bool   `yaml:"allow_any_host_key"`
+}
+
+type yamlDefaults struct {
+	Mode    string   `yaml:"mode"`
+	Exclude []string `yaml:"exclude"`
+}
+
+type yamlDeployment struct {
+	Source  string   `yaml:"source"`
+	Target  string   `yaml:"target"`
+	Mode    string   `yaml:"mode"`
+	Exclude []string `yaml:"exclude"`
+}
+
+type yamlSafety struct {
 	MaxDeletes int `yaml:"max_deletes"`
 }
 
-type yamlTarget struct {
-	Local    string   `yaml:"local"`
-	Remote   string   `yaml:"remote"`
-	Strategy string   `yaml:"strategy"`
-	Ignore   []string `yaml:"ignore"`
+// yamlAdvanced uses pointers so "not set" keeps the run-wide default while an
+// explicit 0 (e.g. retries: 0, timeout: 0) means what it says.
+type yamlAdvanced struct {
+	Retries            *int    `yaml:"retries"`
+	Timeout            *int    `yaml:"timeout"`
+	StallTimeout       *int    `yaml:"stall_timeout"`
+	Concurrency        autoInt `yaml:"concurrency"`
+	RequestConcurrency autoInt `yaml:"request_concurrency"`
+	SkipUnchanged      bool    `yaml:"skip_unchanged"`
 }
 
-// loadConfigFile reads, parses and applies the YAML config file onto cfg.
+type yamlPermissions struct {
+	Files         string `yaml:"files"`
+	Directories   string `yaml:"directories"`
+	PreserveTimes bool   `yaml:"preserve_times"`
+}
+
+type yamlSync struct {
+	FastPath bool   `yaml:"fast_path"`
+	Manifest string `yaml:"manifest"`
+}
+
+// autoInt is an integer that also accepts the literal "auto" (or being
+// absent), both meaning "let easySFTP pick the default".
+type autoInt struct {
+	set bool
+	v   int
+}
+
+func (a *autoInt) UnmarshalYAML(node *yaml.Node) error {
+	if node.Value == "auto" {
+		return nil
+	}
+	if err := node.Decode(&a.v); err != nil {
+		return fmt.Errorf("must be a number or \"auto\", got %q", node.Value)
+	}
+	a.set = true
+	return nil
+}
+
+// or returns the configured value, or def when unset/"auto".
+func (a autoInt) or(def int) int {
+	if a.set {
+		return a.v
+	}
+	return def
+}
+
+// allowedKeys lists the valid option names per config-file section, keyed by
+// the section's dotted path ("" is the file's top level, "deployments.*" any
+// named deployment). checkKeys walks the raw YAML against it so a typo fails
+// with a suggestion instead of a silent no-op or a cryptic decoder error.
+var allowedKeys = map[string][]string{
+	"":                 {"version", "connection", "defaults", "deployments", "safety", "advanced", "permissions", "sync"},
+	"connection":       {"host", "port", "username", "host_key", "known_hosts", "allow_any_host_key", "proxy"},
+	"connection.proxy": {"host", "port", "username", "host_key", "known_hosts", "allow_any_host_key"},
+	"defaults":         {"mode", "exclude"},
+	"deployments.*":    {"source", "target", "mode", "exclude"},
+	"safety":           {"max_deletes"},
+	"advanced":         {"retries", "timeout", "stall_timeout", "concurrency", "request_concurrency", "skip_unchanged"},
+	"permissions":      {"files", "directories", "preserve_times"},
+	"sync":             {"fast_path", "manifest"},
+}
+
+// checkKeys validates every mapping key in the file against allowedKeys and
+// reports the first unknown one with its location and, when a known key is
+// close enough, a "did you mean" suggestion.
+func checkKeys(node *yaml.Node, section, location string) error {
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	allowed := allowedKeys[section]
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key, value := node.Content[i].Value, node.Content[i+1]
+		at := key
+		if location != "" {
+			at = location + "." + key
+		}
+		if !contains(allowed, key) {
+			msg := fmt.Sprintf("unknown option %q at %q", key, at)
+			if s := closestKey(key, allowed); s != "" {
+				msg += fmt.Sprintf("; did you mean %q?", s)
+			}
+			return fmt.Errorf("%s", msg)
+		}
+		// Recurse into the sections that have their own key set.
+		sub := section
+		if section == "" {
+			sub = key
+		} else {
+			sub = section + "." + key
+		}
+		if _, ok := allowedKeys[sub]; ok {
+			if err := checkKeys(value, sub, at); err != nil {
+				return err
+			}
+		}
+		if (section == "" && key == "deployments") && value.Kind == yaml.MappingNode {
+			for j := 0; j+1 < len(value.Content); j += 2 {
+				name, dep := value.Content[j].Value, value.Content[j+1]
+				if err := checkKeys(dep, "deployments.*", "deployments."+name); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func contains(list []string, s string) bool {
+	for _, l := range list {
+		if l == s {
+			return true
+		}
+	}
+	return false
+}
+
+// closestKey returns the allowed key closest to got (edit distance at most
+// 2), or "" when nothing is close enough to suggest.
+func closestKey(got string, allowed []string) string {
+	best, bestDist := "", 3
+	for _, a := range allowed {
+		if d := editDistance(got, a); d < bestDist {
+			best, bestDist = a, d
+		}
+	}
+	return best
+}
+
+// editDistance is the classic Levenshtein distance.
+func editDistance(a, b string) int {
+	prev := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		cur := make([]int, len(b)+1)
+		cur[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			cur[j] = minInt(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
+		}
+		prev = cur
+	}
+	return prev[len(b)]
+}
+
+func minInt(vals ...int) int {
+	m := vals[0]
+	for _, v := range vals[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}
+
+// loadConfigFile reads, parses and applies the v3 YAML config file onto cfg.
 func loadConfigFile(cfg *Config, path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("could not read config-file %q: %w", path, err)
+		return fmt.Errorf("could not read config %q: %w", path, err)
 	}
 
-	dec := yaml.NewDecoder(bytes.NewReader(data))
-	dec.KnownFields(true) // unknown keys become a clear error instead of silent no-ops
-	var yc yamlConfig
-	if err := dec.Decode(&yc); err != nil {
-		return fmt.Errorf("config-file %q is not valid: %w", path, err)
+	fail := func(err error) error {
+		return fmt.Errorf("config %q: %w", path, err)
 	}
-	return applyYAML(cfg, &yc)
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return fail(err)
+	}
+	if len(root.Content) > 0 {
+		if err := checkKeys(root.Content[0], "", ""); err != nil {
+			return fail(err)
+		}
+	}
+
+	var yc yamlConfig
+	if err := root.Decode(&yc); err != nil {
+		return fail(err)
+	}
+	if err := applyYAML(cfg, &yc); err != nil {
+		return fail(err)
+	}
+	return nil
 }
 
 func applyYAML(cfg *Config, yc *yamlConfig) error {
-	if yc.Version != 1 {
-		return fmt.Errorf("config-file: 'version' must be 1, got %d", yc.Version)
+	if yc.Version != 3 {
+		return fmt.Errorf("'version' must be 3, got %d (v1 config files are not supported by easySFTP v3; see docs/migration-v3.md)", yc.Version)
 	}
 
+	// Connection.
+	conn := yc.Connection
+	cfg.Server = strings.TrimSpace(conn.Host)
+	cfg.Username = strings.TrimSpace(conn.Username)
+	cfg.Port = 22
+	if conn.Port != 0 {
+		cfg.Port = conn.Port
+	}
+	cfg.HostKeyFingerprints = splitLines(conn.HostKey)
+	cfg.KnownHosts = strings.TrimSpace(conn.KnownHosts)
+	cfg.AllowAnyHostKey = conn.AllowAnyHostKey
+	if p := conn.Proxy; p != nil {
+		proxy := &Proxy{
+			Server:              strings.TrimSpace(p.Host),
+			Port:                22,
+			Username:            strings.TrimSpace(p.Username),
+			HostKeyFingerprints: splitLines(p.HostKey),
+			KnownHosts:          strings.TrimSpace(p.KnownHosts),
+			AllowAnyHostKey:     p.AllowAnyHostKey,
+		}
+		if p.Port != 0 {
+			proxy.Port = p.Port
+		}
+		if proxy.Server == "" {
+			return fmt.Errorf("'connection.proxy.host' is required when connection.proxy is set")
+		}
+		cfg.Proxy = proxy
+	}
+
+	// Defaults and deployments.
 	def := StrategyOverlay
-	if yc.Strategy != "" {
-		def = Strategy(yc.Strategy)
+	if yc.Defaults.Mode != "" {
+		def = Strategy(yc.Defaults.Mode)
 		if !def.valid() {
-			return fmt.Errorf("config-file: 'strategy' must be overlay, sync or clean, got %q", yc.Strategy)
+			return fmt.Errorf("'defaults.mode' must be overlay, sync or clean, got %q", yc.Defaults.Mode)
 		}
 	}
-	cfg.Guards.MaxDeletes = yc.Guards.MaxDeletes
+	cfg.IgnoreLines = append(cfg.IgnoreLines, yc.Defaults.Exclude...)
 
-	if len(yc.Targets) == 0 {
-		return fmt.Errorf("config-file: 'targets' must contain at least one entry")
+	deps := yc.Deployments
+	if deps.Kind == 0 || len(deps.Content) == 0 {
+		return fmt.Errorf("'deployments' must contain at least one named deployment, e.g.\n\ndeployments:\n  website:\n    source: dist\n    target: /var/www/html")
 	}
-	for i, t := range yc.Targets {
-		if t.Local == "" || t.Remote == "" {
-			return fmt.Errorf("config-file: target %d: both 'local' and 'remote' are required", i+1)
+	if deps.Kind != yaml.MappingNode {
+		return fmt.Errorf("'deployments' must be a map of named deployments (v1's 'targets' list is not supported; see docs/migration-v3.md)")
+	}
+	seen := map[string]bool{}
+	for i := 0; i+1 < len(deps.Content); i += 2 {
+		name := deps.Content[i].Value
+		if seen[name] {
+			return fmt.Errorf("deployment %q is defined twice", name)
 		}
-		st := def
-		if t.Strategy != "" {
-			st = Strategy(t.Strategy)
-			if !st.valid() {
-				return fmt.Errorf("config-file: target %d (%s): 'strategy' must be overlay, sync or clean, got %q", i+1, t.Remote, t.Strategy)
+		seen[name] = true
+		var d yamlDeployment
+		if err := deps.Content[i+1].Decode(&d); err != nil {
+			return fmt.Errorf("deployment %q: %w", name, err)
+		}
+		if d.Source == "" || d.Target == "" {
+			return fmt.Errorf("deployment %q: both 'source' and 'target' are required", name)
+		}
+		mode := def
+		if d.Mode != "" {
+			mode = Strategy(d.Mode)
+			if !mode.valid() {
+				return fmt.Errorf("deployment %q: 'mode' must be overlay, sync or clean, got %q", name, d.Mode)
 			}
 		}
 		cfg.Uploads = append(cfg.Uploads, UploadPair{
-			Local:    t.Local,
-			Remote:   t.Remote,
-			Strategy: st,
-			Ignore:   t.Ignore,
+			Name:     name,
+			Local:    d.Source,
+			Remote:   d.Target,
+			Strategy: mode,
+			Ignore:   d.Exclude,
 		})
 	}
-	cfg.IgnoreLines = append(cfg.IgnoreLines, yc.Ignore...)
+
+	// Safety, advanced tuning, permissions, sync.
+	cfg.Guards.MaxDeletes = yc.Safety.MaxDeletes
+	if yc.Advanced.Retries != nil {
+		cfg.Retries = *yc.Advanced.Retries
+	}
+	if yc.Advanced.Timeout != nil {
+		cfg.Timeout = time.Duration(*yc.Advanced.Timeout) * time.Second
+	}
+	if yc.Advanced.StallTimeout != nil {
+		cfg.StallTimeout = time.Duration(*yc.Advanced.StallTimeout) * time.Second
+	}
+	cfg.Concurrency = yc.Advanced.Concurrency.or(defaultConcurrency)
+	cfg.SftpRequestConcurrency = yc.Advanced.RequestConcurrency.or(defaultRequestConcurrency)
+	cfg.SkipUnchanged = yc.Advanced.SkipUnchanged
+
+	var err error
+	if cfg.FileMode, err = parseMode(yc.Permissions.Files, "permissions.files"); err != nil {
+		return err
+	}
+	if cfg.DirMode, err = parseMode(yc.Permissions.Directories, "permissions.directories"); err != nil {
+		return err
+	}
+	cfg.PreserveTimes = yc.Permissions.PreserveTimes
+
+	cfg.SyncFastPath = yc.Sync.FastPath
+	if cfg.ManifestName, err = parseManifestName(yc.Sync.Manifest); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/config/configfile_test.go
+++ b/internal/config/configfile_test.go
@@ -1,84 +1,157 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// writeConfig writes a YAML config file into a temp dir and returns its path.
-func writeConfig(t *testing.T, body string) string {
+// loadFile runs a config file's content through the loader against a fresh
+// config with the run-wide defaults, returning the error.
+func loadFile(t *testing.T, content string) (*Config, error) {
 	t.Helper()
-	p := filepath.Join(t.TempDir(), "easysftp.yml")
-	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
-		t.Fatal(err)
+	cfg := &Config{
+		Concurrency:            defaultConcurrency,
+		SftpRequestConcurrency: defaultRequestConcurrency,
+		Retries:                defaultRetries,
+		ManifestName:           DefaultManifestName,
 	}
-	return p
+	err := loadConfigFile(cfg, writeConfig(t, content))
+	return cfg, err
 }
 
-func TestLoadConfigFile(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("EASYSFTP_UPLOADS", "") // provided by the file instead
-	t.Setenv("EASYSFTP_CONFIG_FILE", writeConfig(t, `
-version: 1
-strategy: sync
-ignore:
-  - "*.map"
-guards:
-  max_deletes: 5
-targets:
-  - local: ./dist/
-    remote: /var/www/html/
-    ignore:
-      - node_modules/
-  - local: ./docs/
-    remote: /var/www/docs/
-    strategy: clean
-`))
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(cfg.Uploads) != 2 {
-		t.Fatalf("expected 2 targets, got %d", len(cfg.Uploads))
-	}
-	if cfg.Uploads[0].Strategy != StrategySync {
-		t.Errorf("target 0 should inherit sync, got %q", cfg.Uploads[0].Strategy)
-	}
-	if cfg.Uploads[1].Strategy != StrategyClean {
-		t.Errorf("target 1 should override to clean, got %q", cfg.Uploads[1].Strategy)
-	}
-	if cfg.Guards.MaxDeletes != 5 {
-		t.Errorf("expected max_deletes 5, got %d", cfg.Guards.MaxDeletes)
-	}
-	if len(cfg.Uploads[0].Ignore) != 1 || cfg.Uploads[0].Ignore[0] != "node_modules/" {
-		t.Errorf("unexpected target ignore: %v", cfg.Uploads[0].Ignore)
-	}
-	if len(cfg.IgnoreLines) != 1 || cfg.IgnoreLines[0] != "*.map" {
-		t.Errorf("unexpected global ignore: %v", cfg.IgnoreLines)
-	}
-}
-
-func TestConfigFileErrors(t *testing.T) {
+func TestConfigFileUnknownKeySuggestions(t *testing.T) {
 	cases := []struct {
-		name, body, wantErr string
+		name    string
+		content string
+		wantErr []string
 	}{
-		{"wrong version", "version: 2\ntargets:\n  - {local: a, remote: /b}", "'version' must be 1"},
-		{"unknown key", "version: 1\nstartegy: sync\ntargets:\n  - {local: a, remote: /b}", "not valid"},
-		{"bad strategy", "version: 1\nstrategy: mirror\ntargets:\n  - {local: a, remote: /b}", "overlay, sync or clean"},
-		{"bad target strategy", "version: 1\ntargets:\n  - {local: a, remote: /b, strategy: nope}", "overlay, sync or clean"},
-		{"no targets", "version: 1\ntargets: []", "at least one entry"},
-		{"missing remote", "version: 1\ntargets:\n  - {local: a}", "both 'local' and 'remote'"},
-		{"negative max_deletes", "version: 1\nguards: {max_deletes: -1}\ntargets:\n  - {local: a, remote: /b}", "max_deletes"},
+		{
+			"typo in advanced",
+			`version: 3
+connection:
+  host: h
+  username: u
+deployments:
+  web:
+    source: a
+    target: /b
+advanced:
+  concurency: 8
+`,
+			[]string{`unknown option "concurency" at "advanced.concurency"`, `did you mean "concurrency"?`},
+		},
+		{
+			"typo at top level",
+			"version: 3\nconection:\n  host: h\n",
+			[]string{`unknown option "conection"`, `did you mean "connection"?`},
+		},
+		{
+			"typo in a deployment",
+			`version: 3
+connection:
+  host: h
+  username: u
+deployments:
+  website:
+    source: a
+    taget: /b
+`,
+			[]string{`unknown option "taget" at "deployments.website.taget"`, `did you mean "target"?`},
+		},
+		{
+			"typo in proxy",
+			`version: 3
+connection:
+  host: h
+  proxy:
+    hostt: b
+`,
+			[]string{`unknown option "hostt" at "connection.proxy.hostt"`, `did you mean "host"?`},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			setBaseEnv(t)
-			t.Setenv("EASYSFTP_UPLOADS", "")
-			t.Setenv("EASYSFTP_CONFIG_FILE", writeConfig(t, tc.body))
-			_, err := Load()
+			_, err := loadFile(t, tc.content)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			for _, want := range tc.wantErr {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error should contain %q, got:\n%v", want, err)
+				}
+			}
+		})
+	}
+	t.Run("no suggestion for a distant name", func(t *testing.T) {
+		_, err := loadFile(t, "version: 3\nbanana: true\n")
+		if err == nil || !strings.Contains(err.Error(), `unknown option "banana"`) {
+			t.Fatalf("expected an unknown-option error, got %v", err)
+		}
+		if strings.Contains(err.Error(), "did you mean") {
+			t.Fatalf("expected no suggestion for a distant key, got %v", err)
+		}
+	})
+}
+
+func TestConfigFileVersionValidation(t *testing.T) {
+	t.Run("missing version", func(t *testing.T) {
+		_, err := loadFile(t, "connection:\n  host: h\n")
+		if err == nil || !strings.Contains(err.Error(), "'version' must be 3") {
+			t.Fatalf("expected a version error, got %v", err)
+		}
+	})
+	t.Run("v1 config is rejected with a migration hint", func(t *testing.T) {
+		_, err := loadFile(t, "version: 1\nconnection:\n  host: h\n")
+		if err == nil || !strings.Contains(err.Error(), "migration-v3") {
+			t.Fatalf("expected a v1 migration hint, got %v", err)
+		}
+	})
+}
+
+func TestConfigFileV1TargetsListIsRejected(t *testing.T) {
+	// A v1 file's 'targets' list fails the unknown-key check with a hint at
+	// the closest v3 concept.
+	_, err := loadFile(t, "version: 3\ntargets:\n  - local: ./dist/\n    remote: /www/\n")
+	if err == nil || !strings.Contains(err.Error(), `unknown option "targets"`) {
+		t.Fatalf("expected an unknown-option error for v1 'targets', got %v", err)
+	}
+}
+
+func TestConfigFileDeploymentsListIsRejected(t *testing.T) {
+	_, err := loadFile(t, `version: 3
+connection:
+  host: h
+  username: u
+deployments:
+  - source: ./dist/
+    target: /www/
+`)
+	if err == nil || !strings.Contains(err.Error(), "map of named deployments") {
+		t.Fatalf("expected a named-deployments error for a list, got %v", err)
+	}
+}
+
+func TestConfigFileValidation(t *testing.T) {
+	base := "version: 3\nconnection:\n  host: h\n  username: u\n"
+	deployment := "deployments:\n  web:\n    source: a\n    target: /b\n"
+	cases := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{"no deployments", base, "'deployments' must contain at least one named deployment"},
+		{"missing target", base + "deployments:\n  web:\n    source: ./dist/\n", "both 'source' and 'target' are required"},
+		{"bad mode", base + "deployments:\n  web:\n    source: a\n    target: /b\n    mode: mirror\n", "'mode' must be overlay, sync or clean"},
+		{"bad default mode", base + "defaults:\n  mode: mirror\n" + deployment, "'defaults.mode' must be overlay, sync or clean"},
+		{"duplicate deployment", base + "deployments:\n  web:\n    source: a\n    target: /b\n  web:\n    source: c\n    target: /d\n", "defined twice"},
+		{"proxy without host", "version: 3\nconnection:\n  host: h\n  username: u\n  proxy:\n    username: j\n" + deployment, "'connection.proxy.host' is required"},
+		{"bad manifest name", base + deployment + "sync:\n  manifest: sub/m.json\n", "sync.manifest must be a bare file name"},
+		{"bad permissions", base + deployment + "permissions:\n  files: \"999\"\n", "invalid permissions.files"},
+		{"bad concurrency value", base + deployment + "advanced:\n  concurrency: fast\n", "must be a number or \"auto\""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadFile(t, tc.content)
 			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
 			}
@@ -86,39 +159,48 @@ func TestConfigFileErrors(t *testing.T) {
 	}
 }
 
-func TestConfigFileRejectsMixingWithInputs(t *testing.T) {
-	setBaseEnv(t) // sets EASYSFTP_UPLOADS
-	t.Setenv("EASYSFTP_CONFIG_FILE", writeConfig(t, "version: 1\ntargets:\n  - {local: a, remote: /b}"))
-	_, err := Load()
-	if err == nil || !strings.Contains(err.Error(), "config-file") {
-		t.Fatalf("expected mixing error, got %v", err)
-	}
-}
-
-func TestStrategyInput(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("EASYSFTP_STRATEGY", "sync")
-	cfg, err := Load()
+func TestConfigFileDeploymentOrderIsPreserved(t *testing.T) {
+	cfg, err := loadFile(t, `version: 3
+connection:
+  host: h
+  username: u
+deployments:
+  zeta:
+    source: a
+    target: /a
+  alpha:
+    source: b
+    target: /b
+  mid:
+    source: c
+    target: /c
+`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Uploads[0].Strategy != StrategySync {
-		t.Errorf("expected sync strategy, got %q", cfg.Uploads[0].Strategy)
+	got := []string{cfg.Uploads[0].Name, cfg.Uploads[1].Name, cfg.Uploads[2].Name}
+	want := []string{"zeta", "alpha", "mid"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("deployment order not preserved: got %v, want %v", got, want)
+		}
 	}
 }
 
-func TestDeleteInputIsRejected(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("EASYSFTP_DELETE", "true")
-	if _, err := Load(); err == nil || !strings.Contains(err.Error(), "strategy: clean") {
-		t.Fatalf("expected the delete tombstone error, got %v", err)
+func TestEditDistance(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"concurency", "concurrency", 1},
+		{"taget", "target", 1},
+		{"banana", "version", 7},
 	}
-}
-
-func TestDeleteFalseIsAccepted(t *testing.T) {
-	setBaseEnv(t)
-	t.Setenv("EASYSFTP_DELETE", "false")
-	if _, err := Load(); err != nil {
-		t.Fatalf("delete=false must stay accepted (it is the action.yml default): %v", err)
+	for _, tc := range cases {
+		if got := editDistance(tc.a, tc.b); got != tc.want {
+			t.Errorf("editDistance(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
 	}
 }

--- a/internal/uploader/connection.go
+++ b/internal/uploader/connection.go
@@ -39,19 +39,30 @@ func sendKeepalives(ctx context.Context, client func() *ssh.Client, interval tim
 	}
 }
 
+// hopNames holds the user-facing option names of one hop's host key knobs,
+// so warnings and errors point at what the user actually writes: inline
+// input names for the primary hop in inline mode, config-file paths in
+// config mode, and connection.proxy.* paths for the jump host (which only
+// exists in config mode).
+type hopNames struct {
+	hostKey    string
+	knownHosts string
+	allowAny   string
+	privateKey string
+}
+
 // hop carries the connection parameters of one SSH hop: the primary server,
-// or the optional jump host in front of it. inputPrefix ("" or "proxy-")
-// names the inputs in warnings and errors, so each hop's message points at
-// the right knobs.
+// or the optional jump host in front of it.
 type hop struct {
-	addr         string
-	user         string
-	password     string
-	privateKey   string
-	passphrase   string
-	fingerprints []string
-	knownHosts   string
-	inputPrefix  string
+	addr            string
+	user            string
+	password        string
+	privateKey      string
+	passphrase      string
+	fingerprints    []string
+	knownHosts      string
+	allowAnyHostKey bool
+	names           hopNames
 }
 
 // clientConfig builds the ssh.ClientConfig for this hop, including its own
@@ -77,28 +88,46 @@ func (h hop) clientConfig(timeout time.Duration, log Logger) (*ssh.ClientConfig,
 
 // targetHop maps the primary connection settings onto a hop.
 func targetHop(cfg *config.Config) hop {
+	names := hopNames{hostKey: "host-key", knownHosts: "known-hosts", allowAny: "allow-any-host-key", privateKey: "private-key"}
+	if cfg.ConfigPath != "" {
+		names = hopNames{hostKey: "connection.host_key", knownHosts: "connection.known_hosts",
+			allowAny: "connection.allow_any_host_key", privateKey: "private-key"}
+	}
 	return hop{
-		addr:         net.JoinHostPort(cfg.Server, fmt.Sprintf("%d", cfg.Port)),
-		user:         cfg.Username,
-		password:     cfg.Password,
-		privateKey:   cfg.PrivateKey,
-		passphrase:   cfg.Passphrase,
-		fingerprints: cfg.HostKeyFingerprints,
-		knownHosts:   cfg.KnownHosts,
+		addr:            net.JoinHostPort(cfg.Server, fmt.Sprintf("%d", cfg.Port)),
+		user:            cfg.Username,
+		password:        cfg.Password,
+		privateKey:      cfg.PrivateKey,
+		passphrase:      cfg.Passphrase,
+		fingerprints:    cfg.HostKeyFingerprints,
+		knownHosts:      cfg.KnownHosts,
+		allowAnyHostKey: cfg.AllowAnyHostKey,
+		names:           names,
 	}
 }
 
-// jumpHop maps the proxy-* settings onto a hop.
+// jumpHop maps the connection.proxy settings onto a hop.
 func jumpHop(p *config.Proxy) hop {
 	return hop{
-		addr:         net.JoinHostPort(p.Server, fmt.Sprintf("%d", p.Port)),
-		user:         p.Username,
-		password:     p.Password,
-		privateKey:   p.PrivateKey,
-		passphrase:   p.Passphrase,
-		fingerprints: p.HostKeyFingerprints,
-		knownHosts:   p.KnownHosts,
-		inputPrefix:  "proxy-",
+		addr:            net.JoinHostPort(p.Server, fmt.Sprintf("%d", p.Port)),
+		user:            p.Username,
+		password:        p.Password,
+		privateKey:      p.PrivateKey,
+		passphrase:      p.Passphrase,
+		fingerprints:    p.HostKeyFingerprints,
+		knownHosts:      p.KnownHosts,
+		allowAnyHostKey: p.AllowAnyHostKey,
+		names: hopNames{hostKey: "connection.proxy.host_key", knownHosts: "connection.proxy.known_hosts",
+			allowAny: "connection.proxy.allow_any_host_key", privateKey: "proxy-private-key"},
+	}
+}
+
+// logHostKeyStatus reports one hop's successful verification. The unverified
+// case already warned in hostKeyCallback; this line is the positive signal
+// the compact default log promises ("Host key verified").
+func logHostKeyStatus(h hop, log Logger) {
+	if len(h.fingerprints) > 0 || h.knownHosts != "" {
+		log.Infof("host key of %s verified against the pinned key(s)", h.addr)
 	}
 }
 
@@ -122,6 +151,7 @@ func connect(cfg *config.Config, log Logger) (*ssh.Client, *sftp.Client, func(),
 		if err != nil {
 			return nil, nil, noop, fmt.Errorf("connecting to %s: %w", target.addr, err)
 		}
+		logHostKeyStatus(target, log)
 	} else {
 		sshClient, cleanup, err = dialViaJump(cfg, target.addr, targetConfig, log)
 		if err != nil {
@@ -156,6 +186,7 @@ func dialViaJump(cfg *config.Config, targetAddr string, targetConfig *ssh.Client
 	if err != nil {
 		return nil, nil, fmt.Errorf("connecting to jump host %s: %w", jump.addr, err)
 	}
+	logHostKeyStatus(jump, log)
 	log.Infof("connecting to %s as %s through the jump host ...", targetAddr, targetConfig.User)
 	conn, err := jumpClient.Dial("tcp", targetAddr)
 	if err != nil {
@@ -168,6 +199,7 @@ func dialViaJump(cfg *config.Config, targetAddr string, targetConfig *ssh.Client
 		jumpClient.Close()
 		return nil, nil, fmt.Errorf("connecting to %s through jump host %s: %w", targetAddr, jump.addr, err)
 	}
+	logHostKeyStatus(targetHop(cfg), log)
 	return ssh.NewClient(ncc, chans, reqs), func() { jumpClient.Close() }, nil
 }
 
@@ -182,7 +214,7 @@ func authMethods(h hop) ([]ssh.AuthMethod, error) {
 			signer, err = ssh.ParsePrivateKey([]byte(key + "\n"))
 		}
 		if err != nil {
-			return nil, fmt.Errorf("parsing %sprivate-key: %w", h.inputPrefix, err)
+			return nil, fmt.Errorf("parsing %s: %w", h.names.privateKey, err)
 		}
 		methods = append(methods, ssh.PublicKeys(signer))
 	}

--- a/internal/uploader/hostkeys.go
+++ b/internal/uploader/hostkeys.go
@@ -13,16 +13,23 @@ import (
 func hostKeyCallback(h hop, log Logger) (ssh.HostKeyCallback, error) {
 	want := h.fingerprints
 	if len(want) == 0 && h.knownHosts == "" {
-		// The warning fires per hop: a pinned target behind an unpinned jump
-		// host (or vice versa) still deserves a nudge for the open hop.
-		log.Warningf("no %[1]shost-key-fingerprint or %[1]sknown-hosts configured; the identity of %[2]s will NOT be verified. "+
-			"Run 'ssh-keyscan <server>' and set the %[1]sknown-hosts input (or convert with 'ssh-keygen -lf -' "+
-			"and set %[1]shost-key-fingerprint) to pin it.", h.inputPrefix, h.addr)
+		// Unverified connections are an explicit opt-in in v3, per hop: a
+		// pinned target behind an unpinned jump host (or vice versa) still
+		// fails for the open hop unless that hop opts out too.
+		if !h.allowAnyHostKey {
+			return nil, fmt.Errorf("the identity of %[1]s cannot be verified: no %[2]s or %[3]s configured. "+
+				"Pin the server's keys (run 'ssh-keyscan <server>' and set %[3]s, or convert with 'ssh-keygen -lf -' and set %[2]s), "+
+				"or explicitly accept any host key with %[4]s (NOT recommended: allows man-in-the-middle attacks)",
+				h.addr, h.names.hostKey, h.names.knownHosts, h.names.allowAny)
+		}
+		log.Warningf("%s is set; the identity of %s will NOT be verified and man-in-the-middle attacks are possible. "+
+			"Pin the server's keys via %s or %s and remove the opt-out.",
+			h.names.allowAny, h.addr, h.names.hostKey, h.names.knownHosts)
 		return ssh.InsecureIgnoreHostKey(), nil
 	}
 	for _, fp := range want {
 		if !strings.HasPrefix(fp, "SHA256:") {
-			return nil, fmt.Errorf("%shost-key-fingerprint must be a SHA256 fingerprint like 'SHA256:...', got %q", h.inputPrefix, fp)
+			return nil, fmt.Errorf("%s must be a SHA256 fingerprint like 'SHA256:...', got %q", h.names.hostKey, fp)
 		}
 	}
 	var khCallback ssh.HostKeyCallback

--- a/internal/uploader/loglevel_test.go
+++ b/internal/uploader/loglevel_test.go
@@ -21,13 +21,12 @@ func countInfos(log *recordingLogger, substr string) int {
 	return n
 }
 
-func TestQuietSuppressesPerFileLines(t *testing.T) {
+func TestNormalSuppressesPerFileLines(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()
 	writeTree(t, local, map[string]string{"a.txt": "1", "b.txt": "2"})
 
 	cfg := baseConfig(srv)
-	cfg.LogLevel = config.LogQuiet
 	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategySync}}
 
 	log := &recordingLogger{testLogger: testLogger{t}}
@@ -39,23 +38,25 @@ func TestQuietSuppressesPerFileLines(t *testing.T) {
 		t.Errorf("expected 2 uploads, got %d", stats.FilesUploaded)
 	}
 	if n := countInfos(log, "upload "); n != 0 {
-		t.Errorf("expected no per-file upload lines in quiet mode, got %d: %v", n, log.infos)
+		t.Errorf("expected no per-file upload lines at the default level, got %d: %v", n, log.infos)
 	}
 	if n := countInfos(log, "sync: "); n != 1 {
-		t.Errorf("expected the per-target sync summary to survive quiet mode, got %d", n)
+		t.Errorf("expected the per-deployment sync summary to survive the default level, got %d", n)
+	}
+	if n := countInfos(log, "deployment "); n != 1 {
+		t.Errorf("expected one deployment summary line, got %d: %v", n, log.infos)
 	}
 	if n := countInfos(log, "connecting to "); n != 1 {
-		t.Errorf("expected the connection line to survive quiet mode, got %d", n)
+		t.Errorf("expected the connection line to survive the default level, got %d", n)
 	}
 }
 
-func TestQuietDryRunStillLogsThePlan(t *testing.T) {
+func TestNormalDryRunStillLogsThePlan(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()
 	writeTree(t, local, map[string]string{"a.txt": "1"})
 
 	cfg := baseConfig(srv)
-	cfg.LogLevel = config.LogQuiet
 	cfg.DryRun = true
 	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
 
@@ -64,11 +65,11 @@ func TestQuietDryRunStillLogsThePlan(t *testing.T) {
 		t.Fatal(err)
 	}
 	if n := countInfos(log, "would upload "); n != 1 {
-		t.Errorf("dry-run must log the plan regardless of quiet, got %d plan lines: %v", n, log.infos)
+		t.Errorf("dry-run must log the plan regardless of log-level, got %d plan lines: %v", n, log.infos)
 	}
 }
 
-func TestVerboseExplainsIgnoreDecisions(t *testing.T) {
+func TestVerboseLogsPerFileLines(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()
 	writeTree(t, local, map[string]string{"index.html": "x", "debug.log": "y"})
@@ -82,17 +83,21 @@ func TestVerboseExplainsIgnoreDecisions(t *testing.T) {
 	if _, err := Run(context.Background(), cfg, log); err != nil {
 		t.Fatal(err)
 	}
-	if n := countInfos(log, `skip debug.log (ignore pattern "*.log")`); n != 1 {
-		t.Errorf("expected one ignore-decision line, got %d: %v", n, log.infos)
+	if n := countInfos(log, "upload "); n != 1 {
+		t.Errorf("expected the per-file upload line at verbose level, got %d", n)
+	}
+	if n := countInfos(log, "ignore pattern"); n != 0 {
+		t.Errorf("expected no exclude-decision lines at verbose level, got %d: %v", n, log.infos)
 	}
 }
 
-func TestNormalDoesNotExplainIgnoreDecisions(t *testing.T) {
+func TestDebugExplainsExcludeDecisions(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()
 	writeTree(t, local, map[string]string{"index.html": "x", "debug.log": "y"})
 
 	cfg := baseConfig(srv)
+	cfg.LogLevel = config.LogDebug
 	cfg.IgnoreLines = []string{"*.log"}
 	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
 
@@ -100,10 +105,10 @@ func TestNormalDoesNotExplainIgnoreDecisions(t *testing.T) {
 	if _, err := Run(context.Background(), cfg, log); err != nil {
 		t.Fatal(err)
 	}
-	if n := countInfos(log, "ignore pattern"); n != 0 {
-		t.Errorf("expected no ignore-decision lines at normal level, got %d: %v", n, log.infos)
+	if n := countInfos(log, `skip debug.log (ignore pattern "*.log")`); n != 1 {
+		t.Errorf("expected one exclude-decision line, got %d: %v", n, log.infos)
 	}
 	if n := countInfos(log, "upload "); n != 1 {
-		t.Errorf("expected the per-file upload line at normal level, got %d", n)
+		t.Errorf("expected the per-file upload line at debug level, got %d", n)
 	}
 }

--- a/internal/uploader/planner.go
+++ b/internal/uploader/planner.go
@@ -90,7 +90,7 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, opts planOption
 	// sync and clean reconcile a directory tree; they are meaningless for a
 	// single file and would delete the wrong things, so reject that up front.
 	if !info.IsDir() && strategy != config.StrategyOverlay {
-		return p, fmt.Errorf("strategy %q requires a directory, but local path %q is a single file (use the overlay strategy)", strategy, pair.Local)
+		return p, fmt.Errorf("mode %q requires a directory, but local path %q is a single file (use the overlay mode)", strategy, pair.Local)
 	}
 
 	// A single file maps directly onto the remote path. A trailing slash on

--- a/internal/uploader/proxyjump_test.go
+++ b/internal/uploader/proxyjump_test.go
@@ -85,7 +85,7 @@ func TestProxyJumpVerifiesTargetHostKey(t *testing.T) {
 	}
 }
 
-func TestProxyJumpWarnsPerUnpinnedHop(t *testing.T) {
+func TestProxyJumpUnpinnedHopRequiresOptIn(t *testing.T) {
 	target := startTestServer(t)
 	jump := startTestJumpServer(t)
 	local := t.TempDir()
@@ -97,6 +97,15 @@ func TestProxyJumpWarnsPerUnpinnedHop(t *testing.T) {
 	cfg.Proxy.HostKeyFingerprints = nil
 	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
 
+	// Without the per-hop opt-in the unpinned jump host fails the run, even
+	// though the target itself is pinned.
+	_, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "connection.proxy.host_key") {
+		t.Fatalf("expected an unverified jump-host error naming the proxy options, got %v", err)
+	}
+
+	// With the opt-in the run succeeds but still warns for the open hop.
+	cfg.Proxy.AllowAnyHostKey = true
 	log := &recordingLogger{testLogger: testLogger{t}}
 	if _, err := Run(context.Background(), cfg, log); err != nil {
 		t.Fatal(err)
@@ -104,12 +113,12 @@ func TestProxyJumpWarnsPerUnpinnedHop(t *testing.T) {
 	found := false
 	log.mu.Lock()
 	for _, w := range log.warnings {
-		if strings.Contains(w, "proxy-host-key-fingerprint") {
+		if strings.Contains(w, "connection.proxy.allow_any_host_key") {
 			found = true
 		}
 	}
 	log.mu.Unlock()
 	if !found {
-		t.Errorf("expected an unverified-host-key warning naming the proxy inputs, got %v", log.warnings)
+		t.Errorf("expected an unverified-host-key warning naming the proxy opt-in, got %v", log.warnings)
 	}
 }

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -76,12 +76,12 @@ func nonDirConflict(client *sftp.Client, dir string) string {
 	return ""
 }
 
-// checkRemoteRoot refuses a destructive strategy whose target resolves to the
+// checkRemoteRoot refuses a destructive mode whose target resolves to the
 // filesystem root or an unspecific path: the one guard that is always on.
 func checkRemoteRoot(remote string) error {
 	switch normalizeRemote(remote) {
 	case "/", ".", "", "~":
-		return fmt.Errorf("refusing a destructive strategy on remote root %q; target a specific subdirectory instead", remote)
+		return fmt.Errorf("refusing a destructive mode on remote root %q; target a specific subdirectory instead", remote)
 	}
 	return nil
 }

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -40,16 +40,14 @@ type Stats struct {
 	BytesUploaded int64
 	Duration      time.Duration
 
-	// Targets breaks the totals above down per upload pair. It is only
-	// populated when the config has more than one pair: a single-target run
-	// has nothing to break down, so it stays nil and callers can use that to
-	// decide whether a per-target table is worth showing.
+	// Targets breaks the totals above down per deployment, in plan order.
 	Targets []TargetStats
 }
 
-// TargetStats summarizes what a run did (or would do) for a single upload
-// pair, so a multi-target deploy can be broken down in the job summary.
+// TargetStats summarizes what a run did (or would do) for a single
+// deployment, so the job summary can break a deploy down per deployment.
 type TargetStats struct {
+	Name          string // deployment name from the config file; "" inline
 	Local         string
 	Remote        string
 	Strategy      config.Strategy
@@ -57,6 +55,7 @@ type TargetStats struct {
 	FilesDeleted  int
 	FilesSkipped  int
 	BytesUploaded int64
+	Duration      time.Duration
 }
 
 // Run executes the configured upload and returns transfer statistics.
@@ -72,10 +71,10 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		st := effectiveStrategy(pair)
 		lines := append(append([]string{}, cfg.IgnoreLines...), pair.Ignore...)
 		matcher := ignore.CompileIgnoreLines(lines...)
-		// verbose is nil unless log-level is verbose; buildPlan then explains
-		// every ignore decision.
+		// verbose is nil unless log-level is debug; buildPlan then explains
+		// every exclude decision.
 		var verbose Logger
-		if cfg.Verbose() {
+		if cfg.Debug() {
 			verbose = log
 		}
 		p, err := buildPlan(pair, st, planOptions{
@@ -115,21 +114,26 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 			return stats, err
 		}
 		before := *stats
+		planStart := time.Now()
 		err := executePlan(ctx, cfg, sess, p, stats, watch, log)
-		if len(plans) > 1 {
-			// Recorded from the before/after delta (not threaded through
-			// executePlan) so a target's partial progress on failure is
-			// still captured, matching the totals' own partial-progress
-			// behavior.
-			stats.Targets = append(stats.Targets, TargetStats{
-				Local:         p.pair.Local,
-				Remote:        p.pair.Remote,
-				Strategy:      p.strategy,
-				FilesUploaded: stats.FilesUploaded - before.FilesUploaded,
-				FilesDeleted:  stats.FilesDeleted - before.FilesDeleted,
-				FilesSkipped:  stats.FilesSkipped - before.FilesSkipped,
-				BytesUploaded: stats.BytesUploaded - before.BytesUploaded,
-			})
+		// Recorded from the before/after delta (not threaded through
+		// executePlan) so a target's partial progress on failure is
+		// still captured, matching the totals' own partial-progress
+		// behavior.
+		ts := TargetStats{
+			Name:          p.pair.Name,
+			Local:         p.pair.Local,
+			Remote:        p.pair.Remote,
+			Strategy:      p.strategy,
+			FilesUploaded: stats.FilesUploaded - before.FilesUploaded,
+			FilesDeleted:  stats.FilesDeleted - before.FilesDeleted,
+			FilesSkipped:  stats.FilesSkipped - before.FilesSkipped,
+			BytesUploaded: stats.BytesUploaded - before.BytesUploaded,
+			Duration:      time.Since(planStart),
+		}
+		stats.Targets = append(stats.Targets, ts)
+		if err == nil {
+			logDeploymentSummary(cfg, p.pair, ts, log)
 		}
 		if err != nil {
 			if watch != nil && watch.fired.Load() {
@@ -142,13 +146,30 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	return stats, nil
 }
 
+// logDeploymentSummary logs the compact one-line result of a completed
+// deployment, the core of the default (non-verbose) log output.
+func logDeploymentSummary(cfg *config.Config, pair config.UploadPair, ts TargetStats, log Logger) {
+	if cfg.DryRun {
+		log.Infof("deployment %s: %d file(s) to upload (%s), %d to delete, %d unchanged (dry-run)",
+			pair.Label(), ts.FilesUploaded, humanSize(ts.BytesUploaded), ts.FilesDeleted, ts.FilesSkipped)
+		return
+	}
+	log.Infof("deployment %s: uploaded %d file(s) (%s), deleted %d, skipped %d unchanged, took %s",
+		pair.Label(), ts.FilesUploaded, humanSize(ts.BytesUploaded), ts.FilesDeleted, ts.FilesSkipped,
+		ts.Duration.Round(time.Millisecond))
+}
+
 // executePlan performs (or previews) one plan according to its strategy.
 func executePlan(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, watch *stallWatchdog, log Logger) error {
-	log.Group(fmt.Sprintf("%s => %s [%s] (%d local files)", p.pair.Local, p.pair.Remote, p.strategy, len(p.files)))
+	header := fmt.Sprintf("%s => %s [%s] (%d local files)", p.pair.Local, p.pair.Remote, p.strategy, len(p.files))
+	if p.pair.Name != "" {
+		header = fmt.Sprintf("%s: %s", p.pair.Name, header)
+	}
+	log.Group(header)
 	defer log.EndGroup()
 
 	if cfg.SkipUnchanged && p.strategy != config.StrategyOverlay {
-		log.Warningf("skip-unchanged only applies to the overlay strategy; ignoring it for this %s target", p.strategy)
+		log.Warningf("advanced.skip_unchanged only applies to the overlay mode; ignoring it for this %s deployment", p.strategy)
 	}
 
 	if p.strategy == config.StrategySync {

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -48,6 +48,9 @@ func baseConfig(srv *testServer) *config.Config {
 		SftpRequestConcurrency: 16,
 		Retries:                0,
 		Timeout:                10 * time.Second,
+		// The in-process test server's host key is not pinned; opt out of
+		// verification like a directly constructed config must in v3.
+		AllowAnyHostKey: true,
 	}
 }
 
@@ -184,20 +187,20 @@ func TestMultiTargetStatsBreakdown(t *testing.T) {
 	}
 }
 
-func TestSingleTargetStatsHaveNoBreakdown(t *testing.T) {
+func TestSingleTargetStatsAreRecorded(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()
 	writeTree(t, local, map[string]string{"index.html": "hi"})
 
 	cfg := baseConfig(srv)
-	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+	cfg.Uploads = []config.UploadPair{{Name: "website", Local: local, Remote: "/www"}}
 
 	stats, err := Run(context.Background(), cfg, testLogger{t})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stats.Targets != nil {
-		t.Errorf("expected no per-target breakdown for a single target, got %+v", stats.Targets)
+	if len(stats.Targets) != 1 || stats.Targets[0].Name != "website" || stats.Targets[0].FilesUploaded != 1 {
+		t.Errorf("expected one named target entry with 1 upload, got %+v", stats.Targets)
 	}
 }
 
@@ -380,6 +383,53 @@ func TestHostKeyFingerprint(t *testing.T) {
 		_, err := Run(context.Background(), cfg, testLogger{t})
 		if err == nil || !strings.Contains(err.Error(), "SHA256") {
 			t.Fatalf("expected SHA256 format error, got %v", err)
+		}
+	})
+}
+
+func TestUnverifiedHostKeyRequiresOptIn(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "x"})
+
+	t.Run("no pins and no opt-in fails", func(t *testing.T) {
+		cfg := baseConfig(srv)
+		cfg.AllowAnyHostKey = false
+		cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+		_, err := Run(context.Background(), cfg, testLogger{t})
+		if err == nil || !strings.Contains(err.Error(), "allow-any-host-key") {
+			t.Fatalf("expected an unverified-host-key error naming the opt-in, got %v", err)
+		}
+	})
+
+	t.Run("opt-in connects but warns", func(t *testing.T) {
+		cfg := baseConfig(srv)
+		cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+		log := &recordingLogger{testLogger: testLogger{t}}
+		if _, err := Run(context.Background(), cfg, log); err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		log.mu.Lock()
+		for _, w := range log.warnings {
+			if strings.Contains(w, "allow-any-host-key") {
+				found = true
+			}
+		}
+		log.mu.Unlock()
+		if !found {
+			t.Errorf("expected an allow-any-host-key warning, got %v", log.warnings)
+		}
+	})
+
+	t.Run("config-mode error names the config options", func(t *testing.T) {
+		cfg := baseConfig(srv)
+		cfg.AllowAnyHostKey = false
+		cfg.ConfigPath = ".github/easysftp.yml"
+		cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+		_, err := Run(context.Background(), cfg, testLogger{t})
+		if err == nil || !strings.Contains(err.Error(), "connection.allow_any_host_key") {
+			t.Fatalf("expected the config-mode option name in the error, got %v", err)
 		}
 	})
 }
@@ -785,7 +835,7 @@ func TestOverlaySkipUnchangedDryRun(t *testing.T) {
 	}
 }
 
-// skip-unchanged only applies to overlay; other strategies warn and ignore it.
+// skip_unchanged only applies to overlay; other modes warn and ignore it.
 func TestSkipUnchangedWarnsOnNonOverlay(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()
@@ -801,12 +851,12 @@ func TestSkipUnchangedWarnsOnNonOverlay(t *testing.T) {
 	}
 	found := false
 	for _, w := range log.warnings {
-		if strings.Contains(w, "skip-unchanged") {
+		if strings.Contains(w, "skip_unchanged only applies to the overlay mode") {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected a warning that skip-unchanged is ignored for sync, got %v", log.warnings)
+		t.Errorf("expected a warning that skip_unchanged is ignored for sync, got %v", log.warnings)
 	}
 }
 

--- a/schema/easysftp.schema.json
+++ b/schema/easysftp.schema.json
@@ -2,25 +2,125 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/eiserv/easySFTP/main/schema/easysftp.schema.json",
   "title": "easySFTP configuration",
-  "description": "Deployment configuration for the easySFTP GitHub Action. Connection settings (server, credentials, host key) are NOT part of this file; keep those in action inputs / secrets.",
+  "description": "Configuration file (version 3) for the easySFTP GitHub Action. Holds every non-secret setting: connection, named deployments, safety limits and advanced tuning. Credentials (password, private keys, passphrases) stay in GitHub Secrets and are passed as action inputs; never put them in this file.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version", "targets"],
+  "required": ["version", "connection", "deployments"],
   "properties": {
     "version": {
-      "description": "Config format version. Must be 1.",
-      "const": 1
+      "description": "Config format version. Must be 3.",
+      "const": 3
     },
-    "strategy": {
-      "$ref": "#/$defs/strategy",
-      "description": "Default strategy for all targets. Defaults to 'overlay'."
+    "connection": {
+      "description": "Where and as whom to connect. Credentials are NOT part of this file; pass them as the password / private-key / passphrase action inputs.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "username"],
+      "properties": {
+        "host": {
+          "description": "Hostname or IP address of the SFTP server.",
+          "type": "string",
+          "minLength": 1
+        },
+        "port": {
+          "description": "SSH port. Defaults to 22.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "username": {
+          "description": "Username used for authentication.",
+          "type": "string",
+          "minLength": 1
+        },
+        "host_key": {
+          "description": "Expected SHA256 fingerprint(s) of the server's host key, one per line (format \"SHA256:...\"). Without host_key or known_hosts, the run fails unless allow_any_host_key is set.",
+          "type": "string"
+        },
+        "known_hosts": {
+          "description": "Expected host key(s) in OpenSSH known_hosts format (verbatim ssh-keyscan output). Alternative to host_key; a key matching either is accepted.",
+          "type": "string"
+        },
+        "allow_any_host_key": {
+          "description": "Explicitly skip host key verification. NOT recommended: allows man-in-the-middle attacks.",
+          "type": "boolean"
+        },
+        "proxy": {
+          "description": "Optional jump host (bastion) through which the SFTP server is reached, like OpenSSH's ProxyJump. Credentials come from the proxy-password / proxy-private-key / proxy-passphrase action inputs.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["host", "username"],
+          "properties": {
+            "host": {
+              "description": "Hostname or IP address of the jump host.",
+              "type": "string",
+              "minLength": 1
+            },
+            "port": {
+              "description": "SSH port of the jump host. Defaults to 22.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "username": {
+              "description": "Username for the jump host.",
+              "type": "string",
+              "minLength": 1
+            },
+            "host_key": {
+              "description": "SHA256 fingerprint(s) of the jump host's key, one per line. Host key verification applies to each hop independently.",
+              "type": "string"
+            },
+            "known_hosts": {
+              "description": "Jump host key(s) in known_hosts format; alternative to host_key.",
+              "type": "string"
+            },
+            "allow_any_host_key": {
+              "description": "Explicitly skip host key verification for the jump host hop. NOT recommended.",
+              "type": "boolean"
+            }
+          }
+        }
+      }
     },
-    "ignore": {
-      "description": "Global gitignore-style exclude patterns applied to every target.",
-      "type": "array",
-      "items": { "type": "string" }
+    "defaults": {
+      "description": "Defaults applied to every deployment unless overridden per deployment.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": { "$ref": "#/$defs/mode" },
+        "exclude": { "$ref": "#/$defs/exclude" }
+      }
     },
-    "guards": {
+    "deployments": {
+      "description": "Named deployments. Each name appears in logs and the job summary.",
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source", "target"],
+        "properties": {
+          "source": {
+            "description": "Local path (file or directory) to upload.",
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "description": "Remote destination path.",
+            "type": "string",
+            "minLength": 1
+          },
+          "mode": { "$ref": "#/$defs/mode" },
+          "exclude": {
+            "description": "Deployment-specific exclude patterns, additive to defaults.exclude.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "safety": {
       "description": "Safety limits applied before any deletion.",
       "type": "object",
       "additionalProperties": false,
@@ -32,42 +132,94 @@
         }
       }
     },
-    "targets": {
-      "description": "One or more local => remote deployment targets.",
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["local", "remote"],
-        "properties": {
-          "local": {
-            "description": "Local path (file or directory) to upload.",
-            "type": "string",
-            "minLength": 1
-          },
-          "remote": {
-            "description": "Remote destination path.",
-            "type": "string",
-            "minLength": 1
-          },
-          "strategy": {
-            "$ref": "#/$defs/strategy",
-            "description": "Overrides the top-level strategy for this target."
-          },
-          "ignore": {
-            "description": "Target-specific exclude patterns, additive to the global ones.",
-            "type": "array",
-            "items": { "type": "string" }
-          }
+    "advanced": {
+      "description": "Transfer tuning. The defaults suit most deployments.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "retries": {
+          "description": "Retries per file on transient errors, and the reconnect budget for dropped connections. Defaults to 2; 0 disables retries.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "timeout": {
+          "description": "Connection timeout in seconds. Defaults to 30; 0 disables the timeout.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "stall_timeout": {
+          "description": "Abort the run when active remote operations make no progress for this many seconds. Defaults to 0 (off).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "concurrency": {
+          "description": "Number of files uploaded in parallel, or \"auto\" for the built-in default.",
+          "$ref": "#/$defs/autoInt"
+        },
+        "request_concurrency": {
+          "description": "Maximum in-flight SFTP requests per file (pipelining within one file's transfer), or \"auto\" for the built-in default.",
+          "$ref": "#/$defs/autoInt"
+        },
+        "skip_unchanged": {
+          "description": "For overlay deployments, skip uploading a file when the remote file already exists with the same size (coarse; use mode sync for exact content comparison).",
+          "type": "boolean"
+        }
+      }
+    },
+    "permissions": {
+      "description": "Remote permission and timestamp handling. All best-effort: a server that rejects the request produces a warning, not a failure.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "files": {
+          "description": "Octal permission (e.g. \"0644\") applied to every uploaded file instead of mirroring the local mode bits.",
+          "type": "string",
+          "pattern": "^0?[0-7]{3}$"
+        },
+        "directories": {
+          "description": "Octal permission (e.g. \"0755\") applied to every remote directory the run creates or touches.",
+          "type": "string",
+          "pattern": "^0?[0-7]{3}$"
+        },
+        "preserve_times": {
+          "description": "Keep each uploaded file's local modification time on the server instead of \"now\".",
+          "type": "boolean"
+        }
+      }
+    },
+    "sync": {
+      "description": "Settings of the sync mode's manifest.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fast_path": {
+          "description": "Reuse a file's manifest hash instead of re-reading it when size and modification time still match (rsync-style quick check; can miss same-size same-second edits).",
+          "type": "boolean"
+        },
+        "manifest": {
+          "description": "File name of the manifest kept in each sync target (default \".easysftp-manifest.json\"). Must be a bare file name, no path.",
+          "type": "string",
+          "minLength": 1
         }
       }
     }
   },
   "$defs": {
-    "strategy": {
+    "mode": {
+      "description": "How the remote target is reconciled: overlay (upload only), sync (manifest-tracked mirror) or clean (wipe, then upload).",
       "type": "string",
       "enum": ["overlay", "sync", "clean"]
+    },
+    "exclude": {
+      "description": "Gitignore-style exclude patterns.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "autoInt": {
+      "oneOf": [
+        { "type": "integer", "minimum": 1 },
+        { "const": "auto" }
+      ]
     }
   }
 }

--- a/scripts/action-lib.sh
+++ b/scripts/action-lib.sh
@@ -10,13 +10,28 @@ easysftp_error() {
   return 1
 }
 
-validate_build_mode() {
-  case "${1:-}" in
-    prebuilt | source)
-      printf '%s\n' "$1"
+# detect_build_mode picks how to obtain the easySFTP binary from the action
+# ref alone (the build-mode input was removed in v3): a ref matching the
+# checkout's release version (tag or exact release commit) uses the verified
+# prebuilt release asset; every development ref (branches, other commit SHAs,
+# local "uses: ./") builds the checkout from source.
+detect_build_mode() {
+  local action_ref=$1
+  local version=$2
+  local release_commit=${3:-}
+  local major minor patch
+
+  IFS=. read -r major minor patch <<< "${version#v}"
+  case "$action_ref" in
+    "v$major" | "v$major.$minor" | "v$major.$minor.$patch")
+      printf 'prebuilt\n'
       ;;
     *)
-      easysftp_error "invalid build-mode '${1:-}'; supported values are 'prebuilt' and 'source'"
+      if [[ "$action_ref" =~ ^[0-9a-f]{40}$ ]] && [[ -n "$release_commit" ]] && [[ "$action_ref" == "$release_commit" ]]; then
+        printf 'prebuilt\n'
+      else
+        printf 'source\n'
+      fi
       ;;
   esac
 }
@@ -44,30 +59,6 @@ read_release_version() {
   fi
 
   printf '%s\n' "${lines[1]}"
-}
-
-validate_release_ref() {
-  local action_ref=$1
-  local version=$2
-  local release_commit=${3:-}
-  local major minor patch
-
-  IFS=. read -r major minor patch <<< "${version#v}"
-  case "$action_ref" in
-    "v$major" | "v$major.$minor" | "v$major.$minor.$patch")
-      ;;
-    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
-      if [[ ! "$action_ref" =~ ^[0-9a-f]{40}$ ]] || [[ "$action_ref" != "$release_commit" ]]; then
-        easysftp_error "commit ref '$action_ref' does not match the published $version release commit. Use build-mode: source"
-      fi
-      ;;
-    v[0-9]*)
-      easysftp_error "action ref '$action_ref' does not match version '$version' from .easysftp-version"
-      ;;
-    *)
-      easysftp_error "prebuilt mode requires a release tag ref (@vX, @vX.Y, or @vX.Y.Z) or its matching full commit SHA; '$action_ref' is a development ref. Use build-mode: source"
-      ;;
-  esac
 }
 
 resolve_release_commit() {

--- a/scripts/prepare-action.sh
+++ b/scripts/prepare-action.sh
@@ -6,7 +6,10 @@ script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 # shellcheck source=scripts/action-lib.sh
 source "$script_dir/action-lib.sh"
 
-mode=$(validate_build_mode "${INPUT_BUILD_MODE:-}")
+if [[ -n "${INPUT_BUILD_MODE:-}" ]]; then
+  easysftp_error "the 'build-mode' input was removed in easySFTP v3; the build mode is now selected automatically from the action ref. See docs/migration-v3.md"
+fi
+
 action_path=${ACTION_PATH:?ACTION_PATH is required}
 action_path=${action_path//\\//}
 while [[ "$action_path" == *'/./'* ]]; do
@@ -26,13 +29,17 @@ else
   binary="$work_dir/easysftp"
 fi
 
+version=$(read_release_version "$action_path/.easysftp-version")
+release_commit=''
+if [[ "${ACTION_REF:-}" =~ ^[0-9a-f]{40}$ ]]; then
+  # Best effort: an unresolvable release commit (network hiccup, unpublished
+  # tag) falls back to a source build of this exact checkout instead of
+  # failing the run or substituting a stale release binary.
+  release_commit=$(resolve_release_commit "$version" 2>/dev/null || true)
+fi
+mode=$(detect_build_mode "${ACTION_REF:-}" "$version" "$release_commit")
+
 if [[ "$mode" == 'prebuilt' ]]; then
-  version=$(read_release_version "$action_path/.easysftp-version")
-  release_commit=''
-  if [[ "${ACTION_REF:-}" =~ ^[0-9a-f]{40}$ ]]; then
-    release_commit=$(resolve_release_commit "$version")
-  fi
-  validate_release_ref "${ACTION_REF:-}" "$version" "$release_commit"
   asset=$(resolve_release_asset "${RUNNER_OS:-}" "${RUNNER_ARCH:-}")
   checksums="$work_dir/checksums.txt"
 
@@ -41,6 +48,8 @@ if [[ "$mode" == 'prebuilt' ]]; then
   verify_release_checksum "$binary" "$checksums" "$asset"
   chmod +x "$binary"
   echo "Using verified easySFTP $version release asset $asset"
+else
+  echo "Ref '${ACTION_REF:-<local>}' is not the $version release; building easySFTP from source"
 fi
 
 {

--- a/scripts/test-action.sh
+++ b/scripts/test-action.sh
@@ -29,9 +29,16 @@ expect_equal() {
   fi
 }
 
-expect_equal 'prebuilt mode' 'prebuilt' "$(validate_build_mode prebuilt)"
-expect_equal 'source mode' 'source' "$(validate_build_mode source)"
-expect_failure 'invalid build mode' validate_build_mode archive
+expect_equal 'major tag detects prebuilt' 'prebuilt' "$(detect_build_mode v1 v1.2.3)"
+expect_equal 'minor tag detects prebuilt' 'prebuilt' "$(detect_build_mode v1.2 v1.2.3)"
+expect_equal 'exact tag detects prebuilt' 'prebuilt' "$(detect_build_mode v1.2.3 v1.2.3)"
+expect_equal 'branch ref detects source' 'source' "$(detect_build_mode main v1.2.3)"
+expect_equal 'empty ref detects source' 'source' "$(detect_build_mode '' v1.2.3)"
+expect_equal 'mismatched tag detects source' 'source' "$(detect_build_mode v2 v1.2.3)"
+release_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+expect_equal 'release commit detects prebuilt' 'prebuilt' "$(detect_build_mode "$release_sha" v1.2.3 "$release_sha")"
+expect_equal 'other commit detects source' 'source' "$(detect_build_mode bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb v1.2.3 "$release_sha")"
+expect_equal 'commit without resolved release detects source' 'source' "$(detect_build_mode "$release_sha" v1.2.3 '')"
 
 expect_equal 'Linux x64 mapping' 'easysftp_linux_x64' "$(resolve_release_asset Linux X64)"
 expect_equal 'Linux arm64 mapping' 'easysftp_linux_arm64' "$(resolve_release_asset Linux ARM64)"
@@ -100,7 +107,6 @@ chmod +x "$tmp/bin/git"
 output_file="$tmp/prebuilt-output"
 PATH="$tmp/bin:$PATH" \
 MOCK_ASSET_DIR="$tmp/assets" \
-INPUT_BUILD_MODE=prebuilt \
 ACTION_PATH="$tmp/action" \
 ACTION_REF="$release_version" \
 RUNNER_OS=Linux \
@@ -123,7 +129,6 @@ if [[ "${RUNNER_OS:-}" == 'Windows' ]] && command -v cygpath >/dev/null 2>&1; th
   source_github_output=$(cygpath -w "$source_github_output")
   source_runner_os=Windows
 fi
-INPUT_BUILD_MODE=source \
 ACTION_PATH="$source_action_path" \
 ACTION_REF=main \
 RUNNER_OS="$source_runner_os" \
@@ -133,14 +138,21 @@ GITHUB_OUTPUT="$source_github_output" \
   bash "$repo_root/scripts/prepare-action.sh"
 expect_equal 'source preparation' 'source' "$(sed -n 's/^build-mode=//p' "$source_output")"
 
+# The build-mode input became a tombstone in v3: setting it must fail with a
+# migration hint instead of being honored or ignored.
+expect_failure 'removed build-mode input' env \
+  INPUT_BUILD_MODE=source \
+  ACTION_PATH="$source_action_path" \
+  ACTION_REF=main \
+  RUNNER_OS="$source_runner_os" \
+  RUNNER_ARCH=X64 \
+  RUNNER_TEMP="$source_runner_temp" \
+  GITHUB_OUTPUT="$tmp/tombstone-output" \
+  bash "$repo_root/scripts/prepare-action.sh"
+
 printf '%s\n' '# x-release-please-start-version' '1.2.3' '# x-release-please-end' > "$tmp/bad-version"
 expect_failure 'invalid version file' read_release_version "$tmp/bad-version"
-expect_failure 'development ref in prebuilt mode' validate_release_ref main v1.2.3
-expect_failure 'mismatched rolling tag' validate_release_ref v2 v1.2.3
-release_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 expect_equal 'annotated release commit resolution' "$release_sha" "$(PATH="$tmp/bin:$PATH" resolve_release_commit v1.2.3)"
-expect_equal 'matching release commit ref' '' "$(validate_release_ref "$release_sha" v1.2.3 "$release_sha")"
-expect_failure 'unpublished commit ref' validate_release_ref bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb v1.2.3 "$release_sha"
 
 : > "$tmp/missing-checksum"
 expect_failure 'missing checksum entry' verify_release_checksum "$tmp/assets/easysftp_linux_x64" "$tmp/missing-checksum" 'easysftp_linux_x64'

--- a/site/assets/docs.js
+++ b/site/assets/docs.js
@@ -17,6 +17,7 @@ var PAGES = [
   { id: "security", title: "security", group: "guide", dir: "docs/" },
   { id: "troubleshooting", title: "troubleshooting", group: "guide", dir: "docs/" },
   { id: "contributing", title: "contributing", group: "project", dir: "" },
+  { id: "migration-v3", title: "migrating v2 => v3", group: "project", dir: "docs/" },
   { id: "migrating-v1-to-v2", title: "migrating v1 => v2", group: "project", dir: "docs/" }
 ];
 


### PR DESCRIPTION
Closes #123.

Reworks easySFTP's configuration around one product rule, from the issue:

> Inline configuration for an ordinary deployment. One config file for
> everything complex. GitHub Secrets only for secret values. No mixed mode.

## The two v3 modes

**Inline mode** for the common single-target deploy, small and self-explanatory:

```yaml
- uses: eiserv/easySFTP@v3
  with:
    host: sftp.example.com
    username: ${{ secrets.SFTP_USERNAME }}
    password: ${{ secrets.SFTP_PASSWORD }}
    host-key: ${{ secrets.SFTP_HOST_KEY }}
    source: dist
    target: /var/www/html
```

**Config mode** for everything complex: `config: <file>` holds every non-secret
setting (connection, named deployments, safety, advanced tuning) in one
version-3 YAML file. Only credentials, `dry-run` and `log-level` combine with it.

```yaml
- uses: eiserv/easySFTP@v3
  with:
    config: .github/easysftp.yml
    private-key: ${{ secrets.SFTP_PRIVATE_KEY }}
```

Setting any inline connection/deployment input alongside `config` fails the run:
no mixed mode, one source of truth per setting, no precedence table.

## What changed

- **Renamed inputs:** `server`→`host`, `uploads`→`source`+`target`,
  `strategy`→`mode`, `ignore`→`exclude`, `host-key-fingerprint`→`host-key`,
  `config-file`→`config`.
- **Advanced knobs moved into the config file** (`advanced.*`, `permissions.*`,
  `sync.*`, `safety.max_deletes`), out of the prominent action surface.
- **Proxy/bastion connection moved into the config file** (`connection.proxy`);
  only proxy credentials remain inputs.
- **Named deployments** replace the anonymous target list; the name shows up in
  logs and the job summary ("Deployment \"documentation\" failed").
- **Host key verification is now required** (issue's explicit-opt-in request):
  a run without `host-key`/`known-hosts` fails unless `allow-any-host-key: true`
  is set explicitly. The opt-in still warns every run. v2 silently
  warned-and-connected.
- **`build-mode` removed:** build mode is detected automatically from the action
  ref (release tags/exact release commit → verified prebuilt binary; dev refs →
  source build).
- **Compact default logging:** connection status, one summary per deployment,
  host-key status and config source in the job summary. Per-file lines →
  `log-level: verbose`; exclude decisions → `log-level: debug`.
- **Strict validation:** unknown config keys fail with a location and a
  "did you mean" suggestion; `version: 1` files and removed inputs fail with
  migration hints instead of silent no-ops.
- **Docs:** README leads with Quick Start and notes advanced use stays supported
  via the config file; configuration/strategies/examples/security/troubleshooting
  updated; new `docs/migration-v3.md`; JSON Schema and commented example config
  rewritten to version 3.

## Decisions made where the issue left them open

- **Opt-in name:** `allow-any-host-key` (config: `connection.allow_any_host_key`).
- **Default delete limit:** kept **unlimited** (`safety.max_deletes: 0`), matching
  v2; the always-on remote-root refusal stays. The issue floated a finite
  default but left it as "consider"; changing it is easy to add later and hard
  to walk back, so this PR keeps today's behavior and lets users opt into a limit.
- **`log-level`** stays an action input (valid in both modes, like `dry-run`), so
  verbosity can be raised without editing the config file. New levels:
  `normal` (default) / `verbose` / `debug`.

## Testing

- `go test ./...` green (config, uploader, actionmeta, cmd, gha).
- `bash scripts/test-action.sh` green (auto build-mode detection, tombstone
  rejection).
- New tests cover inline mode, config mode, mixed-mode rejection, migration-hint
  errors, unknown-key suggestions, the host-key opt-in (primary and proxy hop),
  and the compact/verbose/debug logging split.
- CI self-test rewritten to v3 inputs plus new cases: missing-host-key rejection,
  the `allow-any-host-key` opt-in, and a removed v2 input failing loudly.
- `go test -race` was **not** run locally (`-race requires cgo`, no C toolchain on
  this machine, per CLAUDE.md); CI runs the race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)