### PR TITLE
feat: settable file-mode, dir-mode and preserve-times inline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
           source: ./selftest-site/
           target: /upload/
           exclude: "*.log"
+          file-mode: "0640"
 
       - name: Verify upload
         run: |
@@ -146,6 +147,11 @@ jobs:
           docker exec sftp test -f /home/demo/upload/assets/style.css
           if docker exec sftp test -e /home/demo/upload/debug.log; then
             echo "::error::ignored file was uploaded"
+            exit 1
+          fi
+          mode=$(docker exec sftp stat -c '%a' /home/demo/upload/index.html)
+          if [ "$mode" != "640" ]; then
+            echo "::error::file-mode input was not applied (got $mode, want 640)"
             exit 1
           fi
           [ "${{ steps.upload.outputs.files-uploaded }}" = "2" ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,10 @@ messages).
 The complete v3 input surface is:
 
 1. **Inline mode**: `host`, `port`, `username`, `host-key`, `known-hosts`,
-   `allow-any-host-key`, `source`, `target`, `mode`, `exclude`. Setting any of
-   these together with `config` fails the run (the check at the top of
-   `config.Load()`): there is no mixed mode.
+   `allow-any-host-key`, `source`, `target`, `mode`, `exclude`, `file-mode`,
+   `dir-mode`, `preserve-times`. Setting any of these together with `config`
+   fails the run (the check at the top of `config.Load()`): there is no mixed
+   mode.
    **Never give these inputs a `default:` in `action.yml`**: the runner
    exports declared defaults unconditionally, so the mutual-exclusion check
    sees them as "user-set" and rejects every config-file run; that's how
@@ -66,10 +67,14 @@ The complete v3 input surface is:
    change how a run authenticates or reports, never what it deploys.
 
 So a new knob is normally a config-file field, not an input. Adding it as an
