### PR TITLE
fix(ci): call the release benchmark from the release workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,9 +13,16 @@ name: SFTP benchmark
 #   pull_request       every release PR is benchmarked once when it opens, so
 #                      the numbers are visible before the merge. Nothing is
 #                      stored: the release is not real yet.
-#   release            after the release PR merged and release-please published
-#                      the tag, the tagged code is measured once more and that
-#                      result is committed as the official reference.
+#   workflow_call      release-please.yml calls this after it created a release,
+#                      passing the tag as "release-version". The tagged code is
+#                      measured once more and committed as the official
+#                      reference.
+#
+# That last one is a "uses:" call and not an "on: release" trigger on purpose.
+# release-please creates the GitHub Release with the GITHUB_TOKEN, and events
+# raised by that token never start a workflow run, so an "on: release" job
+# silently never runs. v3.3.0 shipped without its benchmark that way. The
+# release-binaries pipeline is wired the same way for the same reason.
 #
 # Approval: the "benchmark" environment is the gate for manual and release-PR
 # runs. Give it required reviewers in the repository settings, otherwise every
@@ -50,6 +57,10 @@ on:
         description: "Optional second ref to benchmark in the same run, for comparison (e.g. main)."
         required: false
         type: string
+      release-version:
+        description: "Repairs a missed release benchmark: measures this tag and stores it as the official reference (e.g. v3.3.0). Refuses to overwrite an existing one."
+        required: false
+        type: string
       repeats:
         description: "Measured repeats per scenario; the median is reported."
         required: false
@@ -70,8 +81,12 @@ on:
   # push to main, and one preview measurement per release PR is enough.
   pull_request:
     types: [opened, reopened]
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      release-version:
+        description: "Tag to benchmark and store as the official reference of that release."
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -93,7 +108,9 @@ jobs:
     timeout-minutes: 60
     # The maintainer gate issue #169 asks for. See the header: protect
     # "benchmark" with required reviewers, leave "benchmark-release" open.
-    environment: ${{ github.event_name == 'release' && 'benchmark-release' || 'benchmark' }}
+    # "push" is only ever release-please.yml calling this workflow; a manual
+    # repair run of a release stays behind the approval like any other one.
+    environment: ${{ github.event_name == 'push' && 'benchmark-release' || 'benchmark' }}
     permissions:
       # Only the release run pushes, but the token is scoped per job.
       contents: write
@@ -108,37 +125,40 @@ jobs:
         env:
           # Through the environment, never interpolated into the script: these
           # are user input, and "${{ }}" in a run block is a shell injection.
-          EVENT: ${{ github.event_name }}
           PR: ${{ inputs.pr }}
           CANDIDATE: ${{ inputs.candidate-ref }}
-          TAG: ${{ github.event.release.tag_name }}
+          VERSION: ${{ inputs.release-version }}
           FALLBACK: ${{ github.sha }}
         run: |
           set -euo pipefail
