### PR TITLE
chore: drop dead gha.Noticef and move the test-only manifestName const

### DIFF
--- a/internal/gha/gha.go
+++ b/internal/gha/gha.go
@@ -31,11 +31,6 @@ func Infof(format string, args ...any) {
 	fmt.Println(sanitizeLine(fmt.Sprintf(format, args...)))
 }
 
-// Noticef prints a notice annotation.
-func Noticef(format string, args ...any) {
-	fmt.Printf("::notice::%s\n", escapeData(fmt.Sprintf(format, args...)))
-}
-
 // Warningf prints a warning annotation.
 func Warningf(format string, args ...any) {
 	fmt.Printf("::warning::%s\n", escapeData(fmt.Sprintf(format, args...)))

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -17,12 +17,6 @@ import (
 	"github.com/eiserv/easySFTP/internal/config"
 )
 
-// manifestName is the default file name the sync strategy keeps in each remote
-// target to record what it previously uploaded. Only files listed there are
-// ever deleted, so files placed on the server by others are left untouched.
-// The manifest-name input can override it per run; see Config.SyncManifestName.
-const manifestName = config.DefaultManifestName
-
 // manifestVersion is written to every manifest this version of easySFTP
 // produces. v1 manifests (hash only, no size/mtime) are still read; see
 // readManifest.

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -16,6 +16,12 @@ import (
 	"github.com/eiserv/easySFTP/internal/config"
 )
 
+// manifestName is the default manifest file name, the one a test config that
+// does not set manifest-name ends up using. Production code never reads a
+// constant for this: it goes through cfg.SyncManifestName(), which honors the
+// manifest-name input (issue #108).
+const manifestName = config.DefaultManifestName
+
 func syncConfig(srv *testServer, local string) *config.Config {
 	cfg := baseConfig(srv)
 	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategySync}}


### PR DESCRIPTION
Closes #108.

Both leftovers from the issue, no behavior change:

1. **`gha.Noticef` deleted** (`internal/gha/gha.go`). No callers anywhere, production or test. `escapeData` stays in use by `Warningf`/`Errorf`/`Group`. If a notice annotation is ever wanted, re-adding it is three lines next to its callsite.
2. **`manifestName` moved to `sync_test.go`** (`internal/uploader`). Production code has gone through `cfg.SyncManifestName()` since the `manifest-name` input landed, so the constant only served tests that build a config without that input. Its doc comment is gone too: it restated what `config.DefaultManifestName` already documents, and a second copy is a second thing to keep true. The test-side comment now says why the constant exists at all.

## Testing

- `go test ./...` green, `gofmt -l .` clean, `go vet ./...` clean.
- `go test -race ./...` could not run locally (no C toolchain: `-race requires cgo`); relying on the CI race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)