### PR TITLE
ci: pin the atmoz/sftp self-test image by digest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Start SFTP server
+        # Pinned by digest, like every action in this repo: a mutable tag lets
+        # a retag (compromised or merely broken) flow straight into CI, and
+        # makes the self-test fail without a change here. Dependabot does not
+        # update inline "docker run" digests, so this is updated by hand with:
+        #   docker buildx imagetools inspect atmoz/sftp:alpine
         run: |
-          docker run -d --name sftp -p 2222:22 atmoz/sftp:alpine demo:demopass:::upload
+          docker run -d --name sftp -p 2222:22 atmoz/sftp@sha256:a6cb3eb29202ca7f57e73bb7e527286e66e0e822fff65609207c7e0ef2d135a3 demo:demopass:::upload # atmoz/sftp:alpine
           for i in $(seq 1 30); do
             nc -z localhost 2222 && exit 0
             sleep 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,10 @@ this. The prefix decides the release bump
 - Behavior changes are covered by tests and documented (README / `docs/` /
   `action.yml` input descriptions).
 - No new dependencies unless truly needed.
+- Anything CI pulls from outside the repo is pinned by hash: actions by their
+  full commit SHA, container images by `@sha256:` digest (with the readable
+  tag kept as a trailing comment). Dependabot does not touch inline
+  `docker run` digests, so those are bumped by hand.
 - Errors are wrapped with context (`fmt.Errorf("...: %w", err)`), log output
   goes through the `Logger`/`gha` helpers.
 - Destructive-path changes (anything that deletes remote files) keep the


### PR DESCRIPTION
Closes #8.

## What changed

```diff
-docker run -d --name sftp -p 2222:22 atmoz/sftp:alpine demo:demopass:::upload
+docker run -d --name sftp -p 2222:22 atmoz/sftp@sha256:a6cb3eb2…35a3 demo:demopass:::upload # atmoz/sftp:alpine
```

The digest is the one `atmoz/sftp:alpine` resolves to today (read from the registry manifest; it is a single-platform amd64 manifest, which is what `ubuntu-latest` needs). The tag is kept as a trailing comment, and a step comment records the refresh command (`docker buildx imagetools inspect atmoz/sftp:alpine`) plus the reason it has to be manual: Dependabot does not touch inline `docker run` digests.

I also checked the rest of the workflows while here: every `uses:` is already pinned to a full 40-char SHA (only local `./` references and reusable-workflow calls are unpinned, which is correct), and this image was the last unpinned external input. `CONTRIBUTING.md`'s review checklist now states the rule so the next external dependency lands pinned.

## Testing

The self-test job in this PR's own CI run is the test: if the digest were wrong or unreachable, `docker run` would fail immediately and the job would go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)