-input means arguing why it belongs in category 3. Note the cost of that
-choice: today a user who wants one permission bit set has to convert their
-whole deploy to a config file (issue #133). Per-deployment granularity is a
-separate, later decision; don't build it speculatively.
+input means arguing why it belongs in category 1 or 3.
+
+`file-mode` / `dir-mode` / `preserve-times` are the worked example (issue
+#133): they are category 1, mirrored by `permissions.*` in category 2, so a
+Windows deploy that needs `file-mode: "0644"` does not have to convert its
+whole workflow into a config file. Each setting still has exactly one home
+*per mode*, which is what keeps "no precedence question" true. Per-deployment
+granularity is a separate, later decision; don't build it speculatively.
 
 ## Testing quirks
 

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,29 @@ inputs:
       "node_modules/"). Prefix with "!" to re-include files.
     required: false
 
+  # --- Permissions (inline mode) ---
+  file-mode:
+    description: >-
+      Octal permission (e.g. "0644") applied to every uploaded file, instead
+      of mirroring the local file's bits. Worth setting on Windows runners,
+      which have no POSIX bits to mirror and otherwise upload world-writable
+      files. Best-effort: a server that rejects the chmod warns, it does not
+      fail the run. In config mode this is permissions.files.
+    required: false
+  dir-mode:
+    description: >-
+      Octal permission (e.g. "0755") applied to every remote directory the
+      run creates or touches, instead of leaving the server's umask default.
+      Best-effort, like file-mode. In config mode this is
+      permissions.directories.
+    required: false
+  preserve-times:
+    description: >-
+      Set to "true" to keep each uploaded file's local modification time on
+      the server instead of "now". Best-effort, like file-mode. In config
+      mode this is permissions.preserve_times.
+    required: false
+
   # --- Config mode ---
   config:
     description: >-
@@ -195,15 +218,6 @@ inputs:
   manifest-name:
     description: "Removed in v3: moved to 'sync.manifest' in the config file. See docs/migration-v3.md."
     required: false
-  dir-mode:
-    description: "Removed in v3: moved to 'permissions.directories' in the config file. See docs/migration-v3.md."
-    required: false
-  file-mode:
-    description: "Removed in v3: moved to 'permissions.files' in the config file. See docs/migration-v3.md."
-    required: false
-  preserve-times:
-    description: "Removed in v3: moved to 'permissions.preserve_times' in the config file. See docs/migration-v3.md."
-    required: false
   proxy-server:
     description: "Removed in v3: moved to 'connection.proxy.host' in the config file. See docs/migration-v3.md."
     required: false
@@ -290,6 +304,9 @@ runs:
         EASYSFTP_TARGET: ${{ inputs.target }}
         EASYSFTP_MODE: ${{ inputs.mode }}
         EASYSFTP_EXCLUDE: ${{ inputs.exclude }}
+        EASYSFTP_FILE_MODE: ${{ inputs.file-mode }}
+        EASYSFTP_DIR_MODE: ${{ inputs.dir-mode }}
+        EASYSFTP_PRESERVE_TIMES: ${{ inputs.preserve-times }}
         EASYSFTP_CONFIG: ${{ inputs.config }}
         EASYSFTP_PROXY_PASSWORD: ${{ inputs.proxy-password }}
         EASYSFTP_PROXY_PRIVATE_KEY: ${{ inputs.proxy-private-key }}
@@ -314,9 +331,6 @@ runs:
         EASYSFTP_SYNC_FAST_PATH: ${{ inputs.sync-fast-path }}
         EASYSFTP_SKIP_UNCHANGED: ${{ inputs.skip-unchanged }}
         EASYSFTP_MANIFEST_NAME: ${{ inputs.manifest-name }}
-        EASYSFTP_DIR_MODE: ${{ inputs.dir-mode }}
-        EASYSFTP_FILE_MODE: ${{ inputs.file-mode }}
-        EASYSFTP_PRESERVE_TIMES: ${{ inputs.preserve-times }}
         EASYSFTP_PROXY_SERVER: ${{ inputs.proxy-server }}
         EASYSFTP_PROXY_PORT: ${{ inputs.proxy-port }}
         EASYSFTP_PROXY_USERNAME: ${{ inputs.proxy-username }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,21 @@ Everything else has a sensible default.
 | `mode` | | `overlay` | [Reconciliation mode](strategies.md): `overlay`, `sync` or `clean`. |
 | `exclude` | | - | Gitignore-style exclude patterns, one per line. `!` re-includes. |
 
+### Permissions (inline mode)
+
+| Input | Default | Description |
+|---|---|---|
+| `file-mode` | mirror local | Octal permission (e.g. `"0644"`) for every uploaded file. |
+| `dir-mode` | server umask | Octal permission (e.g. `"0755"`) for every remote directory the run creates or touches. |
+| `preserve-times` | `false` | Keep each uploaded file's local modification time on the server. |
+
+All three are best-effort: a server that rejects the `SETSTAT` request
+produces one warning per deployment, not a failure. Their config-mode
+equivalents are [`permissions.*`](#permissions); like every other non-secret
+setting they belong to exactly one mode, so setting them alongside `config`
+fails the run. Set at least `file-mode: "0644"` when you deploy from a
+Windows runner (see the [note below](#permissions)).
+
 ### Run-wide switches (both modes)
 
 | Input | Default | Description |
@@ -90,9 +105,10 @@ step shrinks to the config path plus credentials:
     # proxy-private-key: ${{ secrets.JUMP_PRIVATE_KEY }}
 ```
 
-Setting any inline connection/deployment input (`host`, `port`, `username`,
-`host-key`, `known-hosts`, `allow-any-host-key`, `source`, `target`, `mode`,
-`exclude`) alongside `config` fails the run: there is no mixed mode.
+Setting any inline connection/deployment/permission input (`host`, `port`,
+`username`, `host-key`, `known-hosts`, `allow-any-host-key`, `source`,
+`target`, `mode`, `exclude`, `file-mode`, `dir-mode`, `preserve-times`)
+alongside `config` fails the run: there is no mixed mode.
 
 The only inputs that combine with `config` are the credentials (`password`,
 `private-key`, `passphrase`, and the `proxy-*` credential counterparts) and
@@ -217,7 +233,9 @@ sync:
 
 All three are best-effort: a server that rejects the `SETSTAT` request
 produces one warning per deployment (not one per file, and not a failure), so
-a multi-deployment run shows which deployments are affected.
+a multi-deployment run shows which deployments are affected. In inline mode
+the same three settings are the `file-mode`, `dir-mode` and `preserve-times`
+[inputs](#permissions-inline-mode).
 
 > **Windows runners:** Windows has no POSIX permission bits, so "mirror local"
 > has nothing to mirror. Go reports `0666` for every writable file and `0444`
@@ -226,8 +244,8 @@ a multi-deployment run shows which deployments are affected.
 > uploads world-writable `666` files where `ubuntu-latest` would upload `644`,
 > which some web servers reject and security scans flag. Set `files: "0644"`
 > (and `directories: "0755"`) explicitly when you deploy from a Windows
-> runner. Both live in the config file, so a Windows deploy that needs them
-> uses `config:` rather than the inline inputs.
+> runner, or the equivalent `file-mode` / `dir-mode` inputs if you deploy
+> inline.
 
 #### `sync`
 
@@ -331,6 +349,7 @@ small; the advanced knobs moved into the config file (see
 | `password`, `private-key`, `passphrase` | both | Credentials (always from secrets). |
 | `host-key`, `known-hosts`, `allow-any-host-key` | inline | Host key verification. |
 | `source`, `target`, `mode`, `exclude` | inline | The single deployment. |
+| `file-mode`, `dir-mode`, `preserve-times` | inline | Remote permissions and timestamps (`permissions.*` in config mode). |
 | `config` | config | Path to the version-3 config file. |
 | `proxy-password`, `proxy-private-key`, `proxy-passphrase` | config | Jump-host credentials (the rest of the proxy config is in the file). |
 | `dry-run`, `log-level` | both | Run-wide switches. |
@@ -338,8 +357,8 @@ small; the advanced knobs moved into the config file (see
 Removed v2 inputs (`server`, `uploads`, `strategy`, `ignore`, `ignore-from`,
 `config-file`, `host-key-fingerprint`, `max-deletes`, `concurrency`,
 `sftp-request-concurrency`, `retries`, `timeout`, `stall-timeout`,
-`sync-fast-path`, `skip-unchanged`, `manifest-name`, `dir-mode`, `file-mode`,
-`preserve-times`, the `proxy-server`/`proxy-port`/`proxy-username`/
+`sync-fast-path`, `skip-unchanged`, `manifest-name`,
+the `proxy-server`/`proxy-port`/`proxy-username`/
 `proxy-host-key-fingerprint`/`proxy-known-hosts` connection inputs,
 `build-mode`, and the `delete` tombstone) still fail loudly with a migration
 hint rather than being silently ignored. See the

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -279,30 +279,16 @@ One thing does differ on Windows: file permissions. Windows has no POSIX
 permission bits, so the default "mirror the local mode" uploads every writable
 file as `0666` (`0444` for read-only ones), where the same deploy from
 `ubuntu-latest` would upload `0644`. If your server or a security scan cares,
-set the modes explicitly. They live in the config file:
+set the modes explicitly, two more lines in the same step:
 
 ```yaml
-# .github/easysftp.yml
-version: 3
-connection:
-  host: sftp.example.com
-  username: deploy
-  host_key: |
-    SHA256:...
-permissions:
-  files: "0644"
-  directories: "0755"
-deployments:
-  site:
-    source: .\build\
-    target: /var/www/html/
+          source: .\build\
+          target: /var/www/html/
+          file-mode: "0644"
+          dir-mode: "0755"
 ```
 
-```yaml
-      - uses: eiserv/easySFTP@v3
-        with:
-          password: ${{ secrets.SFTP_PASSWORD }}
-          config: .github/easysftp.yml
-```
+In config mode the same settings are `permissions.files` and
+`permissions.directories`.
 
 macOS runners have real permission bits and need none of this.

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -56,8 +56,12 @@ non-secret setting, including the connection. Only credentials, `dry-run` and
   exactly one deployment.
 - All advanced/tuning inputs (`concurrency`, `retries`, `timeout`,
   `stall-timeout`, `sftp-request-concurrency`, `sync-fast-path`,
-  `skip-unchanged`, `manifest-name`, `dir-mode`, `file-mode`,
-  `preserve-times`, `max-deletes`) moved into the config file.
+  `skip-unchanged`, `manifest-name`, `max-deletes`) moved into the config
+  file.
+- `dir-mode`, `file-mode` and `preserve-times` are unchanged inline inputs
+  (they were briefly config-file-only in v3.0 and v3.1); in config mode they
+  are `permissions.directories`, `permissions.files` and
+  `permissions.preserve_times`.
 - All proxy/bastion connection inputs moved into the config file
   (`connection.proxy`); only the proxy credentials remain inputs.
 - The config file format changed: `version: 3`, connection settings live in
@@ -101,9 +105,9 @@ reconnects, outputs, and the job summary outputs' names.
 | `skip-unchanged` | `advanced.skip_unchanged` in the config file |
 | `sync-fast-path` | `sync.fast_path` in the config file |
 | `manifest-name` | `sync.manifest` in the config file |
-| `dir-mode` | `permissions.directories` in the config file |
-| `file-mode` | `permissions.files` in the config file |
-| `preserve-times` | `permissions.preserve_times` in the config file |
+| `dir-mode` | unchanged inline; `permissions.directories` in a config file |
+| `file-mode` | unchanged inline; `permissions.files` in a config file |
+| `preserve-times` | unchanged inline; `permissions.preserve_times` in a config file |
 | `proxy-server` | `connection.proxy.host` in the config file |
 | `proxy-port` | `connection.proxy.port` in the config file |
 | `proxy-username` | `connection.proxy.username` in the config file |
@@ -244,9 +248,6 @@ Advanced inputs moved into structured config sections. A v2 step like:
     stall-timeout: 120
     concurrency: 8
     sftp-request-concurrency: 8
-    dir-mode: "755"
-    file-mode: "644"
-    preserve-times: "true"
     manifest-name: .deploy-manifest.json
     sync-fast-path: "true"
     max-deletes: 500
@@ -261,10 +262,6 @@ advanced:
   stall_timeout: 120
   concurrency: 8
   request_concurrency: 8
-permissions:
-  directories: "0755"
-  files: "0644"
-  preserve_times: true
 sync:
   manifest: .deploy-manifest.json
   fast_path: true
@@ -274,7 +271,9 @@ safety:
 
 If you tuned these in a single-target v2 workflow, you now need a (small)
 config file; the automatic defaults cover the common case without any of
-them.
+them. The exception is the `permissions` block: `dir-mode`, `file-mode` and
+`preserve-times` also stayed inline inputs, so a workflow that only sets
+those needs no config file at all.
 
 ## Migrating a jump host (bastion) setup
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,16 +105,23 @@ relative to the chroot: `/upload/...`, not `/home/user/upload/...`.
 Directories created by the run get whatever the server's umask produces, and
 uploaded files mirror their local permission bits. On shared hosting where the
 web server runs as a different user than your SFTP account, that default can
-produce directories the web server can't read. Set `permissions.directories`
-(and, if needed, `permissions.files`) in the config file to force a known-good
-permission, e.g. `directories: "0755"` and `files: "0644"`. Both are
-best-effort; see [configuration.md](configuration.md#permissions).
+produce directories the web server can't read. Force a known-good permission
+with the `dir-mode` and `file-mode` inputs:
+
+```yaml
+    dir-mode: "0755"
+    file-mode: "0644"
+```
+
+In config mode the same settings are `permissions.directories` and
+`permissions.files`. Both are best-effort; see
+[configuration.md](configuration.md#permissions-inline-mode).
 
 Deploying from a **Windows runner** makes this more likely: Windows has no
 POSIX permission bits, so the mirrored local mode is `0666` for every writable
 file (`0444` for read-only ones), and your files land world-writable. Setting
-`permissions.files` explicitly is the fix, and is worth doing even when the
-deploy appears to work.
+`file-mode` explicitly is the fix, and is worth doing even when the deploy
+appears to work.
 
 ### `replacing "<path>": ...` or leftover `.easysftp-tmp` files
 

--- a/internal/actionmeta/actionmeta_test.go
+++ b/internal/actionmeta/actionmeta_test.go
@@ -67,6 +67,7 @@ func TestActionMetadata(t *testing.T) {
 		"host", "port", "username", "password", "private-key", "passphrase",
 		"host-key", "known-hosts", "allow-any-host-key",
 		"source", "target", "mode", "exclude", "config",
+		"file-mode", "dir-mode", "preserve-times",
 		"proxy-password", "proxy-private-key", "proxy-passphrase",
 		"dry-run", "log-level",
 		// removed-input tombstones (fail with a migration hint when set)
@@ -74,7 +75,6 @@ func TestActionMetadata(t *testing.T) {
 		"strategy", "ignore", "ignore-from", "max-deletes", "delete",
 		"concurrency", "sftp-request-concurrency", "retries", "timeout",
 		"stall-timeout", "sync-fast-path", "skip-unchanged", "manifest-name",
-		"dir-mode", "file-mode", "preserve-times",
 		"proxy-server", "proxy-port", "proxy-username",
 		"proxy-host-key-fingerprint", "proxy-known-hosts",
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,9 +253,6 @@ var removedInputs = []removedInput{
 	{"SYNC_FAST_PATH", "the 'sync-fast-path' input moved to 'sync.fast_path' in the config file"},
 	{"MANIFEST_NAME", "the 'manifest-name' input moved to 'sync.manifest' in the config file"},
 	{"SKIP_UNCHANGED", "the 'skip-unchanged' input moved to 'advanced.skip_unchanged' in the config file"},
-	{"DIR_MODE", "the 'dir-mode' input moved to 'permissions.directories' in the config file"},
-	{"FILE_MODE", "the 'file-mode' input moved to 'permissions.files' in the config file"},
-	{"PRESERVE_TIMES", "the 'preserve-times' input moved to 'permissions.preserve_times' in the config file"},
 	{"PROXY_SERVER", "the 'proxy-server' input moved to 'connection.proxy.host' in the config file"},
 	{"PROXY_PORT", "the 'proxy-port' input moved to 'connection.proxy.port' in the config file"},
 	{"PROXY_USERNAME", "the 'proxy-username' input moved to 'connection.proxy.username' in the config file"},
@@ -288,6 +285,9 @@ var inlineOnlyInputs = []struct{ env, input string }{
 	{"TARGET", "target"},
 	{"MODE", "mode"},
 	{"EXCLUDE", "exclude"},
+	{"FILE_MODE", "file-mode"},
+	{"DIR_MODE", "dir-mode"},
+	{"PRESERVE_TIMES", "preserve-times"},
 }
 
 // Load reads the configuration from the environment and validates it.
@@ -378,6 +378,15 @@ func loadInline(cfg *Config, get func(string) string) error {
 	}
 	if cfg.AllowAnyHostKey, err = parseBool(get("ALLOW_ANY_HOST_KEY"), false); err != nil {
 		return fmt.Errorf("invalid allow-any-host-key: %w", err)
+	}
+	if cfg.FileMode, err = parseMode(get("FILE_MODE"), "input 'file-mode'"); err != nil {
+		return err
+	}
+	if cfg.DirMode, err = parseMode(get("DIR_MODE"), "input 'dir-mode'"); err != nil {
+		return err
+	}
+	if cfg.PreserveTimes, err = parseBool(get("PRESERVE_TIMES"), false); err != nil {
+		return fmt.Errorf("invalid preserve-times: %w", err)
 	}
 
 	strategy := StrategyOverlay

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,7 @@ var v3EnvVars = []string{
 	"HOST", "PORT", "USERNAME", "PASSWORD", "PRIVATE_KEY", "PASSPHRASE",
 	"HOST_KEY", "KNOWN_HOSTS", "ALLOW_ANY_HOST_KEY",
 	"SOURCE", "TARGET", "MODE", "EXCLUDE", "CONFIG",
+	"FILE_MODE", "DIR_MODE", "PRESERVE_TIMES",
 	"DRY_RUN", "LOG_LEVEL",
 	"PROXY_PASSWORD", "PROXY_PRIVATE_KEY", "PROXY_PASSPHRASE",
 	// removed-input tombstones
@@ -27,7 +28,6 @@ var v3EnvVars = []string{
 	"IGNORE", "IGNORE_FROM", "MAX_DELETES", "DELETE",
 	"CONCURRENCY", "SFTP_REQUEST_CONCURRENCY", "RETRIES", "TIMEOUT", "STALL_TIMEOUT",
 	"SYNC_FAST_PATH", "MANIFEST_NAME", "SKIP_UNCHANGED",
-	"DIR_MODE", "FILE_MODE", "PRESERVE_TIMES",
 	"PROXY_SERVER", "PROXY_PORT", "PROXY_USERNAME",
 	"PROXY_HOST_KEY_FINGERPRINT", "PROXY_KNOWN_HOSTS",
 }
@@ -127,6 +127,37 @@ func TestLoadInlineModeAndExclude(t *testing.T) {
 	}
 }
 
+// TestLoadInlinePermissions covers issue #133: the permission knobs are
+// settable inline, so a Windows deploy does not need a whole config file for
+// one "file-mode: 0644".
+func TestLoadInlinePermissions(t *testing.T) {
+	setBaseEnv(t)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.FileMode != nil || cfg.DirMode != nil || cfg.PreserveTimes {
+		t.Errorf("expected unset permissions by default, got files=%v dirs=%v times=%v",
+			cfg.FileMode, cfg.DirMode, cfg.PreserveTimes)
+	}
+
+	t.Setenv("EASYSFTP_FILE_MODE", "0644")
+	t.Setenv("EASYSFTP_DIR_MODE", "755")
+	t.Setenv("EASYSFTP_PRESERVE_TIMES", "true")
+	if cfg, err = Load(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.FileMode == nil || *cfg.FileMode != 0o644 {
+		t.Errorf("expected file mode 0644, got %v", cfg.FileMode)
+	}
+	if cfg.DirMode == nil || *cfg.DirMode != 0o755 {
+		t.Errorf("expected dir mode 0755, got %v", cfg.DirMode)
+	}
+	if !cfg.PreserveTimes {
+		t.Error("expected PreserveTimes to be true")
+	}
+}
+
 func TestLoadInlineValidation(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -143,6 +174,9 @@ func TestLoadInlineValidation(t *testing.T) {
 		{"bad dry-run", map[string]string{"EASYSFTP_DRY_RUN": "yes-please"}, "invalid dry-run"},
 		{"bad allow-any-host-key", map[string]string{"EASYSFTP_ALLOW_ANY_HOST_KEY": "maybe"}, "invalid allow-any-host-key"},
 		{"bad log-level", map[string]string{"EASYSFTP_LOG_LEVEL": "quiet"}, "'log-level' must be normal, verbose or debug"},
+		{"bad file-mode", map[string]string{"EASYSFTP_FILE_MODE": "rw-r--r--"}, "invalid input 'file-mode'"},
+		{"bad dir-mode", map[string]string{"EASYSFTP_DIR_MODE": "0999"}, "invalid input 'dir-mode'"},
+		{"bad preserve-times", map[string]string{"EASYSFTP_PRESERVE_TIMES": "sometimes"}, "invalid preserve-times"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -194,9 +228,6 @@ func TestLoadRemovedInputsFailWithMigrationHint(t *testing.T) {
 		{"SYNC_FAST_PATH", "sync.fast_path"},
 		{"MANIFEST_NAME", "sync.manifest"},
 		{"SKIP_UNCHANGED", "advanced.skip_unchanged"},
-		{"DIR_MODE", "permissions.directories"},
-		{"FILE_MODE", "permissions.files"},
-		{"PRESERVE_TIMES", "permissions.preserve_times"},
 		{"PROXY_SERVER", "connection.proxy.host"},
 		{"PROXY_PORT", "connection.proxy.port"},
 		{"PROXY_USERNAME", "connection.proxy.username"},
@@ -401,6 +432,9 @@ func TestLoadConfigModeRejectsInlineInputs(t *testing.T) {
 		{"EASYSFTP_ALLOW_ANY_HOST_KEY", "allow-any-host-key"},
 		{"EASYSFTP_USERNAME", "username"},
 		{"EASYSFTP_PORT", "port"},
+		{"EASYSFTP_FILE_MODE", "file-mode"},
+		{"EASYSFTP_DIR_MODE", "dir-mode"},
+		{"EASYSFTP_PRESERVE_TIMES", "preserve-times"},
 	} {
 		t.Run(in.name, func(t *testing.T) {
 			setConfigModeEnv(t, minimalConfigFile)


### PR DESCRIPTION
Closes #133.

## The problem

v3 moved `dir-mode`, `file-mode` and `preserve-times` into the config file
(`permissions.*`) and left only "Removed in v3" tombstones behind. Because
inline mode and config mode are mutually exclusive, a user who needs one
permission bit had to convert their entire deploy (host, username, host key,
source, target, mode, exclude) into YAML.

#109 makes that concrete: every deploy from a `windows-latest` runner
uploads world-writable `0666` files, because Windows has no POSIX bits for
"mirror local" to mirror. The fix is one line, `file-mode: "0644"`, and it
cost a config file.

## The resolution

The issue offered two options; this takes the second, "simpler and more in
the spirit of v3": the three inputs come back as **inline-only** inputs,
mutually exclusive with `config` exactly like `source`/`target`/`mode`.

That keeps v3's headline promise intact: every non-secret setting still has
exactly one home *per mode* (the input inline, `permissions.*` in config
mode), so there is still no precedence question and no two-sources-of-truth
problem. What it does not do is add a third category of "valid in both
modes" inputs, which would have needed a precedence rule.

Per-deployment permissions stay out of scope, as the issue asks.

## Changes

- `action.yml`: the three tombstones become real inputs with user-facing
  descriptions, in a new "Permissions (inline mode)" block. No `default:`
  values (that is the #62 trap), and their env wiring moved from the
  tombstone block to the live one.
- `internal/config/config.go`: dropped from `removedInputs`, added to
  `inlineOnlyInputs`, parsed in `loadInline` (reusing the existing
  `parseMode`/`parseBool`).
- Both drift-check lists updated (`wantInputs` in the actionmeta test, the
  cleared-env list in `setBaseEnv`).
- Docs: `configuration.md` (new inline table, mutual-exclusion list, the
  Windows note, complete input reference), `migration-v3.md` (the three are
  now "unchanged inline" rather than "moved"), `troubleshooting.md` and
  `examples.md` (the Windows permission fix is two lines in the same step
  again, not a config file). `CLAUDE.md` updated to describe the rule this
  establishes.

## Tests

- `TestLoadInlinePermissions`: unset by default, parses `"0644"`/`"755"`/
  `true`.
- Three new invalid-value rows in `TestLoadInlineValidation`.
- Three new rows in `TestLoadConfigModeRejectsInlineInputs` (setting them
  with `config` fails).
- The three removed-input rows dropped from
  `TestLoadRemovedInputsFailWithMigrationHint`.
- CI self-test: the inline upload now passes `file-mode: "0640"` and the
  verify step asserts `stat -c %a` is `640` on the real OpenSSH server. This
  is the only place `action.yml`'s composite wiring runs end to end, which is
  exactly the gap that let #62 ship green.

`go test ./...` passes locally. `-race` was not run (no cgo toolchain on this
machine); relying on CI for the race pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
