### PR TITLE
feat: human-readable sizes in the job summary and final log line

### DIFF
--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -59,8 +60,8 @@ func run() error {
 		mode = "would upload (dry-run)"
 	}
 	if runErr == nil {
-		gha.Infof("done: %s %d file(s), %d byte(s), deleted %d file(s), skipped %d unchanged, took %s",
-			mode, stats.FilesUploaded, stats.BytesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.Duration.Round(time.Millisecond))
+		gha.Infof("done: %s %d file(s), %s, deleted %d file(s), skipped %d unchanged, took %s",
+			mode, stats.FilesUploaded, humanBytes(stats.BytesUploaded), stats.FilesDeleted, stats.FilesSkipped, stats.Duration.Round(time.Millisecond))
 	}
 
 	reportStats(cfg, stats, mode, runErr)
@@ -120,10 +121,34 @@ func buildInfoLine(info *debug.BuildInfo, version string) string {
 	return ""
 }
 
+// humanBytes renders a byte count readably without losing the exact figure,
+// e.g. "70.0 MiB (73,400,320 bytes)". Job summaries get copy-pasted into
+// reports, so the precise number stays available (issue #16). Below one KiB
+// the raw count is already readable and stands alone.
+func humanBytes(n int64) string {
+	if n < 1024 {
+		return uploader.HumanSize(n)
+	}
+	return fmt.Sprintf("%s (%s bytes)", uploader.HumanSize(n), groupDigits(n))
+}
+
+// groupDigits inserts thousands separators: 73400320 -> "73,400,320".
+func groupDigits(n int64) string {
+	s := strconv.FormatInt(n, 10)
+	var b strings.Builder
+	for i := range len(s) {
+		if i > 0 && (len(s)-i)%3 == 0 && s[i-1] != '-' {
+			b.WriteByte(',')
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
 func reportStats(cfg *config.Config, stats *uploader.Stats, mode string, runErr error) {
 	status := "✅ Succeeded"
 	if runErr != nil {
-		status = fmt.Sprintf("❌ Failed after %d file(s), %d byte(s)", stats.FilesUploaded, stats.BytesUploaded)
+		status = fmt.Sprintf("❌ Failed after %d file(s), %s", stats.FilesUploaded, humanBytes(stats.BytesUploaded))
 	}
 
 	gha.SetOutput("files-uploaded", fmt.Sprintf("%d", stats.FilesUploaded))
@@ -137,8 +162,8 @@ func reportStats(cfg *config.Config, stats *uploader.Stats, mode string, runErr 
 		configSource = fmt.Sprintf("`%s` (version 3)", cfg.ConfigPath)
 	}
 	summary := fmt.Sprintf(
-		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Host key | %s |\n| Configuration | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %d |\n| Duration | %s |\n",
-		status, hostKeyStatus(cfg), configSource, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, stats.BytesUploaded, stats.Duration.Round(time.Millisecond))
+		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Host key | %s |\n| Configuration | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %s |\n| Duration | %s |\n",
+		status, hostKeyStatus(cfg), configSource, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, humanBytes(stats.BytesUploaded), stats.Duration.Round(time.Millisecond))
 	summary += deploymentBreakdown(stats.Targets)
 	gha.AppendSummary(summary)
 }
@@ -151,7 +176,10 @@ func deploymentBreakdown(targets []uploader.TargetStats) string {
 	}
 
 	var b strings.Builder
-	b.WriteString("\n#### Deployments\n\n| Deployment | Source | Target | Mode | Uploaded | Deleted | Skipped | Bytes | Duration |\n|---|---|---|---|---|---|---|---|---|\n")
+	// The per-deployment rows use the compact size only: the exact byte count
+	// belongs in the totals above, and repeating it in every row would make
+	// the table unreadably wide.
+	b.WriteString("\n#### Deployments\n\n| Deployment | Source | Target | Mode | Uploaded | Deleted | Skipped | Size | Duration |\n|---|---|---|---|---|---|---|---|---|\n")
 
 	var totalUploaded, totalDeleted, totalSkipped int
 	var totalBytes int64
@@ -160,17 +188,17 @@ func deploymentBreakdown(targets []uploader.TargetStats) string {
 		if name == "" {
 			name = "(inline)"
 		}
-		fmt.Fprintf(&b, "| %s | `%s` | `%s` | %s | %d | %d | %d | %d | %s |\n",
-			name, t.Local, t.Remote, t.Strategy, t.FilesUploaded, t.FilesDeleted, t.FilesSkipped, t.BytesUploaded,
-			t.Duration.Round(time.Millisecond))
+		fmt.Fprintf(&b, "| %s | `%s` | `%s` | %s | %d | %d | %d | %s | %s |\n",
+			name, t.Local, t.Remote, t.Strategy, t.FilesUploaded, t.FilesDeleted, t.FilesSkipped,
+			uploader.HumanSize(t.BytesUploaded), t.Duration.Round(time.Millisecond))
 		totalUploaded += t.FilesUploaded
 		totalDeleted += t.FilesDeleted
 		totalSkipped += t.FilesSkipped
 		totalBytes += t.BytesUploaded
 	}
 	if len(targets) > 1 {
-		fmt.Fprintf(&b, "| **Total** | | | | **%d** | **%d** | **%d** | **%d** | |\n",
-			totalUploaded, totalDeleted, totalSkipped, totalBytes)
+		fmt.Fprintf(&b, "| **Total** | | | | **%d** | **%d** | **%d** | **%s** | |\n",
+			totalUploaded, totalDeleted, totalSkipped, uploader.HumanSize(totalBytes))
 	}
 	return b.String()
 }

--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -91,6 +91,27 @@ func TestBuildInfoLine(t *testing.T) {
 	}
 }
 
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{n: 0, want: "0 B"},
+		{n: 999, want: "999 B"},
+		{n: 1023, want: "1023 B"},
+		{n: 1024, want: "1.0 KiB (1,024 bytes)"},
+		{n: 2048, want: "2.0 KiB (2,048 bytes)"},
+		{n: 73_400_320, want: "70.0 MiB (73,400,320 bytes)"},
+		{n: 1_099_511_627_776, want: "1.0 TiB (1,099,511,627,776 bytes)"},
+	}
+
+	for _, tt := range tests {
+		if got := humanBytes(tt.n); got != tt.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
 func TestReportStatsOnFailure(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "output")
 	summaryPath := filepath.Join(t.TempDir(), "summary")
@@ -129,13 +150,13 @@ func TestReportStatsOnFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, want := range []string{
-		"| Status | ❌ Failed after 3 file(s), 2048 byte(s) |",
+		"| Status | ❌ Failed after 3 file(s), 2.0 KiB (2,048 bytes) |",
 		"| Host key | ✅ pinned |",
 		"| Configuration | inline inputs |",
 		"| Files uploaded | 3 |",
 		"| Files deleted | 1 |",
 		"| Files skipped (unchanged) | 4 |",
-		"| Bytes transferred | 2048 |",
+		"| Bytes transferred | 2.0 KiB (2,048 bytes) |",
 	} {
 		if !strings.Contains(string(summary), want) {
 			t.Errorf("summary does not contain %q:\n%s", want, summary)
@@ -169,10 +190,10 @@ func TestReportStatsMultiTargetBreakdown(t *testing.T) {
 	for _, want := range []string{
 		"| Configuration | `.github/easysftp.yml` (version 3) |",
 		"#### Deployments",
-		"| Deployment | Source | Target | Mode | Uploaded | Deleted | Skipped | Bytes | Duration |",
-		"| website | `./dist/` | `/var/www/html/` | sync | 12 | 3 | 1988 | 4297523 | 1s |",
-		"| documentation | `./docs/` | `/var/www/docs/` | clean | 240 | 214 | 0 | 13528269 | 2s |",
-		"| **Total** | | | | **252** | **217** | **1988** | **17825792** | |",
+		"| Deployment | Source | Target | Mode | Uploaded | Deleted | Skipped | Size | Duration |",
+		"| website | `./dist/` | `/var/www/html/` | sync | 12 | 3 | 1988 | 4.1 MiB | 1s |",
+		"| documentation | `./docs/` | `/var/www/docs/` | clean | 240 | 214 | 0 | 12.9 MiB | 2s |",
+		"| **Total** | | | | **252** | **217** | **1988** | **17.0 MiB** | |",
 	} {
 		if !strings.Contains(string(summary), want) {
 			t.Errorf("summary does not contain %q:\n%s", want, summary)
@@ -218,7 +239,7 @@ func TestReportStatsSingleNamedDeploymentGetsBreakdown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(summary), "| website | `./dist/` | `/www/` | sync | 3 | 0 | 0 | 2048 | 0s |") {
+	if !strings.Contains(string(summary), "| website | `./dist/` | `/www/` | sync | 3 | 0 | 0 | 2.0 KiB | 0s |") {
 		t.Errorf("expected the named deployment row in the summary:\n%s", summary)
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,7 +305,9 @@ reporting or rollback step must consume these partial results. See
 [examples](examples.md#using-the-outputs).
 
 The `files-*`/`bytes-uploaded` outputs stay run-wide totals; there is no
-per-deployment output.
+per-deployment output. Sizes are rendered for humans in the summary and the
+log (`70.0 MiB (73,400,320 bytes)`, and just `70.0 MiB` in the per-deployment
+table); the `bytes-uploaded` output stays a plain integer for machines.
 
 ## Complete input reference
 

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -108,7 +108,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 				}
 			}
 			if cfg.LogPerFile() {
-				log.Infof("%supload %s => %s (%s)", verb, f.localPath, f.remotePath, humanSize(f.size))
+				log.Infof("%supload %s => %s (%s)", verb, f.localPath, f.remotePath, HumanSize(f.size))
 			}
 			if cfg.DryRun {
 				// Report the planned byte count so bytes-uploaded matches the

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -151,11 +151,11 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 func logDeploymentSummary(cfg *config.Config, pair config.UploadPair, ts TargetStats, log Logger) {
 	if cfg.DryRun {
 		log.Infof("deployment %s: %d file(s) to upload (%s), %d to delete, %d unchanged (dry-run)",
-			pair.Label(), ts.FilesUploaded, humanSize(ts.BytesUploaded), ts.FilesDeleted, ts.FilesSkipped)
+			pair.Label(), ts.FilesUploaded, HumanSize(ts.BytesUploaded), ts.FilesDeleted, ts.FilesSkipped)
 		return
 	}
 	log.Infof("deployment %s: uploaded %d file(s) (%s), deleted %d, skipped %d unchanged, took %s",
-		pair.Label(), ts.FilesUploaded, humanSize(ts.BytesUploaded), ts.FilesDeleted, ts.FilesSkipped,
+		pair.Label(), ts.FilesUploaded, HumanSize(ts.BytesUploaded), ts.FilesDeleted, ts.FilesSkipped,
 		ts.Duration.Round(time.Millisecond))
 }
 
@@ -248,7 +248,10 @@ func planVerb(cfg *config.Config) string {
 	return ""
 }
 
-func humanSize(n int64) string {
+// HumanSize renders a byte count in IEC units, e.g. "70.0 MiB". Exported so
+// the job summary in cmd/easysftp formats sizes exactly like the per-file log
+// lines do (issue #16).
+func HumanSize(n int64) string {
 	const unit = 1024
 	if n < unit {
 		return fmt.Sprintf("%d B", n)


### PR DESCRIPTION
Closes #16.

## What changed

`humanSize` in `internal/uploader` is now exported as `uploader.HumanSize` (that is where it is already used for the per-file lines, and `cmd/easysftp` already imports the package, so no new shared package is needed). Every size a human reads now goes through it:

| Place | Before | After |
|---|---|---|
| Summary total | `| Bytes transferred | 73400320 |` | `| Bytes transferred | 70.0 MiB (73,400,320 bytes) |` |
| Final `done:` log line | `73400320 byte(s)` | `70.0 MiB (73,400,320 bytes)` |
| Failure status | `❌ Failed after 3 file(s), 2048 byte(s)` | `❌ Failed after 3 file(s), 2.0 KiB (2,048 bytes)` |
| Per-deployment table | `| … | 4297523 | 1s |` | `| … | 4.1 MiB | 1s |` |

Two judgment calls:

- **The exact count stays**, in parentheses, on the run totals and the `done:` line, as the issue asks: summaries get pasted into reports and tickets.
- **The per-deployment table shows the compact size only**, and its column header changes `Bytes` -> `Size`. Repeating `(73,400,320 bytes)` in every row of a nine-column table makes it unreadably wide, and the exact total is right above it. Below 1 KiB nothing is parenthesized either (`512 B` is already exact).

The `bytes-uploaded` and `duration-ms` **outputs are untouched** (raw integers, machine-readable contract), as required by the acceptance criteria. Duration already rendered as `2m13.4s`, so it needed no change.

## Testing

- New `TestHumanBytes` unit test (0, sub-KiB boundary, KiB, MiB, TiB, separator placement); existing summary tests updated to the new rendering.
- `go test ./...` green, `gofmt -l .` clean, `go vet ./...` clean.
- `go test -race ./...` could not run locally (no C toolchain: `-race requires cgo`); relying on the CI race pass.

`docs/configuration.md` states the split: rendered sizes in summary/log, raw integer in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)