### PR TITLE
fix: scope SETSTAT warn-once messages to the deployment, not the run

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,7 +216,8 @@ sync:
 | `preserve_times` | `false` | Keep each uploaded file's local modification time on the server. |
 
 All three are best-effort: a server that rejects the `SETSTAT` request
-produces one warning per run, not a failure.
+produces one warning per deployment (not one per file, and not a failure), so
+a multi-deployment run shows which deployments are affected.
 
 #### `sync`
 

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -34,7 +34,9 @@ func createRemoteDirs(client *sftp.Client, dirs []string, dirMode *fs.FileMode, 
 		warned := false
 		for _, dir := range dirs {
 			if err := client.Chmod(dir, dirMode.Perm()); err != nil && !warned {
-				log.Warningf("could not set dir-mode %04o on %s (server may reject SETSTAT); not warning again this run: %v", dirMode.Perm(), dir, err)
+				// Scoped to this pass (one per deployment), like the file-mode
+				// and preserve-times warnings in transfer.go; see issue #121.
+				log.Warningf("could not set dir-mode %04o on %s (server may reject SETSTAT); not warning again for this deployment: %v", dirMode.Perm(), dir, err)
 				warned = true
 			}
 			watch.tick()

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -21,12 +21,18 @@ import (
 // rename stays on one filesystem and is atomic.
 const tmpSuffix = ".easysftp-tmp"
 
-// transferEnv carries the run-wide invariants that every level of the upload
-// call chain re-threads to the next (the session, the stall watchdog, the
-// logger and the two warn-once flags). It is built once in uploadFiles and
-// passed down, so per-file positions stay short and, in particular, the two
-// adjacent *atomic.Bool flags can no longer be transposed at a call site: they
-// are named struct fields instead of interchangeable positional arguments.
+// transferEnv carries the invariants that every level of the upload call chain
+// re-threads to the next (the session, the stall watchdog, the logger and the
+// two warn-once flags). It is built once in uploadFiles and passed down, so
+// per-file positions stay short and, in particular, the two adjacent
+// *atomic.Bool flags can no longer be transposed at a call site: they are
+// named struct fields instead of interchangeable positional arguments.
+//
+// uploadFiles runs once per deployment, so the two warn-once flags are scoped
+// to a deployment, not to the whole run: a multi-deployment run against a
+// server that rejects SETSTAT warns once per affected deployment, which is
+// what tells the user how far the problem reaches. The warning texts say so
+// (see issue #121).
 type transferEnv struct {
 	cfg   *config.Config
 	sess  *session
@@ -78,7 +84,8 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 	}
 	// timesWarned doubles as the preserve-times switch: nil means off. The
 	// user explicitly asked for preserved times, so a refusing server warns
-	// (once per run); staying silent would defeat the point of the input.
+	// (once per deployment); staying silent would defeat the point of the
+	// input.
 	if cfg.PreserveTimes {
 		env.timesWarned = new(atomic.Bool)
 	}
@@ -181,10 +188,10 @@ func uploadFile(ctx context.Context, env *transferEnv, f fileItem, index int, mo
 
 	// Best effort: mirrors the local permission bits, or the file-mode
 	// override when set. Some servers reject SETSTAT; an explicit override
-	// warns once per run so the user knows it isn't taking effect, but a
-	// mirrored local mode stays silent as before.
+	// warns once per deployment so the user knows it isn't taking effect, but
+	// a mirrored local mode stays silent as before.
 	if cerr := client.Chmod(tmpPath, mode); cerr != nil && env.modeWarned != nil && !env.modeWarned.Swap(true) {
-		log.Warningf("could not set file-mode %04o on %s (server may reject SETSTAT); not warning again this run: %v", mode, f.remotePath, cerr)
+		log.Warningf("could not set file-mode %04o on %s (server may reject SETSTAT); not warning again for this deployment: %v", mode, f.remotePath, cerr)
 	}
 
 	if err := renameReplace(client, tmpPath, f.remotePath); err != nil {
@@ -194,11 +201,11 @@ func uploadFile(ctx context.Context, env *transferEnv, f fileItem, index int, mo
 
 	// preserve-times (timesWarned non-nil): keep the local modification time
 	// instead of "now". After the rename, so the request targets the final
-	// path; a failure warns once per run and never fails the deploy.
+	// path; a failure warns once per deployment and never fails the deploy.
 	if env.timesWarned != nil {
 		mtime := time.Unix(f.mtime, 0)
 		if cerr := client.Chtimes(f.remotePath, mtime, mtime); cerr != nil && !env.timesWarned.Swap(true) {
-			log.Warningf("could not preserve the modification time on %s (server may reject SETSTAT); not warning again this run: %v", f.remotePath, cerr)
+			log.Warningf("could not preserve the modification time on %s (server may reject SETSTAT); not warning again for this deployment: %v", f.remotePath, cerr)
 		}
 	}
 	return n, nil

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -632,6 +632,53 @@ func TestFileModeFailureWarnsOnceNotPerFile(t *testing.T) {
 	}
 }
 
+// The two SETSTAT warn-once flags live in transferEnv, which is built per
+// deployment, so a multi-deployment run warns once per affected deployment and
+// the message says so instead of promising run-wide suppression (issue #121).
+func TestSetstatWarningsAreScopedPerDeployment(t *testing.T) {
+	srv := startTestServer(t, withFailSetstat())
+	first, second := t.TempDir(), t.TempDir()
+	writeTree(t, first, map[string]string{"a.txt": "1", "b.txt": "2"})
+	writeTree(t, second, map[string]string{"c.txt": "3", "d.txt": "4"})
+
+	mode := fs.FileMode(0o600)
+	cfg := baseConfig(srv)
+	cfg.FileMode = &mode
+	cfg.PreserveTimes = true
+	cfg.Uploads = []config.UploadPair{
+		{Name: "one", Local: first, Remote: "/www/one"},
+		{Name: "two", Local: second, Remote: "/www/two"},
+	}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatalf("rejected SETSTAT requests must not fail the run: %v", err)
+	}
+
+	log.mu.Lock()
+	defer log.mu.Unlock()
+	counts := map[string]int{}
+	for _, w := range log.warnings {
+		switch {
+		case strings.Contains(w, "file-mode"):
+			counts["file-mode"]++
+		case strings.Contains(w, "preserve the modification time"):
+			counts["preserve-times"]++
+		default:
+			continue
+		}
+		if !strings.Contains(w, "not warning again for this deployment") {
+			t.Errorf("warning must scope its suppression promise to the deployment, got: %s", w)
+		}
+	}
+	for _, kind := range []string{"file-mode", "preserve-times"} {
+		if counts[kind] != len(cfg.Uploads) {
+			t.Errorf("expected %d %s warning(s) (one per deployment), got %d: %v",
+				len(cfg.Uploads), kind, counts[kind], log.warnings)
+		}
+	}
+}
+
 func TestDefaultModeMirrorsLocalBitsSilentlyOnFailure(t *testing.T) {
 	srv := startTestServer(t, withFailSetstat())
 	local := t.TempDir()


### PR DESCRIPTION
Closes #121.

## Decision

The issue left the choice open between (1) rewording the messages and (2) hoisting the warn-once flags to run scope. This PR takes **option 1**, for the reason the issue itself hints at: per-deployment visibility is information, not noise. A run against a server that rejects `SETSTAT` for `/www/a` but accepts it for `/www/b` should say so, and the surrounding log group already names the deployment. It is also the smaller change, so nothing has to be threaded through `Run` and `executePlan`.

## What changed

- `internal/uploader/transfer.go`: both messages now say `not warning again for this deployment`; the `transferEnv` doc comment states the scope explicitly instead of calling the flags "run-wide".
- `internal/uploader/remote.go`: the **dir-mode** warning had the identical overstatement (`warned` is local to one `createRemoteDirs` pass, i.e. one per deployment). Issue #121 did not name it, but it is the same root cause, so it is corrected in the same pass rather than left as a third message contradicting the other two.
- `docs/configuration.md`: the `permissions` section said "one warning per run"; now "one warning per deployment (not one per file, and not a failure)".
- New test `TestSetstatWarningsAreScopedPerDeployment`: two deployments against a server that rejects every `SETSTAT`, asserting exactly one file-mode and one preserve-times warning **per deployment** and that each carries the per-deployment wording. It fails if someone later hoists the flags to run scope without also fixing the text.

No behavior change beyond log wording; all three operations stay best-effort and never fail a deploy.

## Testing

- `go test ./...` green, `gofmt -l .` clean, `go vet ./...` clean.
- `go test -race ./...` could not run locally (no C toolchain: `-race requires cgo`); relying on the CI race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)