### PR TITLE
docs: bump actions/checkout to v7 in examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,7 +28,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - run: npm ci && npm run build
 
       - name: Deploy via SFTP
@@ -186,7 +186,7 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - run: npm ci && npm run build
 
       - name: What would deploy?
@@ -263,7 +263,7 @@ jobs:
   deploy:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: eiserv/easySFTP@v3
         with:
           host: sftp.example.com


### PR DESCRIPTION
## Summary
Fixes #110.

Of the three drift items in the issue, only the first is still current; the v3 configuration model rewrite (#124) already resolved the other two:

1. **checkout@v5 in examples (fixed here):** bumped the three `actions/checkout@v5` snippets in `docs/examples.md` to `@v7`, matching the v7.0.0 pin used by this repo's own workflows.
2. **`max-deletes` missing from troubleshooting's mutual-exclusion list (stale):** that passage no longer exists; troubleshooting now documents the v3 error `when 'config' is set, all non-secret settings come from the config file`, which matches `internal/config/config.go`.
3. **Duplicated `²` footnote in `docs/configuration.md` (stale):** the current doc defines `²` once (host-key verification) and uses `³` for the config-file table; no duplicate markers remain.