-          case "$EVENT" in
-          release)
-            ref=$TAG
-            label=$TAG
-            ;;
-          *)
-            if [ -n "${PR:-}" ]; then
-              case "$PR" in
-              '' | *[!0-9]*)
-                echo "::error::pr must be a number, got '$PR'"
-                exit 1
-                ;;
-              esac
-              ref=refs/pull/$PR/merge
-              label=pr-$PR
-            elif [ -n "${CANDIDATE:-}" ]; then
-              ref=$CANDIDATE
-              label=$CANDIDATE
-            else
-              ref=$FALLBACK
-              label=${GITHUB_REF_NAME:-manual}
-            fi
-            ;;
-          esac
+          if [ -n "${VERSION:-}" ]; then
+            # Checked here and not only in benchmark-store.sh: failing after a
+            # measurement that takes minutes is a poor way to report a typo.
+            case "$VERSION" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "::error::release-version must look like v3.3.0, got '$VERSION'"
+              exit 1
+              ;;
+            esac
+            ref=$VERSION
+            label=$VERSION
+          elif [ -n "${PR:-}" ]; then
+            case "$PR" in
+            *[!0-9]*)
+              echo "::error::pr must be a number, got '$PR'"
+              exit 1
+              ;;
+            esac
+            ref=refs/pull/$PR/merge
+            label=pr-$PR
+          elif [ -n "${CANDIDATE:-}" ]; then
+            ref=$CANDIDATE
+            label=$CANDIDATE
+          else
+            ref=$FALLBACK
+            label=${GITHUB_REF_NAME:-manual}
+          fi
           {
             echo "ref=$ref"
             echo "label=$label"
@@ -241,8 +261,8 @@ jobs:
           BENCH_DIR: store-main/benchmarks
           RESULTS_JSON: ${{ runner.temp }}/benchmark-results/results.json
           SUMMARY_MD: ${{ runner.temp }}/benchmark-results/summary.md
-          KIND: ${{ github.event_name == 'release' && 'release' || 'manual' }}
-          VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+          KIND: ${{ inputs.release-version != '' && 'release' || 'manual' }}
+          VERSION: ${{ inputs.release-version }}
           LABEL: ${{ steps.resolve.outputs.label }}
           RECORDED_AT: ${{ steps.resolve.outputs.recorded-at }}
           COMMIT: ${{ steps.build.outputs.candidate-sha }}
@@ -253,8 +273,8 @@ jobs:
         if: github.event_name != 'pull_request'
         working-directory: store-main
         env:
-          KIND: ${{ github.event_name == 'release' && 'release' || 'manual' }}
-          NAME: ${{ github.event_name == 'release' && github.event.release.tag_name || steps.resolve.outputs.label }}
+          KIND: ${{ inputs.release-version != '' && 'release' || 'manual' }}
+          NAME: ${{ steps.resolve.outputs.label }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,3 +36,21 @@ jobs:
     uses: ./.github/workflows/release-binaries.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+
+  # Called from here and not triggered by "on: release" in benchmark.yml: the
+  # release above is created with the GITHUB_TOKEN, and events raised by that
+  # token never start a workflow run. This job does not gate the release; it
+  # measures the tag and files the result under benchmarks/.
+  benchmark:
+    name: Benchmark the released tag
+    needs: release-please
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/benchmark.yml
+    with:
+      release-version: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,12 @@ granularity is a separate, later decision; don't build it speculatively.
   update inline `docker run` digests, so that one is bumped by hand
   (`docker buildx imagetools inspect atmoz/sftp:alpine`). Keep new external
   dependencies pinned the same way.
+- Nothing may hang off `on: release`. release-please creates the release with
+  the `GITHUB_TOKEN`, and events raised by that token never start a workflow
+  run, so such a job silently never runs (v3.3.0 shipped without its benchmark
+  that way). Post-release work is a `uses:` call from `release-please.yml`,
+  gated on `needs.release-please.outputs.release_created`, as
+  `release-binaries` and `benchmark` both do.
 - The self-test job in `.github/workflows/ci.yml` is the only place a real
   OpenSSH server is exercised, and the only place `action.yml`'s composite
   wiring runs end to end. Unit tests set `EASYSFTP_*` directly and never see

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -56,7 +56,7 @@ per scenario, so a reader (human or agent) does not have to open every file.
 ## Official versus manual
 
 - **Official** results are `kind: "release"`. They are measured automatically
-  after release-please published a tag, against exactly that tag, and they are
+  after release-please created a tag, against exactly that tag, and they are
   the only results `latest.*` is ever copied from.
 - **Manual** results are `kind: "manual"`, produced by a manually started run
   (a branch, a tag, or a pull request). They are kept alongside the official
@@ -81,3 +81,9 @@ Start it manually from the Actions tab with a `pr` number to benchmark a pull
 request, or a `candidate-ref` plus an optional `baseline-ref` to compare two
 refs in the same run. A manual run needs an approval on the `benchmark`
 environment first, which only a maintainer can give.
+
+If a release ended up without its official result, the same workflow repairs
+it: set `release-version` to that tag (for example `v3.3.0`). The run measures
+the tag and stores it as the official reference, and it fails rather than
+touch a reference that already exists. Everything else is a manual run and
+stays one.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,14 +59,23 @@ step:
 
 - When the release PR opens, it is benchmarked once and the numbers appear in
   that run's job summary. Nothing is stored yet.
-- After the release is published, the tagged code is benchmarked again and the
-  result is committed to `main` as the official reference for that version,
-  together with an updated `benchmarks/latest.json` and `benchmarks/latest.md`.
+- After Release Please created the release, the `Release` workflow calls the
+  benchmark with the new tag. The tagged code is measured and the result is
+  committed to `main` as the official reference for that version, together with
+  an updated `benchmarks/latest.json` and `benchmarks/latest.md`.
 - Releases older than the current one plus four move to `benchmarks/archive/`.
 
-Both runs need the `BENCHMARK_SFTP_*` secrets. Without them the benchmark job
-fails, which does not block the release: it runs beside the release pipeline,
-not inside it. See [`benchmarks/README.md`](../benchmarks/README.md).
+The benchmark is a `uses:` call from the `Release` workflow and **not** an
+`on: release` trigger: Release Please creates the release with the
+`GITHUB_TOKEN`, and events raised by that token never start a workflow run.
+The binary pipeline is wired the same way for the same reason.
+
+Both runs need the `BENCHMARK_SFTP_*` secrets. The benchmark job failing does
+not undo or block the release; the tag, the GitHub Release and the binaries are
+produced by other jobs. If a release ended up without its benchmark, start the
+`SFTP benchmark` workflow by hand with `release-version` set to that tag. It
+stores the missing official reference and refuses to touch one that already
+exists. See [`benchmarks/README.md`](../benchmarks/README.md).
 
 ## Stable asset names
 


### PR DESCRIPTION
## What & why

`v3.3.0` shipped without its benchmark. The cause is not a misconfiguration,
it is a dead trigger: the job hung off `on: release`, and release-please
creates the GitHub Release with the `GITHUB_TOKEN`. Events raised by that token
never start a workflow run, so no `release`-event run has ever existed in this
repository.

The evidence:

```text
$ gh release view v3.3.0 --json author   -> github-actions[bot]
$ gh run list --workflow benchmark.yml   -> no run with event "release"
```

`release-binaries` already avoids exactly this by being a `uses:` call from
`release-please.yml` instead of an `on: release` job. The benchmark now follows
the same pattern:

- `benchmark.yml` gets a `workflow_call` entry point with a `release-version`
  input, and the `release` trigger is gone.
- `release-please.yml` calls it with the new tag, gated on
  `needs.release-please.outputs.release_created == 'true'`, the same condition
  `release-binaries` uses, with `secrets: inherit`.
- Everything that keyed off `github.event_name == 'release'` now keys off
  `inputs.release-version`. The environment split keys off `github.event_name
  == 'push'`, which can only be release-please.yml calling this workflow.

## Checklist

- [x] `go test ./...`, `go vet ./...` and `gofmt -l .` are clean (no Go changed)
- [x] Behavior changes have a test (`scripts/test-benchmark-store.sh` unchanged and still green; the workflow wiring itself is not unit-testable)
- [x] Docs updated where affected: `docs/RELEASING.md`, `benchmarks/README.md`, `CLAUDE.md`
- [x] New external dependency in CI is pinned by full commit SHA (no new ones)
- [x] `CHANGELOG.md` not hand-edited

## Notes for the reviewer

**`release-version` is now also a `workflow_dispatch` input.** I left that
escape hatch out of #172 on purpose, arguing a missing official result is an
acceptable gap. One release later it is needed, so the argument was wrong.
Setting it measures that tag and stores it as the official reference. Two
things keep it honest: `benchmark-store.sh` still refuses to write a name that
exists, so no reference can be rewritten, and a dispatch run stays behind the
`benchmark` environment approval (only the automatic call from the release
pipeline uses the unprotected `benchmark-release`).

**`v3.3.0` still has no official benchmark.** After this merges, repair it by
starting `SFTP benchmark` from the Actions tab with `release-version: v3.3.0`.
I did not start that run: it uploads against the real host with your secrets
and needs the environment approval anyway.

**How this gets verified.** The wiring cannot be exercised from a PR: `Release`
only runs on pushes to `main`. Merging this PR is itself a push to `main`, so
the `Release` run of that merge loads the file and evaluates the new job (which
then skips, since no release is created). A syntax error in the reusable call
would fail that run at startup. The real proof is the next actual release.

**Not changed:** a failing benchmark makes the `Release` workflow show a red
job even though the release itself succeeded. `continue-on-error` is not
supported on jobs that call a reusable workflow, and the release output (tag,
GitHub Release, binaries) is produced by other jobs that this one does not
gate, so a red benchmark is a truthful signal that the measurement failed, not
that the release did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
