### PR TITLE
ci: store benchmark results per release in benchmarks/

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,27 @@
 name: SFTP benchmark
 
-# Manually triggered throughput measurement against a real SFTP server
-# (issue #169). It collects data only: no threshold here fails anything, since
-# run-to-run variance against an external host is not understood yet.
+# Throughput measurement against a real SFTP server (issue #169), plus the
+# bookkeeping that turns a measurement into a permanent entry in benchmarks/.
+#
+# It collects data only: no threshold here fails anything, since run-to-run
+# variance against an external host is not understood yet.
+#
+# Three ways in:
+#   workflow_dispatch  a manual or experimental run of any ref, or of a PR via
+#                      the "pr" input. Stored as a *manual* result, which never
+#                      becomes an official reference.
+#   pull_request       every release PR is benchmarked once when it opens, so
+#                      the numbers are visible before the merge. Nothing is
+#                      stored: the release is not real yet.
+#   release            after the release PR merged and release-please published
+#                      the tag, the tagged code is measured once more and that
+#                      result is committed as the official reference.
+#
+# Approval: the "benchmark" environment is the gate for manual and release-PR
+# runs. Give it required reviewers in the repository settings, otherwise every
+# account with write access can start a run against the external host. The
+# automatic post-release run uses "benchmark-release", which is meant to stay
+# unprotected so a release does not wait for a click.
 #
 # Required repository secrets:
 #   BENCHMARK_SFTP_HOST         host name of the benchmark server
@@ -19,6 +38,10 @@ name: SFTP benchmark
 on:
   workflow_dispatch:
     inputs:
+      pr:
+        description: "Pull request number to benchmark. Wins over candidate-ref."
+        required: false
+        type: string
       candidate-ref:
         description: "Ref (branch, tag or SHA) to benchmark. Defaults to the ref this workflow was started from."
         required: false
@@ -42,12 +65,20 @@ on:
         required: false
         default: "22"
         type: string
+  # Release PRs only; the job-level "if" below drops every other pull request.
+  # "opened" and not "synchronize": release-please rewrites its branch on every
+  # push to main, and one preview measurement per release PR is enough.
+  pull_request:
+    types: [opened, reopened]
+  release:
+    types: [published]
 
 permissions:
   contents: read
 
 # One benchmark at a time: two runs sharing the host would measure each other,
-# and they would also fight over the same remote directories.
+# they would also fight over the same remote directories, and the storing step
+# would race for a push to main.
 concurrency:
   group: sftp-benchmark
   cancel-in-progress: false
@@ -55,21 +86,70 @@ concurrency:
 jobs:
   benchmark:
     name: Benchmark SFTP throughput
-    # The secrets already require write access to reach; this is the explicit
-    # owner-only gate issue #169 asks for.
-    if: github.actor == github.repository_owner
+    if: >-
+      github.event_name != 'pull_request' ||
+      startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    # The maintainer gate issue #169 asks for. See the header: protect
+    # "benchmark" with required reviewers, leave "benchmark-release" open.
+    environment: ${{ github.event_name == 'release' && 'benchmark-release' || 'benchmark' }}
+    permissions:
+      # Only the release run pushes, but the token is scoped per job.
+      contents: write
     steps:
       # The workflow's own checkout, for scripts/benchmark.sh. It runs first:
       # a root checkout cleans the workspace and would remove the build
       # checkouts below.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Resolve what to benchmark
+        id: resolve
+        env:
+          # Through the environment, never interpolated into the script: these
+          # are user input, and "${{ }}" in a run block is a shell injection.
+          EVENT: ${{ github.event_name }}
+          PR: ${{ inputs.pr }}
+          CANDIDATE: ${{ inputs.candidate-ref }}
+          TAG: ${{ github.event.release.tag_name }}
+          FALLBACK: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          case "$EVENT" in
+          release)
+            ref=$TAG
+            label=$TAG
+            ;;
+          *)
+            if [ -n "${PR:-}" ]; then
+              case "$PR" in
+              '' | *[!0-9]*)
+                echo "::error::pr must be a number, got '$PR'"
+                exit 1
+                ;;
+              esac
+              ref=refs/pull/$PR/merge
+              label=pr-$PR
+            elif [ -n "${CANDIDATE:-}" ]; then
+              ref=$CANDIDATE
+              label=$CANDIDATE
+            else
+              ref=$FALLBACK
+              label=${GITHUB_REF_NAME:-manual}
+            fi
+            ;;
+          esac
+          {
+            echo "ref=$ref"
+            echo "label=$label"
+            echo "recorded-at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_OUTPUT"
+          echo "benchmarking $ref"
+
       - name: Check out the candidate
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.candidate-ref || github.sha }}
+          ref: ${{ steps.resolve.outputs.ref }}
           path: builds/candidate
 
       - name: Check out the baseline
