### PR TITLE
fix: name the real config key when the delete guard aborts a run

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -182,7 +182,7 @@ never deleted by `sync` itself.
 always. Deploy into a specific subdirectory instead. This guard cannot be
 disabled; see [delete guards](strategies.md#delete-guards).
 
-### `refusing to delete N files: exceeds guards.max_deletes`
+### `refusing to delete N files: exceeds safety.max_deletes`
 
 Your run would delete more files than `safety.max_deletes` allows. Inspect the
 plan with `dry-run: true`; if the deletions are intended, raise (or remove)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,8 +110,11 @@ type Proxy struct {
 	AllowAnyHostKey bool
 }
 
-// Guards holds the safety limits applied before any destructive operation.
-type Guards struct {
+// Safety holds the safety limits applied before any destructive operation.
+// The field and type names mirror the config file's "safety" section on
+// purpose: a name that drifts from the YAML key leaks into error messages
+// and sends users to a key that does not exist (issue #140).
+type Safety struct {
 	// MaxDeletes refuses a run that would delete more than this many files.
 	// 0 means unlimited. The refusal to delete the remote root is always on.
 	MaxDeletes int
@@ -140,7 +143,7 @@ type Config struct {
 
 	Uploads     []UploadPair
 	IgnoreLines []string
-	Guards      Guards
+	Safety      Safety
 
 	// ConfigPath is the path of the loaded YAML config file, or "" in inline
 	// mode. It drives config-mode error message wording and the job summary.
@@ -435,8 +438,8 @@ func (c *Config) validate() error {
 		return fmt.Errorf("advanced.timeout must not be negative (use 0 to disable the timeout), got %d", int(c.Timeout/time.Second))
 	case c.StallTimeout < 0:
 		return fmt.Errorf("advanced.stall_timeout must not be negative (use 0 to disable the check), got %d", int(c.StallTimeout/time.Second))
-	case c.Guards.MaxDeletes < 0:
-		return fmt.Errorf("safety.max_deletes must not be negative, got %d", c.Guards.MaxDeletes)
+	case c.Safety.MaxDeletes < 0:
+		return fmt.Errorf("safety.max_deletes must not be negative, got %d", c.Safety.MaxDeletes)
 	}
 	if p := c.Proxy; p != nil {
 		switch {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -91,8 +91,8 @@ func TestLoadInlineDefaults(t *testing.T) {
 	if cfg.Timeout != 30*time.Second {
 		t.Errorf("expected 30s default timeout, got %s", cfg.Timeout)
 	}
-	if cfg.Guards.MaxDeletes != 0 {
-		t.Errorf("expected unlimited max deletes by default, got %d", cfg.Guards.MaxDeletes)
+	if cfg.Safety.MaxDeletes != 0 {
+		t.Errorf("expected unlimited max deletes by default, got %d", cfg.Safety.MaxDeletes)
 	}
 	if cfg.ManifestName != DefaultManifestName {
 		t.Errorf("expected default manifest name %q, got %q", DefaultManifestName, cfg.ManifestName)
@@ -345,8 +345,8 @@ sync:
 	if len(cfg.IgnoreLines) != 1 || cfg.IgnoreLines[0] != "*.map" {
 		t.Errorf("unexpected global excludes: %v", cfg.IgnoreLines)
 	}
-	if cfg.Guards.MaxDeletes != 500 {
-		t.Errorf("expected max_deletes 500, got %d", cfg.Guards.MaxDeletes)
+	if cfg.Safety.MaxDeletes != 500 {
+		t.Errorf("expected max_deletes 500, got %d", cfg.Safety.MaxDeletes)
 	}
 	if cfg.Retries != 4 || cfg.Timeout != 60*time.Second || cfg.StallTimeout != 120*time.Second ||
 		cfg.Concurrency != 8 || cfg.SftpRequestConcurrency != 4 || !cfg.SkipUnchanged {
@@ -367,7 +367,7 @@ func TestLoadConfigModeDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Retries != 2 ||
-		cfg.Timeout != 30*time.Second || cfg.StallTimeout != 0 || cfg.Guards.MaxDeletes != 0 {
+		cfg.Timeout != 30*time.Second || cfg.StallTimeout != 0 || cfg.Safety.MaxDeletes != 0 {
 		t.Errorf("unexpected config-mode defaults: %+v", cfg)
 	}
 	if cfg.Uploads[0].Strategy != StrategyOverlay {

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -334,7 +334,7 @@ func applyYAML(cfg *Config, yc *yamlConfig) error {
 	}
 
 	// Safety, advanced tuning, permissions, sync.
-	cfg.Guards.MaxDeletes = yc.Safety.MaxDeletes
+	cfg.Safety.MaxDeletes = yc.Safety.MaxDeletes
 	if yc.Advanced.Retries != nil {
 		cfg.Retries = *yc.Advanced.Retries
 	}

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -90,8 +90,8 @@ func checkRemoteRoot(remote string) error {
 
 // checkMaxDeletes enforces the guards.max_deletes limit (0 means unlimited).
 func checkMaxDeletes(n int, cfg *config.Config) error {
-	if cfg.Guards.MaxDeletes > 0 && n > cfg.Guards.MaxDeletes {
-		return fmt.Errorf("refusing to delete %d files: exceeds guards.max_deletes=%d (raise the limit, or run with dry-run to inspect the plan)", n, cfg.Guards.MaxDeletes)
+	if cfg.Safety.MaxDeletes > 0 && n > cfg.Safety.MaxDeletes {
+		return fmt.Errorf("refusing to delete %d files: exceeds safety.max_deletes=%d (raise the limit in the config file, or run with dry-run to inspect the plan)", n, cfg.Safety.MaxDeletes)
 	}
 	return nil
 }

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -156,11 +156,14 @@ func TestSyncMaxDeletesGuard(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := syncConfig(srv, local)
-	cfg.Guards.MaxDeletes = 1
+	cfg.Safety.MaxDeletes = 1
 
 	_, err := Run(context.Background(), cfg, testLogger{t})
-	if err == nil || !strings.Contains(err.Error(), "max_deletes") {
-		t.Fatalf("expected max_deletes guard error, got %v", err)
+	// The key must be spelled exactly as the config file spells it: the
+	// message tells the user what to raise, so a wrong key sends them to a
+	// field the strict parser then rejects (issue #140).
+	if err == nil || !strings.Contains(err.Error(), "safety.max_deletes") {
+		t.Fatalf("expected a safety.max_deletes guard error, got %v", err)
 	}
 	// Nothing was deleted because the guard fires before any removal.
 	if !remoteExists(t, srv, "/www/b.txt") {


### PR DESCRIPTION
Closes #140.

## The bug

Trip the delete guard and easySFTP said:

```
refusing to delete 812 files: exceeds guards.max_deletes=500 (raise the limit, or run with dry-run to inspect the plan)
```

There is no `guards.max_deletes`. The config file, the JSON Schema and the
docs all spell it **`safety.max_deletes`**. A user following that advice adds
`guards:` to their config file and gets an unknown-field error from the strict
parser, right after a destructive run was aborted, which is the worst moment
to send someone chasing a key that does not exist.

`docs/troubleshooting.md` had inherited the collision on the page itself: the
section heading quoted the error (`guards.max_deletes`) and the next sentence
gave the correct key (`safety.max_deletes`).

## The fix

The wrong name leaked in from the Go field, which was `config.Guards` while
the YAML section it is parsed from is `safety`. One message got it right
(`config.go`'s negative-value validation) and one got it wrong, which is what
a name that does not match its source invites.

So rather than patching the one string, the field now matches the YAML:

    config.Guards / type Guards  ->  config.Safety / type Safety

plus the message itself (and it now says *where* to raise the limit), and the
troubleshooting heading. Nothing links to the old heading anchor, so there is
no dangling reference.

I grepped every other error string that names a config key (`advanced.*`,
`sync.*`, `connection.*`, `permissions.*`): no other drift, all match the
schema sections.

## Test

`TestSyncMaxDeletesGuard` asserted only that the error contained
`"max_deletes"`, which the wrong key satisfied too. It now pins
`"safety.max_deletes"`, so this cannot regress silently.

`go test ./...`, `go vet ./...` and `gofmt -l .` are clean. `-race` could not
run locally ("-race requires cgo", no C toolchain on this machine); CI covers
the race pass.

## Note

This is a user-facing message fix, so it is `fix:` and will cut a patch
release. No behavior changes: the guard fires under exactly the same
conditions as before.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
