### PR TITLE
docs: note that Windows runners have no local permission bits to mirror

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,13 +211,23 @@ sync:
 
 | Field | Default | Description |
 |---|---|---|
-| `files` | mirror local | Octal permission (e.g. `"0644"`) for every uploaded file. |
+| `files` | mirror local | Octal permission (e.g. `"0644"`) for every uploaded file. On Windows runners there are no local bits to mirror; see the note below. |
 | `directories` | server umask | Octal permission (e.g. `"0755"`) for every remote directory the run creates or touches. |
 | `preserve_times` | `false` | Keep each uploaded file's local modification time on the server. |
 
 All three are best-effort: a server that rejects the `SETSTAT` request
 produces one warning per deployment (not one per file, and not a failure), so
 a multi-deployment run shows which deployments are affected.
+
+> **Windows runners:** Windows has no POSIX permission bits, so "mirror local"
+> has nothing to mirror. Go reports `0666` for every writable file and `0444`
+> for read-only ones (and loses the executable bit), which is what the run
+> then requests on the server. The same deploy from `windows-latest` therefore
+> uploads world-writable `666` files where `ubuntu-latest` would upload `644`,
+> which some web servers reject and security scans flag. Set `files: "0644"`
+> (and `directories: "0755"`) explicitly when you deploy from a Windows
+> runner. Both live in the config file, so a Windows deploy that needs them
+> uses `config:` rather than the inline inputs.
 
 #### `sync`
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -255,8 +255,9 @@ deployments:
 
 ## Windows and macOS runners
 
-Nothing changes: easySFTP is a compiled Go binary and runs natively on
-`ubuntu-*`, `macos-*` and `windows-*` runners (no Docker required):
+The workflow does not change: easySFTP is a compiled Go binary and runs
+natively on `ubuntu-*`, `macos-*` and `windows-*` runners (no Docker
+required):
 
 ```yaml
 jobs:
@@ -273,3 +274,35 @@ jobs:
           source: .\build\
           target: /var/www/html/
 ```
+
+One thing does differ on Windows: file permissions. Windows has no POSIX
+permission bits, so the default "mirror the local mode" uploads every writable
+file as `0666` (`0444` for read-only ones), where the same deploy from
+`ubuntu-latest` would upload `0644`. If your server or a security scan cares,
+set the modes explicitly. They live in the config file:
+
+```yaml
+# .github/easysftp.yml
+version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: |
+    SHA256:...
+permissions:
+  files: "0644"
+  directories: "0755"
+deployments:
+  site:
+    source: .\build\
+    target: /var/www/html/
+```
+
+```yaml
+      - uses: eiserv/easySFTP@v3
+        with:
+          password: ${{ secrets.SFTP_PASSWORD }}
+          config: .github/easysftp.yml
+```
+
+macOS runners have real permission bits and need none of this.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -110,6 +110,12 @@ produce directories the web server can't read. Set `permissions.directories`
 permission, e.g. `directories: "0755"` and `files: "0644"`. Both are
 best-effort; see [configuration.md](configuration.md#permissions).
 
+Deploying from a **Windows runner** makes this more likely: Windows has no
+POSIX permission bits, so the mirrored local mode is `0666` for every writable
+file (`0444` for read-only ones), and your files land world-writable. Setting
+`permissions.files` explicitly is the fix, and is worth doing even when the
+deploy appears to work.
+
 ### `replacing "<path>": ...` or leftover `.easysftp-tmp` files
 
 easySFTP uploads to a temporary sibling file (named `<path>.easysftp-tmp.<n>`)


### PR DESCRIPTION
Closes #109.

## Verified, not assumed

Ran the check on Windows 11 / Go 1.25 before writing anything (`os.Stat` on files created by a build):

| Local file | Reported mode |
|---|---|
| writable file | `0666` |
| read-only file | `0444` |
| file with the exec bit set on Linux | `0666` (exec bit lost) |
| directory | `0777` |

So the issue's claim holds: a deploy from `windows-latest` requests `666` on every file where the same deploy from `ubuntu-latest` requests `644`. Directories are unaffected in practice, because easySFTP only chmods them when `permissions.directories` is set (otherwise the server's umask decides).

## What changed

- `docs/configuration.md`: the `permissions.files` row points at a new note under the table explaining the Windows behavior and recommending explicit `files: "0644"` / `directories: "0755"`.
- `docs/troubleshooting.md`: one paragraph in the existing "files land with the wrong bits" entry, since a Windows deploy hits it without any obvious symptom on the local side.
- `docs/examples.md`: the "Windows and macOS runners" section no longer opens with "Nothing changes"; it now says the *workflow* does not change, then shows the config-file snippet that sets the modes. macOS is called out as unaffected.

**One deviation from the issue text:** it asks for a note on the `file-mode` row of `action.yml` and a `file-mode:`/`dir-mode:` snippet in the examples. Those inline inputs no longer exist in v3 (`action.yml` only keeps them as "Removed in v3" stubs pointing at `permissions.*` in the config file), so the recommendation is written against the v3 names, and the examples snippet uses `config:` instead. That also means a Windows deploy that wants explicit modes has to use a config file, which the docs now say outright.

Docs only, no code change. `go test ./...` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)