### PR TITLE
feat: manually triggered SFTP benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,143 @@
+name: SFTP benchmark
+
+# Manually triggered throughput measurement against a real SFTP server
+# (issue #169). It collects data only: no threshold here fails anything, since
+# run-to-run variance against an external host is not understood yet.
+#
+# Required repository secrets:
+#   BENCHMARK_SFTP_HOST         host name of the benchmark server
+#   BENCHMARK_SFTP_USERNAME     SFTP user name
+#   BENCHMARK_SFTP_PASSWORD     SFTP password
+#   BENCHMARK_SFTP_KNOWN_HOSTS  verbatim output of "ssh-keyscan <host>", so the
+#                               benchmark verifies the server like any other
+#                               easySFTP run does
+#
+# The account must be a throwaway one: everything below
+# "<remote-base>/<build>/<scenario>" is wiped before every repeat and again at
+# the end of the run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate-ref:
+        description: "Ref (branch, tag or SHA) to benchmark. Defaults to the ref this workflow was started from."
+        required: false
+        type: string
+      baseline-ref:
+        description: "Optional second ref to benchmark in the same run, for comparison (e.g. main)."
+        required: false
+        type: string
+      repeats:
+        description: "Measured repeats per scenario; the median is reported."
+        required: false
+        default: "3"
+        type: string
+      remote-base:
+        description: "Remote directory the benchmark owns. Everything below it is disposable."
+        required: false
+        default: "/easysftp-benchmark"
+        type: string
+      port:
+        description: "SFTP port of the benchmark server."
+        required: false
+        default: "22"
+        type: string
+
+permissions:
+  contents: read
+
+# One benchmark at a time: two runs sharing the host would measure each other,
+# and they would also fight over the same remote directories.
+concurrency:
+  group: sftp-benchmark
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Benchmark SFTP throughput
+    # The secrets already require write access to reach; this is the explicit
+    # owner-only gate issue #169 asks for.
+    if: github.actor == github.repository_owner
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      # The workflow's own checkout, for scripts/benchmark.sh. It runs first:
+      # a root checkout cleans the workspace and would remove the build
+      # checkouts below.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check out the candidate
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.candidate-ref || github.sha }}
+          path: builds/candidate
+
+      - name: Check out the baseline
+        if: inputs.baseline-ref != ''
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.baseline-ref }}
+          path: builds/baseline
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build both refs
+        id: build
+        env:
+          CGO_ENABLED: "0"
+          # Through the environment, never interpolated into the script: a ref
+          # is user input, and "${{ }}" in a run block is a shell injection.
+          CANDIDATE_REF_INPUT: ${{ inputs.candidate-ref }}
+          BASELINE_REF_INPUT: ${{ inputs.baseline-ref }}
+          DEFAULT_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/bin"
+          build() {
+            local dir=$1 name=$2
+            ( cd "$dir" && go build -trimpath -ldflags="-s -w" -o "$RUNNER_TEMP/bin/$name" ./cmd/easysftp )
+          }
+          build builds/candidate easysftp-candidate
+          echo "candidate-ref=${CANDIDATE_REF_INPUT:-$DEFAULT_REF} ($(git -C builds/candidate rev-parse --short HEAD))" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASELINE_REF_INPUT" ]; then
+            build builds/baseline easysftp-baseline
+            {
+              echo "baseline-bin=$RUNNER_TEMP/bin/easysftp-baseline"
+              echo "baseline-ref=$BASELINE_REF_INPUT ($(git -C builds/baseline rev-parse --short HEAD))"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run the benchmark
+        env:
+          CANDIDATE_BIN: ${{ runner.temp }}/bin/easysftp-candidate
+          CANDIDATE_REF: ${{ steps.build.outputs.candidate-ref }}
+          BASELINE_BIN: ${{ steps.build.outputs.baseline-bin }}
+          BASELINE_REF: ${{ steps.build.outputs.baseline-ref }}
+          REPEATS: ${{ inputs.repeats }}
+          REMOTE_BASE: ${{ inputs.remote-base }}
+          # OUT_DIR is uploaded as an artifact; LOG_DIR (which holds logs that
+          # name the host and user) deliberately is not.
+          OUT_DIR: ${{ runner.temp }}/benchmark-results
+          LOG_DIR: ${{ runner.temp }}/benchmark-logs
+          DATASET_DIR: ${{ runner.temp }}/benchmark-data
+          BENCH_HOST: ${{ secrets.BENCHMARK_SFTP_HOST }}
+          BENCH_PORT: ${{ inputs.port }}
+          BENCH_USERNAME: ${{ secrets.BENCHMARK_SFTP_USERNAME }}
+          BENCH_PASSWORD: ${{ secrets.BENCHMARK_SFTP_PASSWORD }}
+          BENCH_KNOWN_HOSTS: ${{ secrets.BENCHMARK_SFTP_KNOWN_HOSTS }}
+        run: bash scripts/benchmark.sh
+
+      - name: Publish the summary
+        if: always()
+        run: cat "$RUNNER_TEMP/benchmark-results/summary.md" >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Upload the results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-${{ github.run_id }}
+          path: ${{ runner.temp }}/benchmark-results
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,3 +338,38 @@ jobs:
           [ "${{ steps.badkey.outcome }}" = "failure" ]
           [ "${{ steps.nokey.outcome }}" = "failure" ]
           [ "${{ steps.v2input.outcome }}" = "failure" ]
+
+      # The benchmark harness (issue #169) normally runs against an external
+      # server behind secrets, so this container is the only place its
+      # plumbing can be exercised: binary invocation, step-output parsing and
+      # the JSON/Markdown aggregation. One repeat is enough to prove the
+      # pipeline; the numbers it produces are meaningless against localhost.
+      - name: Smoke-test the benchmark harness
+        env:
+          CANDIDATE_BIN: ${{ runner.temp }}/bench-bin/easysftp
+          CANDIDATE_REF: self-test
+          REPEATS: "1"
+          REMOTE_BASE: /upload/benchmark
+          OUT_DIR: ${{ runner.temp }}/bench-out
+          LOG_DIR: ${{ runner.temp }}/bench-logs
+          DATASET_DIR: ${{ runner.temp }}/bench-data
+          BENCH_HOST: localhost
+          BENCH_PORT: "2222"
+          BENCH_USERNAME: demo
+          BENCH_PASSWORD: demopass
+        run: |
+          mkdir -p "$RUNNER_TEMP/bench-bin"
+          go build -o "$RUNNER_TEMP/bench-bin/easysftp" ./cmd/easysftp
+          BENCH_KNOWN_HOSTS=$(ssh-keyscan -p 2222 localhost 2>/dev/null)
+          export BENCH_KNOWN_HOSTS
+          bash scripts/benchmark.sh
+          jq -e '.results | length == 3 and all(.files > 0 and .median_ms > 0 and .failed_runs == 0)' "$OUT_DIR/results.json"
+          test -s "$OUT_DIR/summary.md"
+
+      - name: Verify the benchmark left nothing behind
+        run: |
+          if [ -n "$(docker exec sftp find /home/demo/upload/benchmark -type f)" ]; then
+            echo "::error::benchmark payload survived its own cleanup"
+            docker exec sftp find /home/demo/upload/benchmark
+            exit 1
+          fi

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -123,6 +123,9 @@ generate_dataset() {
 }
 
 # run_easysftp <binary> <source> <remote> <mode> <log> <outputs-file>
+# BENCH_* are never assigned here: they come from the environment and
+# require_env has already refused an empty one.
+# shellcheck disable=SC2153
 run_easysftp() {
   local binary=$1 source=$2 remote=$3 mode=$4 log=$5 outputs=$6
   : >"$outputs"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+#
+# easySFTP upload benchmark (issue #169).
+#
+# Measures one or two builds of easySFTP against a real SFTP server and writes
+# results.json plus summary.md. It collects data only: nothing here fails on a
+# slow number, because run-to-run variance against an external host is not
+# understood yet.
+#
+# Everything comes from the environment; .github/workflows/benchmark.yml builds
+# the binaries and sets these:
+#
+#   CANDIDATE_BIN, CANDIDATE_REF  build under test and the ref it was built from
+#   BASELINE_BIN,  BASELINE_REF   optional comparison build (may be empty)
+#   REPEATS                       measured repeats per scenario (default 3)
+#   REMOTE_BASE                   remote directory this benchmark owns
+#   OUT_DIR                       results.json and summary.md land here
+#   DATASET_DIR                   generated payload
+#   LOG_DIR                       per-run logs; must NOT be inside OUT_DIR
+#   BENCH_HOST, BENCH_PORT, BENCH_USERNAME, BENCH_PASSWORD, BENCH_KNOWN_HOSTS
+#
+# Candidate and baseline are interleaved repeat by repeat, not run as two
+# blocks: a shared host's throughput drifts over minutes, and a block layout
+# would charge that drift to whichever build ran second.
+#
+# "Median" here is the lower middle value for an even repeat count, which is
+# why an odd number of repeats is the better choice.
+
+set -euo pipefail
+
+# Scenario payloads, as "<count>:<KiB each>" groups. Fixed on purpose: a
+# benchmark whose payload changes between runs measures nothing.
+scenario_spec() {
+  case $1 in
+  small) echo '300:4' ;;               # per-file round-trip overhead dominates
+  mixed) echo '40:16 12:256 4:2048' ;; # roughly a built website
+  large) echo '2:16384' ;;             # raw transfer throughput
+  *)
+    echo "::error::unknown scenario $1" >&2
+    return 1
+    ;;
+  esac
+}
+
+SCENARIOS=(small mixed large)
+
+require_env() {
+  local name missing=0
+  for name in "$@"; do
+    if [[ -z "${!name:-}" ]]; then
+      echo "::error::$name is required but empty" >&2
+      missing=1
+    fi
+  done
+  if ((missing)); then
+    echo "::error::See the secret list in .github/workflows/benchmark.yml" >&2
+    exit 1
+  fi
+}
+
+require_env CANDIDATE_BIN CANDIDATE_REF OUT_DIR DATASET_DIR LOG_DIR \
+  REMOTE_BASE BENCH_HOST BENCH_USERNAME BENCH_PASSWORD BENCH_KNOWN_HOSTS
+
+REPEATS=${REPEATS:-3}
+BENCH_PORT=${BENCH_PORT:-22}
+BASELINE_BIN=${BASELINE_BIN:-}
+BASELINE_REF=${BASELINE_REF:-}
+
+if [[ ! "$REPEATS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::REPEATS must be a positive integer, got '$REPEATS'" >&2
+  exit 1
+fi
+
+# The benchmark wipes everything below "$REMOTE_BASE/<build>/<scenario>" before
+# every repeat, so a too-broad path is a data-loss bug, not a slow benchmark.
+# easySFTP itself refuses "/"; this refuses the rest of the obvious mistakes.
+case "$REMOTE_BASE" in
+/ | . | .. | */)
+  echo "::error::REMOTE_BASE ('$REMOTE_BASE') must be a dedicated directory such as /easysftp-benchmark, without a trailing slash" >&2
+  exit 1
+  ;;
+esac
+
+mkdir -p "$OUT_DIR" "$DATASET_DIR" "$LOG_DIR"
+
+# Run logs echo the host name and the user name, both secrets here. OUT_DIR is
+# uploaded as a workflow artifact, where nothing is masked, so the logs must
+# live outside it.
+out_abs=$(cd "$OUT_DIR" && pwd -P)
+log_abs=$(cd "$LOG_DIR" && pwd -P)
+if [[ "$log_abs" == "$out_abs" || "$log_abs" == "$out_abs"/* ]]; then
+  echo "::error::LOG_DIR must not be inside OUT_DIR: run logs name the host and user, and OUT_DIR is uploaded as an artifact" >&2
+  exit 1
+fi
+
+runs_file="$LOG_DIR/runs.jsonl"
+aggregate_file="$LOG_DIR/aggregate.json"
+: >"$runs_file"
+
+generate_dataset() {
+  local scenario dir spec count size index sub
+  local -a specs
+  mkdir -p "$DATASET_DIR/empty"
+  for scenario in "${SCENARIOS[@]}"; do
+    dir="$DATASET_DIR/$scenario"
+    rm -rf "$dir"
+    index=0
+    read -r -a specs <<<"$(scenario_spec "$scenario")"
+    for spec in "${specs[@]}"; do
+      count=${spec%%:*}
+      size=${spec##*:}
+      while ((count-- > 0)); do
+        # Spread over subdirectories so remote directory creation is part of
+        # the measurement, as it is in a real site upload.
+        sub="$dir/part$((index % 8))"
+        mkdir -p "$sub"
+        head -c "$((size * 1024))" /dev/urandom >"$sub/file$index.bin"
+        index=$((index + 1))
+      done
+    done
+    echo "dataset $scenario: $index file(s), $(du -sh "$dir" | cut -f1)"
+  done
+}
+
+# run_easysftp <binary> <source> <remote> <mode> <log> <outputs-file>
+run_easysftp() {
+  local binary=$1 source=$2 remote=$3 mode=$4 log=$5 outputs=$6
+  : >"$outputs"
+  env \
+    GITHUB_OUTPUT="$outputs" \
+    EASYSFTP_HOST="$BENCH_HOST" \
+    EASYSFTP_PORT="$BENCH_PORT" \
+    EASYSFTP_USERNAME="$BENCH_USERNAME" \
+    EASYSFTP_PASSWORD="$BENCH_PASSWORD" \
+    EASYSFTP_KNOWN_HOSTS="$BENCH_KNOWN_HOSTS" \
+    EASYSFTP_SOURCE="$source" \
+    EASYSFTP_TARGET="$remote" \
+    EASYSFTP_MODE="$mode" \
+    "$binary" >"$log" 2>&1
+}
+
+# step_number <outputs-file> <name>: reads a number written in the
+# GITHUB_OUTPUT heredoc format, 0 when the run died before writing it.
+step_number() {
+  local value
+  value=$(awk -v key="$2" 'index($0, key "<<") == 1 { getline; print; exit }' "$1")
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "$value"
+  else
+    echo 0
+  fi
+}
+
+# count_matches <file> <grep args...>: always prints a number, so the callers
+# can hand it straight to "jq --argjson".
+count_matches() {
+  local file=$1 count
+  shift
+  count=$(grep -c "$@" "$file" 2>/dev/null || true)
+  if [[ "$count" =~ ^[0-9]+$ ]]; then
+    echo "$count"
+  else
+    echo 0
+  fi
+}
+
+# measure <label> <binary> <ref> <scenario> <repeat>
+measure() {
+  local label=$1 binary=$2 ref=$3 scenario=$4 repeat=$5
+  local remote="$REMOTE_BASE/$label/$scenario"
+  local stem="$LOG_DIR/$label-$scenario-$repeat"
+  local code=0
+
+  # Unmeasured: every repeat starts from the same empty remote directory, so
+  # repeat 1 (uploading into nothing) measures the same thing as the repeats
+  # after it (which would otherwise overwrite existing files).
+  if ! run_easysftp "$binary" "$DATASET_DIR/empty" "$remote" clean "$stem.clean.log" "$stem.clean.out"; then
+    echo "::warning::pre-clean of $label/$scenario repeat $repeat failed"
+    cat "$stem.clean.log"
+  fi
+
+  run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" overlay "$stem.log" "$stem.out" || code=$?
+  if ((code != 0)); then
+    # Into the job log, which masks secrets. Never into the artifact.
+    echo "::warning::$label/$scenario repeat $repeat exited $code"
+    cat "$stem.log"
+  fi
+
+  jq -nc \
+    --arg label "$label" \
+    --arg ref "$ref" \
+    --arg scenario "$scenario" \
+    --argjson repeat "$repeat" \
+    --argjson exit_code "$code" \
+    --argjson duration_ms "$(step_number "$stem.out" duration-ms)" \
+    --argjson files "$(step_number "$stem.out" files-uploaded)" \
+    --argjson bytes "$(step_number "$stem.out" bytes-uploaded)" \
+    --argjson retries "$(count_matches "$stem.log" -e retrying -e reconnecting)" \
+    --argjson errors "$(count_matches "$stem.log" '^::error::')" \
+    '$ARGS.named' >>"$runs_file"
+
+  echo "$label/$scenario repeat $repeat: $(step_number "$stem.out" duration-ms) ms, exit $code"
+}
+
+labels=(candidate)
+binaries=("$CANDIDATE_BIN")
+refs=("$CANDIDATE_REF")
+if [[ -n "$BASELINE_BIN" ]]; then
+  labels+=(baseline)
+  binaries+=("$BASELINE_BIN")
+  refs+=("${BASELINE_REF:-unknown}")
+fi
+
+generate_dataset
+
+for scenario in "${SCENARIOS[@]}"; do
+  for ((repeat = 1; repeat <= REPEATS; repeat++)); do
+    for i in "${!labels[@]}"; do
+      measure "${labels[$i]}" "${binaries[$i]}" "${refs[$i]}" "$scenario" "$repeat"
+    done
+  done
+done
+
+# Leave the benchmark directories empty so the payload does not linger on the
+# server. Best effort: a cleanup hiccup must not hide the results.
+for scenario in "${SCENARIOS[@]}"; do
+  for i in "${!labels[@]}"; do
+    stem="$LOG_DIR/cleanup-${labels[$i]}-$scenario"
+    run_easysftp "${binaries[$i]}" "$DATASET_DIR/empty" \
+      "$REMOTE_BASE/${labels[$i]}/$scenario" clean "$stem.log" "$stem.out" ||
+      echo "::warning::cleanup of ${labels[$i]}/$scenario failed"
+  done
+done
+
+jq -s '
+  def median: sort | .[(((length - 1) / 2) | floor)];
+  group_by([.label, .scenario])
+  | map({
+      label: .[0].label,
+      ref: .[0].ref,
+      scenario: .[0].scenario,
+      repeats: length,
+      failed_runs: (map(select(.exit_code != 0)) | length),
+      files: (map(.files) | max),
+      bytes: (map(.bytes) | max),
+      durations_ms: map(.duration_ms),
+      median_ms: (map(.duration_ms) | median),
+      min_ms: (map(.duration_ms) | min),
+      max_ms: (map(.duration_ms) | max),
+      retries: (map(.retries) | add),
+      errors: (map(.errors) | add)
+    })
+  | map(. + {
+      mib_per_s: (if .median_ms > 0 then (.bytes / 1048576) / (.median_ms / 1000) else 0 end),
+      files_per_s: (if .median_ms > 0 then .files / (.median_ms / 1000) else 0 end)
+    })
+' "$runs_file" >"$aggregate_file"
+
+jq -n \
+  --slurpfile results "$aggregate_file" \
+  --arg candidate_ref "$CANDIDATE_REF" \
+  --arg baseline_ref "$BASELINE_REF" \
+  --argjson repeats "$REPEATS" \
+  --arg runner "$(uname -sr), $(nproc) cpu" \
+  '{
+     candidate_ref: $candidate_ref,
+     baseline_ref: $baseline_ref,
+     repeats: $repeats,
+     runner: $runner,
+     settings: "easySFTP defaults (no advanced.* overrides): concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay",
+     scenarios: {
+       small: "300 files x 4 KiB",
+       mixed: "40 x 16 KiB + 12 x 256 KiB + 4 x 2 MiB",
+       large: "2 files x 16 MiB"
+     },
+     results: $results[0]
+   }' >"$OUT_DIR/results.json"
+
+# summary.md carries the same numbers, readable. The delta column compares the
+# candidate's median against the baseline's; negative means faster.
+{
+  echo "## easySFTP benchmark"
+  echo
+  echo "| Setting | Value |"
+  echo "|---|---|"
+  echo "| Candidate | \`$CANDIDATE_REF\` |"
+  echo "| Baseline | \`${BASELINE_REF:-none}\` |"
+  echo "| Repeats per scenario | $REPEATS |"
+  echo "| Runner | $(uname -sr), $(nproc) cpu |"
+  echo "| Settings | easySFTP defaults: concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay |"
+  echo
+  echo "| Scenario | Build | Files | Size | Median | Min | Max | MiB/s | files/s | Retries | Errors | Failed runs | Delta |"
+  echo "|---|---|---|---|---|---|---|---|---|---|---|---|---|"
+  for scenario in "${SCENARIOS[@]}"; do
+    baseline_median=$(jq -r --arg s "$scenario" \
+      'map(select(.scenario == $s and .label == "baseline")) | .[0].median_ms // empty' "$aggregate_file")
+    for label in "${labels[@]}"; do
+      row=$(jq -r --arg s "$scenario" --arg l "$label" '
+        map(select(.scenario == $s and .label == $l)) | .[0]
+        | [.files, (.bytes / 1048576 * 10 | round / 10),
+           .median_ms, .min_ms, .max_ms,
+           (.mib_per_s * 10 | round / 10), (.files_per_s * 10 | round / 10),
+           .retries, .errors, .failed_runs]
+        | @tsv' "$aggregate_file")
+      IFS=$'\t' read -r files mib median min max mibs fps retries errors failed <<<"$row"
+      delta='-'
+      if [[ "$label" == candidate && -n "$baseline_median" && "$baseline_median" != 0 ]]; then
+        delta=$(awk -v c="$median" -v b="$baseline_median" 'BEGIN { printf "%+.1f%%", (c - b) / b * 100 }')
+      fi
+      echo "| $scenario | $label | $files | ${mib} MiB | ${median} ms | ${min} ms | ${max} ms | $mibs | $fps | $retries | $errors | $failed | $delta |"
+    done
+  done
+  echo
+  echo "Data only: these numbers set no threshold and fail no build. Collected to evaluate the single-connection ceiling discussed in issue #158."
+} >"$OUT_DIR/summary.md"
+
+cat "$OUT_DIR/summary.md"


### PR DESCRIPTION
Closes #169.

## What

A `workflow_dispatch`-only benchmark that measures easySFTP upload throughput against a real SFTP server, so the connection-pool question in #158 can be decided on numbers instead of on reading the code.

- `.github/workflows/benchmark.yml`: owner-only, fixed `ubuntu-24.04` image, one run at a time (`concurrency: sftp-benchmark`). Builds the candidate ref and an optional baseline ref in the same job, runs the benchmark, publishes a job summary and uploads the results as an artifact.
- `scripts/benchmark.sh`: the whole measurement. Generates three fixed datasets, runs each scenario `repeats` times per build, and writes `results.json` plus `summary.md`.
- `.github/workflows/ci.yml`: a smoke test of the harness in the existing self-test job, against the local `atmoz/sftp` container. The real benchmark needs secrets and an external host, so that container is the only place the plumbing (binary invocation, step-output parsing, JSON/Markdown aggregation) can be exercised on every push. It also asserts the benchmark cleans up after itself.

## Scenarios

| Scenario | Payload | What it stresses |
|---|---|---|
| `small` | 300 x 4 KiB | per-file round-trip overhead |
| `mixed` | 40 x 16 KiB + 12 x 256 KiB + 4 x 2 MiB | a built website |
| `large` | 2 x 16 MiB | raw transfer throughput |

Recorded per scenario and build: median, min and max duration, MiB/s, files/s, retries, errors and failed runs, plus the ref, the runner and the effective settings. Raw per-run durations stay in `results.json`.

## Decisions worth reviewing

- **Interleaved, not blocked.** Candidate and baseline alternate repeat by repeat. A shared host's throughput drifts over minutes; two blocks would charge that drift to whichever build ran second.
- **Pre-clean is not measured.** Every repeat wipes its remote directory first (unmeasured), so repeat 1 (uploading into an empty directory) measures the same thing as the repeats after it, which would otherwise overwrite.
- **Median is the lower middle value** on an even repeat count, which is why an odd `repeats` is the better choice. Default 3.
- **Run logs never reach the artifact.** They name the host and the user, both secrets here, and artifacts are not masked. The script refuses to start if `LOG_DIR` is inside `OUT_DIR`; failures are dumped into the job log instead, where GitHub masks secrets.
- **Inline mode, stock settings.** No config file, so the run uses easySFTP's defaults (concurrency 4, request_concurrency 16, retries 2, timeout 30s) and records them. A knob for `advanced.*` is deliberately not built yet: whoever tries a connection pool can add exactly the knob that experiment needs.
- **Data only.** No threshold fails anything, per the issue.
- Refs come in through the environment, never interpolated into a `run:` block.

## Setup still needed (manual, in GitHub)

Repository secrets:

| Secret | Value |
|---|---|
| `BENCHMARK_SFTP_HOST` | host name of the benchmark webspace |
| `BENCHMARK_SFTP_USERNAME` | SFTP user name |
| `BENCHMARK_SFTP_PASSWORD` | SFTP password |
| `BENCHMARK_SFTP_KNOWN_HOSTS` | verbatim output of `ssh-keyscan <host>` |

The host key is pinned like in any other easySFTP run, so `BENCHMARK_SFTP_KNOWN_HOSTS` is required, not optional. There is no opt-out in this workflow.

The account must be a throwaway one: everything below `<remote-base>/<build>/<scenario>` (default base `/easysftp-benchmark`) is wiped before every repeat and again at the end.

## Verification

- `bash -n scripts/benchmark.sh` locally; shellcheck and the harness smoke test run in CI here (no local shellcheck/jq/Docker on this machine).
- The benchmark workflow itself cannot run until the secrets exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