@@ -88,11 +168,8 @@ jobs:
         id: build
         env:
           CGO_ENABLED: "0"
-          # Through the environment, never interpolated into the script: a ref
-          # is user input, and "${{ }}" in a run block is a shell injection.
-          CANDIDATE_REF_INPUT: ${{ inputs.candidate-ref }}
+          CANDIDATE_REF_INPUT: ${{ steps.resolve.outputs.ref }}
           BASELINE_REF_INPUT: ${{ inputs.baseline-ref }}
-          DEFAULT_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/bin"
@@ -101,7 +178,11 @@ jobs:
             ( cd "$dir" && go build -trimpath -ldflags="-s -w" -o "$RUNNER_TEMP/bin/$name" ./cmd/easysftp )
           }
           build builds/candidate easysftp-candidate
-          echo "candidate-ref=${CANDIDATE_REF_INPUT:-$DEFAULT_REF} ($(git -C builds/candidate rev-parse --short HEAD))" >> "$GITHUB_OUTPUT"
+          candidate_sha=$(git -C builds/candidate rev-parse HEAD)
+          {
+            echo "candidate-ref=$CANDIDATE_REF_INPUT ($(git -C builds/candidate rev-parse --short HEAD))"
+            echo "candidate-sha=$candidate_sha"
+          } >> "$GITHUB_OUTPUT"
           if [ -n "$BASELINE_REF_INPUT" ]; then
             build builds/baseline easysftp-baseline
             {
@@ -116,15 +197,15 @@ jobs:
           CANDIDATE_REF: ${{ steps.build.outputs.candidate-ref }}
           BASELINE_BIN: ${{ steps.build.outputs.baseline-bin }}
           BASELINE_REF: ${{ steps.build.outputs.baseline-ref }}
-          REPEATS: ${{ inputs.repeats }}
-          REMOTE_BASE: ${{ inputs.remote-base }}
+          REPEATS: ${{ inputs.repeats || '3' }}
+          REMOTE_BASE: ${{ inputs.remote-base || '/easysftp-benchmark' }}
           # OUT_DIR is uploaded as an artifact; LOG_DIR (which holds logs that
           # name the host and user) deliberately is not.
           OUT_DIR: ${{ runner.temp }}/benchmark-results
           LOG_DIR: ${{ runner.temp }}/benchmark-logs
           DATASET_DIR: ${{ runner.temp }}/benchmark-data
           BENCH_HOST: ${{ secrets.BENCHMARK_SFTP_HOST }}
-          BENCH_PORT: ${{ inputs.port }}
+          BENCH_PORT: ${{ inputs.port || '22' }}
           BENCH_USERNAME: ${{ secrets.BENCHMARK_SFTP_USERNAME }}
           BENCH_PASSWORD: ${{ secrets.BENCHMARK_SFTP_PASSWORD }}
           BENCH_KNOWN_HOSTS: ${{ secrets.BENCHMARK_SFTP_KNOWN_HOSTS }}
@@ -141,3 +222,50 @@ jobs:
           name: benchmark-${{ github.run_id }}
           path: ${{ runner.temp }}/benchmark-results
           if-no-files-found: ignore
+
+      # Everything below stores the result in benchmarks/ on main. A release PR
+      # run (pull_request) stops here: nothing has been released yet.
+      - name: Check out main for storing
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          path: store-main
+          # Full history: the commit below rebases onto whatever landed on main
+          # while the benchmark was running, which a shallow clone cannot do.
+          fetch-depth: 0
+
+      - name: Store the result
+        if: github.event_name != 'pull_request'
+        env:
+          BENCH_DIR: store-main/benchmarks
+          RESULTS_JSON: ${{ runner.temp }}/benchmark-results/results.json
+          SUMMARY_MD: ${{ runner.temp }}/benchmark-results/summary.md
+          KIND: ${{ github.event_name == 'release' && 'release' || 'manual' }}
+          VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+          LABEL: ${{ steps.resolve.outputs.label }}
+          RECORDED_AT: ${{ steps.resolve.outputs.recorded-at }}
+          COMMIT: ${{ steps.build.outputs.candidate-sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/benchmark-store.sh
+
+      - name: Commit the result to main
+        if: github.event_name != 'pull_request'
+        working-directory: store-main
+        env:
+          KIND: ${{ github.event_name == 'release' && 'release' || 'manual' }}
+          NAME: ${{ github.event_name == 'release' && github.event.release.tag_name || steps.resolve.outputs.label }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add benchmarks
+          if git diff --cached --quiet; then
+            echo "nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: store $KIND benchmark for $NAME"
+          # main usually moved on during a run that takes minutes; only new
+          # files are added here, so replaying them on top is safe.
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
         shell: bash
         run: bash scripts/test-action.sh
 
+      # Linux only: the benchmark workflow runs on ubuntu-24.04, so that is the
+      # only platform this bookkeeping has to work on.
+      - name: Test benchmark storage and retention
+        if: runner.os == 'Linux'
+        run: bash scripts/test-benchmark-store.sh
+
       - name: Validate action metadata
         run: go test ./internal/actionmeta
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,19 @@ granularity is a separate, later decision; don't build it speculatively.
   wiring runs end to end. Unit tests set `EASYSFTP_*` directly and never see
   declared input defaults, which is how #62 shipped green.
 
+## Benchmarks
+
+`scripts/benchmark.sh` measures, `scripts/benchmark-store.sh` files the result
+under `benchmarks/`; `benchmarks/README.md` documents the layout and is the
+page to keep in sync when either script changes. Read `benchmarks/index.json`
+before opening single files.
+
+Two invariants the whole thing rests on: a stored result is never rewritten
+(storing an existing name fails), and `latest.*` is only ever a copy of a
+`kind: "release"` entry, so a manual run cannot become an official number.
+`scripts/test-benchmark-store.sh` (run by CI, needs `jq`) pins the retention
+window, the archiving and both invariants.
+
 ## Behavior worth knowing before you change it
 
 - Uploads from **Windows runners** have no local permission bits to mirror:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,83 @@
+# Benchmarks
+
+Upload throughput of easySFTP against a real SFTP server, measured by
+[`scripts/benchmark.sh`](../scripts/benchmark.sh) and filed here by
+[`scripts/benchmark-store.sh`](../scripts/benchmark-store.sh).
+
+These numbers set no threshold and fail no build. They exist to see where the
+time goes (issues #158 and #169), so read them as one host's behaviour on one
+day, not as a guarantee.
+
+## Where to look first
+
+| You want | Read |
+|---|---|
+| The current official numbers | `latest.md` (`latest.json` for the raw data) |
+| A listing of everything stored here | `index.json` |
+| One specific release | `release-vX.Y.Z.md` / `.json` |
+| An older release | `archive/release-vX.Y.Z.*` |
+
+## What is in here
+
+```text
+benchmarks/
+  latest.json                        copy of the newest official release result
+  latest.md                          the same, human readable
+  index.json                         every stored result, machine readable
+  release-vX.Y.Z.json                official reference of a release
+  release-vX.Y.Z.md
+  manual-<UTC stamp>-<label>.json    manual or experimental run
+  manual-<UTC stamp>-<label>.md
+  archive/                           the same file names, past the keep window
+```
+
+Every result is a pair: the raw JSON and a Markdown summary of the same run.
+The JSON wraps the measurement verbatim under `.benchmark` and adds provenance
+around it:
+
+```jsonc
+{
+  "schema_version": 1,
+  "kind": "release",        // or "manual"
+  "version": "v3.2.2",      // null for manual runs
+  "label": null,            // the manual run's label, null for releases
+  "official": true,         // false for everything that is not a release
+  "recorded_at": "2026-07-27T12:00:00Z",
+  "commit": "…",
+  "run_url": "…",
+  "benchmark": { /* results.json from scripts/benchmark.sh */ }
+}
+```
+
+`index.json` lists all of them newest first, with `kind`, `official`,
+`archived`, the paths of both files, and the candidate's median milliseconds
+per scenario, so a reader (human or agent) does not have to open every file.
+
+## Official versus manual
+
+- **Official** results are `kind: "release"`. They are measured automatically
+  after release-please published a tag, against exactly that tag, and they are
+  the only results `latest.*` is ever copied from.
+- **Manual** results are `kind: "manual"`, produced by a manually started run
+  (a branch, a tag, or a pull request). They are kept alongside the official
+  ones and are clearly named, but they never become a reference and never
+  overwrite one.
+- Release PRs are benchmarked once when they open, so the numbers are visible
+  before the merge. That run stores nothing: its result belongs to a release
+  that does not exist yet. The official file is the post-tag measurement.
+
+## Retention
+
+The current release and the four before it stay in `benchmarks/`. Older
+releases move to `benchmarks/archive/`, and manual runs move with them once
+they are older than the oldest kept release. Nothing is ever deleted or
+rewritten: storing a name that already exists fails on purpose, so a number
+that was once published stays exactly as it was published.
+
+## Running a benchmark
+
+The `SFTP benchmark` workflow (`.github/workflows/benchmark.yml`) runs it.
+Start it manually from the Actions tab with a `pr` number to benchmark a pull
+request, or a `candidate-ref` plus an optional `baseline-ref` to compare two
+refs in the same run. A manual run needs an approval on the `benchmark`
+environment first, which only a maintainer can give.

--- a/benchmarks/index.json
+++ b/benchmarks/index.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "generated_at": null,
+  "generated_by": "scripts/benchmark-store.sh",
+  "documentation": "benchmarks/README.md",
+  "keep_releases": 5,
+  "latest_release": null,
+  "entries": []
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -52,6 +52,22 @@ version tags or releases by hand.
    `docs/configuration.md`, and `docs/security.md`, plus the README
    "Versioning" section. They do not update themselves (see issue #63).
 
+## Benchmarks around a release
+
+The `SFTP benchmark` workflow rides along with this flow and needs no manual
+step:
+
+- When the release PR opens, it is benchmarked once and the numbers appear in
+  that run's job summary. Nothing is stored yet.
+- After the release is published, the tagged code is benchmarked again and the
+  result is committed to `main` as the official reference for that version,
+  together with an updated `benchmarks/latest.json` and `benchmarks/latest.md`.
+- Releases older than the current one plus four move to `benchmarks/archive/`.
+
+Both runs need the `BENCHMARK_SFTP_*` secrets. Without them the benchmark job
+fails, which does not block the release: it runs beside the release pipeline,
+not inside it. See [`benchmarks/README.md`](../benchmarks/README.md).
+
 ## Stable asset names
 
 ```text

--- a/scripts/benchmark-store.sh
+++ b/scripts/benchmark-store.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#
+# Store one benchmark result set in benchmarks/.
+#
+# scripts/benchmark.sh measures and writes results.json plus summary.md into a
+# throwaway directory. This script turns such a pair into a permanent entry:
+#
+#   benchmarks/release-vX.Y.Z.{json,md}          official reference of a release
+#   benchmarks/manual-<stamp>-<label>.{json,md}  manual or experimental run
+#   benchmarks/latest.{json,md}                  copy of the newest kept release
+#   benchmarks/index.json                        machine readable listing
+#   benchmarks/archive/                          everything past the keep window
+#
+# Two rules the callers depend on:
+#   - A stored file is never rewritten. Storing a name that already exists
+#     fails, in benchmarks/ and in benchmarks/archive/ alike.
+#   - latest.* is only ever a copy of a release entry, so a manual run can
+#     never overwrite an official number.
+#
+# Only latest.*, index.json and the archive/ moves change on a later run; the
+# historical files themselves are moved, never edited.
+#
+# Environment:
+#   RESULTS_JSON    results.json from scripts/benchmark.sh (required)
+#   SUMMARY_MD      summary.md from scripts/benchmark.sh (required)
+#   KIND            "release" or "manual" (required)
+#   VERSION         vMAJOR.MINOR.PATCH, required when KIND=release
+#   LABEL           short slug for a manual run (default "manual")
+#   RECORDED_AT     ISO 8601 UTC timestamp (default: now)
+#   COMMIT          commit the benchmarked build came from (optional)
+#   RUN_URL         workflow run that produced it (optional)
+#   BENCH_DIR       target directory (default "benchmarks")
+#   KEEP_RELEASES   releases kept outside archive/ (default 5: current plus 4)
+
+set -euo pipefail
+
+BENCH_DIR=${BENCH_DIR:-benchmarks}
+KEEP_RELEASES=${KEEP_RELEASES:-5}
+RECORDED_AT=${RECORDED_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
+LABEL=${LABEL:-manual}
+VERSION=${VERSION:-}
+COMMIT=${COMMIT:-}
+RUN_URL=${RUN_URL:-}
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+[[ -n ${RESULTS_JSON:-} ]] || die "RESULTS_JSON is required"
+[[ -n ${SUMMARY_MD:-} ]] || die "SUMMARY_MD is required"
+[[ -f $RESULTS_JSON ]] || die "RESULTS_JSON ('$RESULTS_JSON') does not exist"
+[[ -f $SUMMARY_MD ]] || die "SUMMARY_MD ('$SUMMARY_MD') does not exist"
+jq -e . "$RESULTS_JSON" >/dev/null || die "RESULTS_JSON ('$RESULTS_JSON') is not valid JSON"
+[[ $KEEP_RELEASES =~ ^[1-9][0-9]*$ ]] || die "KEEP_RELEASES must be a positive integer, got '$KEEP_RELEASES'"
+[[ $RECORDED_AT =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] ||
+  die "RECORDED_AT must look like 2026-07-27T12:00:00Z, got '$RECORDED_AT'"
+
+slug=""
+case ${KIND:-} in
+release)
+  # Exactly the tag release-please creates: anything else sorts wrong here and
+  # does not line up with .easysftp-version.
+  [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    die "VERSION must be vMAJOR.MINOR.PATCH for a release benchmark, got '$VERSION'"
+  stem="release-$VERSION"
+  title="release $VERSION"
+  kind_note="official reference"
+  ;;
+manual)
+  # LABEL is a workflow input: keep it inside BENCH_DIR, and inside what a
+  # Windows checkout can write (no colons, so the timestamp loses them too).
+  slug=${LABEL//[^A-Za-z0-9._-]/-}
+  [[ -n ${slug//-/} ]] || die "LABEL must contain at least one letter or digit"
+  stem="manual-$(printf '%s' "$RECORDED_AT" | tr -d ':-')-$slug"
+  title="manual run $slug"
+  kind_note="not an official reference"
+  VERSION=""
+  ;;
+*)
+  die "KIND must be 'release' or 'manual', got '${KIND:-}'"
+  ;;
+esac
+
+mkdir -p "$BENCH_DIR"
+
+for existing in "$BENCH_DIR/$stem".{json,md} "$BENCH_DIR/archive/$stem".{json,md}; do
+  if [[ -e $existing ]]; then
+    die "$existing already exists: stored benchmarks are never rewritten"
+  fi
+done
+
+# The envelope keeps the measurement verbatim under .benchmark and adds only
+# provenance around it, so a reader never has to guess which run a number is.
+jq -n \
+  --arg kind "$KIND" \
+  --arg version "$VERSION" \
+  --arg label "$slug" \
+  --arg recorded_at "$RECORDED_AT" \
+  --arg commit "$COMMIT" \
+  --arg run_url "$RUN_URL" \
+  --slurpfile benchmark "$RESULTS_JSON" \
+  '{
+     schema_version: 1,
+     kind: $kind,
+     version: (if $version == "" then null else $version end),
+     label: (if $label == "" then null else $label end),
+     official: ($kind == "release"),
+     recorded_at: $recorded_at,
+     commit: (if $commit == "" then null else $commit end),
+     run_url: (if $run_url == "" then null else $run_url end),
+     benchmark: $benchmark[0]
+   }' >"$BENCH_DIR/$stem.json"
+
+{
+  echo "# easySFTP benchmark: $title"
+  echo
+  echo "| Field | Value |"
+  echo "|---|---|"
+  echo "| Kind | $KIND ($kind_note) |"
+  if [[ -n $VERSION ]]; then echo "| Version | \`$VERSION\` |"; fi
+  echo "| Recorded | $RECORDED_AT |"
+  if [[ -n $COMMIT ]]; then echo "| Commit | \`$COMMIT\` |"; fi
+  if [[ -n $RUN_URL ]]; then echo "| Workflow run | $RUN_URL |"; fi
+  echo "| Raw data | [$stem.json]($stem.json) |"
+  echo
+  cat "$SUMMARY_MD"
+} >"$BENCH_DIR/$stem.md"
+
+# list_stems <path>...: base names without the .json suffix, one per line.
+# Unmatched globs arrive as their own pattern and are skipped.
+list_stems() {
+  local f base
+  for f in "$@"; do
+    [[ -e $f ]] || continue
+    base=${f##*/}
+    echo "${base%.json}"
+  done
+}
+
+archive() {
+  local name=$1
+  mkdir -p "$BENCH_DIR/archive"
+  mv "$BENCH_DIR/$name.json" "$BENCH_DIR/archive/$name.json"
+  if [[ -e "$BENCH_DIR/$name.md" ]]; then
+    mv "$BENCH_DIR/$name.md" "$BENCH_DIR/archive/$name.md"
+  fi
+  echo "archived $name"
+}
+
+# Releases are kept by version order, not by date: a late benchmark of an old
+# release must not push a newer one out of the window.
+releases=()
+while IFS= read -r version; do
+  releases+=("$version")
+done < <(list_stems "$BENCH_DIR"/release-v*.json | sed 's/^release-//' | sort -V)
+
+if ((${#releases[@]} > KEEP_RELEASES)); then
+  drop=$((${#releases[@]} - KEEP_RELEASES))
+  for ((i = 0; i < drop; i++)); do
+    archive "release-${releases[i]}"
+  done
+  releases=("${releases[@]:drop}")
+fi
+
+newest=""
+cutoff=""
+if ((${#releases[@]} > 0)); then
+  newest=${releases[-1]}
+  cp "$BENCH_DIR/release-$newest.json" "$BENCH_DIR/latest.json"
+  cp "$BENCH_DIR/release-$newest.md" "$BENCH_DIR/latest.md"
+
+  kept=()
+  for version in "${releases[@]}"; do
+    kept+=("$BENCH_DIR/release-$version.json")
+  done
+  cutoff=$(jq -rs 'map(.recorded_at) | min' "${kept[@]}")
+fi
+
+# Manual runs follow the same window: anything recorded before the oldest kept
+# release is history too. ISO 8601 UTC compares correctly as a string.
+if [[ -n $cutoff && $cutoff != null ]]; then
+  while IFS= read -r name; do
+    recorded=$(jq -r '.recorded_at // ""' "$BENCH_DIR/$name.json")
+    if [[ -n $recorded && $recorded < $cutoff ]]; then
+      archive "$name"
+    fi
+  done < <(list_stems "$BENCH_DIR"/manual-*.json)
+fi
+
+# index.json is the entry point for anything that reads this directory without
+# opening every file, agents included.
+entries() {
+  local f rel
+  for f in "$@"; do
+    rel=${f#"$BENCH_DIR"/}
+    jq -c --arg path "$rel" '{
+      kind: .kind,
+      version: .version,
+      label: .label,
+      official: .official,
+      recorded_at: .recorded_at,
+      commit: .commit,
+      run_url: .run_url,
+      candidate_ref: (.benchmark.candidate_ref // null),
+      archived: ($path | startswith("archive/")),
+      json: $path,
+      markdown: ($path | sub("\\.json$"; ".md")),
+      median_ms: (.benchmark.results // []
+        | map(select(.label == "candidate"))
+        | map({key: .scenario, value: .median_ms})
+        | from_entries)
+    }' "$f"
+  done
+}
+
+stored=()
+for path in "$BENCH_DIR"/release-v*.json "$BENCH_DIR"/manual-*.json \
+  "$BENCH_DIR"/archive/release-v*.json "$BENCH_DIR"/archive/manual-*.json; do
+  if [[ -e $path ]]; then
+    stored+=("$path")
+  fi
+done
+
+entries "${stored[@]}" | jq -s \
+  --arg generated "$RECORDED_AT" \
+  --arg latest "$newest" \
+  --argjson keep "$KEEP_RELEASES" \
+  '{
+     schema_version: 1,
+     generated_at: $generated,
+     generated_by: "scripts/benchmark-store.sh",
+     documentation: "benchmarks/README.md",
+     keep_releases: $keep,
+     latest_release: (if $latest == "" then null else $latest end),
+     entries: (sort_by(.recorded_at) | reverse)
+   }' >"$BENCH_DIR/index.json"
+
+echo "stored $stem.json and $stem.md in $BENCH_DIR"

--- a/scripts/test-benchmark-store.sh
+++ b/scripts/test-benchmark-store.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Self-check for scripts/benchmark-store.sh: retention window, archiving,
+# the latest.* pointer and the refusal to rewrite a stored result. Runs
+# against a temporary directory, never against the repository's benchmarks/.
+
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+export BENCH_DIR="$work/benchmarks"
+results="$work/results.json"
+summary="$work/summary.md"
+
+cat >"$results" <<'JSON'
+{
+  "candidate_ref": "test-ref",
+  "baseline_ref": "",
+  "repeats": 1,
+  "results": [
+    { "label": "candidate", "scenario": "small", "median_ms": 1000 },
+    { "label": "baseline", "scenario": "small", "median_ms": 1200 }
+  ]
+}
+JSON
+echo "## easySFTP benchmark" >"$summary"
+
+failures=0
+
+pass() { echo "PASS: $1"; }
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+store() { # store <kind> <version-or-label> <recorded_at>
+  local kind=$1 name=$2 stamp=$3 version=""
+  if [[ $kind == release ]]; then
+    version=$name
+  fi
+  RESULTS_JSON="$results" SUMMARY_MD="$summary" \
+    KIND="$kind" VERSION="$version" LABEL="$name" RECORDED_AT="$stamp" \
+    bash "$repo_root/scripts/benchmark-store.sh" >/dev/null
+}
+
+expect_file() {
+  if [[ -e "$BENCH_DIR/$1" ]]; then pass "$1 exists"; else fail "$1 is missing"; fi
+}
+
+expect_absent() {
+  if [[ -e "$BENCH_DIR/$1" ]]; then fail "$1 should not exist"; else pass "$1 absent"; fi
+}
+
+expect_equal() {
+  local description=$1 expected=$2 actual=$3
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$description"
+  else
+    fail "$description: expected '$expected', got '$actual'"
+  fi
+}
+
+expect_failure() {
+  local description=$1
+  shift
+  if "$@" >/dev/null 2>&1; then
+    fail "$description unexpectedly succeeded"
+  else
+    pass "$description"
+  fi
+}
+
+# Eight releases plus two manual runs, oldest first. Three releases fall out
+# of the five-wide window, which is where version order and plain string order
+# disagree: sorted as text, v1.0.10 would be archived and v1.0.2 kept.
+store release v1.0.0 2026-01-01T00:00:00Z
+store manual old-run 2026-01-15T00:00:00Z
+store release v1.0.1 2026-02-01T00:00:00Z
+store release v1.0.2 2026-03-01T00:00:00Z
+store release v1.0.9 2026-04-01T00:00:00Z
+store release v1.0.10 2026-05-01T00:00:00Z
+store release v1.1.0 2026-06-01T00:00:00Z
+store manual new-run 2026-06-15T00:00:00Z
+store release v1.1.1 2026-07-01T00:00:00Z
+store release v1.2.0 2026-08-01T00:00:00Z
+
+for version in v1.0.0 v1.0.1 v1.0.2; do
+  expect_absent "release-$version.json"
+  expect_file "archive/release-$version.json"
+  expect_file "archive/release-$version.md"
+done
+for version in v1.0.9 v1.0.10 v1.1.0 v1.1.1 v1.2.0; do
+  expect_file "release-$version.json"
+  expect_file "release-$version.md"
+done
+
+expect_equal 'latest.json points at the newest release' v1.2.0 \
+  "$(jq -r .version "$BENCH_DIR/latest.json")"
+expect_equal 'latest.md carries the newest release' 1 \
+  "$(grep -c 'release v1.2.0' "$BENCH_DIR/latest.md")"
+
+expect_absent manual-20260115T000000Z-old-run.json
+expect_file archive/manual-20260115T000000Z-old-run.json
+expect_file manual-20260615T000000Z-new-run.json
+expect_equal 'a manual run is not an official reference' false \
+  "$(jq -r .official "$BENCH_DIR/manual-20260615T000000Z-new-run.json")"
+
+expect_equal 'index lists every stored result' 10 \
+  "$(jq '.entries | length' "$BENCH_DIR/index.json")"
+expect_equal 'index marks the archived results' 4 \
+  "$(jq '[.entries[] | select(.archived)] | length' "$BENCH_DIR/index.json")"
+expect_equal 'index names the latest release' v1.2.0 \
+  "$(jq -r .latest_release "$BENCH_DIR/index.json")"
+expect_equal 'index carries the candidate medians' 1000 \
+  "$(jq -r '.entries[0].median_ms.small' "$BENCH_DIR/index.json")"
+expect_equal 'the raw measurement is kept verbatim' test-ref \
+  "$(jq -r .benchmark.candidate_ref "$BENCH_DIR/latest.json")"
+
+expect_failure 'storing a release twice' store release v1.2.0 2026-08-02T00:00:00Z
+expect_failure 'storing an archived release again' store release v1.0.0 2026-08-02T00:00:00Z
+expect_failure 'a non-release version' store release 1.2.0 2026-08-02T00:00:00Z
+expect_failure 'an unknown kind' store nightly whatever 2026-08-02T00:00:00Z
+
+# A manual run must not be able to write outside benchmarks/, whatever the
+# workflow input says.
+store manual '../../escaped run' 2026-08-16T00:00:00Z
+expect_file 'manual-20260816T000000Z-..-..-escaped-run.json'
+expect_absent '../../escaped run.json'
+expect_equal 'latest.json still points at the newest release' v1.2.0 \
+  "$(jq -r .version "$BENCH_DIR/latest.json")"
+
+if ((failures > 0)); then
+  echo "$failures check(s) failed" >&2
+  exit 1
+fi
+echo "all benchmark-store checks passed"


### PR DESCRIPTION
## What & why

The benchmark harness from #170 measures and then discards: `results.json` and
`summary.md` only ever existed as a workflow artifact, so nothing could be
compared across releases and nothing was findable afterwards. This adds the
bookkeeping around it.

`scripts/benchmark-store.sh` turns one measurement into a permanent entry:

```text
benchmarks/release-vX.Y.Z.{json,md}          official reference of a release
benchmarks/manual-<stamp>-<label>.{json,md}  manual or experimental run
benchmarks/latest.{json,md}                  copy of the newest kept release
benchmarks/index.json                        every result, machine readable
benchmarks/archive/                          past the keep window
```

Two invariants everything else rests on:

- A stored file is never rewritten. Storing a name that already exists fails,
  in `benchmarks/` and in `benchmarks/archive/` alike, so a published number
  stays exactly as published.
- `latest.*` is only ever a copy of a `kind: "release"` entry, so a manual run
  can never overwrite an official one.

Retention is the current release plus four, cut by **version** order (`sort -V`),
not by date or string order: a late benchmark of an old release must not push a
newer one out. Manual runs move to `archive/` once they are older than the
oldest kept release.

The workflow gains the three ways in:

| Trigger | What runs | What is stored |
|---|---|---|
| `workflow_dispatch` | any ref, or a PR via the new `pr` input | a `manual` result |
| `pull_request` (release PRs only, on open) | the release PR once | nothing, the release is not real yet |
| `release: published` | the published tag | the official reference, committed to `main` |

## Checklist

- [x] `go test ./...`, `go vet ./...` and `gofmt -l .` are clean (no Go changed)
- [x] Behavior changes have a test: `scripts/test-benchmark-store.sh`, run by CI
- [x] Docs updated where affected: `benchmarks/README.md`, `docs/RELEASING.md`, `CLAUDE.md`
- [x] New external dependency in CI is pinned by full commit SHA (no new ones)
- [x] `CHANGELOG.md` not hand-edited

## Notes for the reviewer

**One thing needs a click in the repository settings.** The job-level
`if: github.actor == github.repository_owner` gate is gone: it would have
blocked the automatic post-release run (the actor there is not the owner) and
it makes "approvable by the maintainer" impossible, which is the other half of
what was asked for. The gate is now the `benchmark` environment, so it must get
**required reviewers**, otherwise every account with write access can start a
run against the external host. The automatic post-release run uses a second
environment, `benchmark-release`, meant to stay unprotected so a release does
not wait for a click. Both environments are created on first use; the
`BENCHMARK_SFTP_*` secrets can stay at repository level.

**Titled `ci:` on purpose.** Nothing in the action changes, only workflows,
scripts and docs, so this should not bump a version. #170 shipped as `feat:`;
that felt like the wrong precedent to continue for benchmark plumbing.

**The release PR run stores nothing.** The requirement read "run on the release
PR, store after the merge". Carrying the PR run's artifact across the merge
means digging the run up via `gh run list` after the fact and having no
recovery when the artifact is gone. Measuring the published tag instead is one
code path, always works, and the numbers then belong to exactly the tagged
code. The release PR is still benchmarked when it opens, so reviewers see the
numbers before merging; the stored file is the post-tag measurement.

Deliberately left out: a PR comment with the numbers (job summary plus artifact
cover it), an automatic baseline comparison against the previous release in the
release run (the stored files make that a lookup), and a separate retention
rule for manual runs. `pull_request` is filtered by a job-level `if` on
`head_ref`, so unrelated PRs show one skipped job.

**Testing.** `scripts/test-benchmark-store.sh` covers the retention window
(eight releases, three archived, including the `v1.0.2` / `v1.0.10` case where
version order and string order disagree), the `latest.*` pointer, manual runs
being archived behind the window, the refusal to rewrite, and label sanitising
(`../../escaped run` stays inside `benchmarks/`). It passed locally, but only
against a hand-written jq stand-in: this machine has no jq, Docker or WSL, so
the bash logic is verified and the jq programs themselves get their first real
run in CI. `shellcheck` also did not run locally for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
