### PR TITLE
ci(benchmark): run the benchmark on the self-hosted runner and keep everything else off it

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,6 +30,24 @@ name: SFTP benchmark
 # automatic post-release run uses "benchmark-release", which is meant to stay
 # unprotected so a release does not wait for a click.
 #
+# Self-hosted runner: this job runs on a fixed machine (labels self-hosted,
+# Linux, X64) so results are comparable instead of landing on whatever
+# GitHub-hosted region was free. It is the only job in this repository that may
+# use it; every other workflow stays on GitHub-hosted runners. Three layers
+# keep untrusted code off that machine, and all three are needed:
+#   1. workflow_dispatch and workflow_call require write access already.
+#   2. The pull_request path is restricted to release-please branches *of this
+#      repository*. A fork can name its branch "release-please--anything", so
+#      the head-repo check, not the branch name, is what keeps forks out.
+#   3. Repository setting "Fork pull request workflows from outside
+#      collaborators" must stay on "Require approval for all external
+#      contributors". Without it an outside contributor can add
+#      "runs-on: self-hosted" to any workflow in a fork PR and execute
+#      arbitrary code on the machine; no YAML in this repository can prevent
+#      that, since a pull_request run uses the workflow files from the PR.
+# The runner also holds nothing sensitive by design: secrets are passed per
+# run, not stored on it.
+#
 # Required repository secrets:
 #   BENCHMARK_SFTP_HOST         host name of the benchmark server
 #   BENCHMARK_SFTP_USERNAME     SFTP user name
@@ -103,8 +121,11 @@ jobs:
     name: Benchmark SFTP throughput
     if: >-
       github.event_name != 'pull_request' ||
-      startsWith(github.head_ref, 'release-please--')
-    runs-on: ubuntu-24.04
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       startsWith(github.head_ref, 'release-please--'))
+    # The one job in this repo on the self-hosted runner. Everything else stays
+    # on GitHub-hosted runners; see the "Self-hosted runner" note in the header.
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 60
     # The maintainer gate issue #169 asks for. See the header: protect
     # "benchmark" with required reviewers, leave "benchmark-release" open.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -71,8 +71,12 @@ per scenario, so a reader (human or agent) does not have to open every file.
 The benchmark runs on a fixed self-hosted runner, not on a GitHub-hosted one:
 those land in a changing region on changing hardware, which puts the machine
 into every delta between two releases. Each result records where it ran in its
-`runner` field (`self-hosted` or `github-hosted`, plus kernel and CPU count).
-Two results are only comparable when that field matches.
+`runner` field, and two results are only comparable when that field matches.
+
+Results up to and including v3.3.1 predate this and name only the kernel and
+CPU count (`Linux 6.17.0-1020-azure, 4 cpu`); every one of them was measured on
+a GitHub-hosted runner. From the next release on the field starts with
+`self-hosted`.
 
 ## Retention
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -66,6 +66,14 @@ per scenario, so a reader (human or agent) does not have to open every file.
   before the merge. That run stores nothing: its result belongs to a release
   that does not exist yet. The official file is the post-tag measurement.
 
+## Where the numbers were measured
+
+The benchmark runs on a fixed self-hosted runner, not on a GitHub-hosted one:
+those land in a changing region on changing hardware, which puts the machine
+into every delta between two releases. Each result records where it ran in its
+`runner` field (`self-hosted` or `github-hosted`, plus kernel and CPU count).
+Two results are only comparable when that field matches.
+
 ## Retention
 
 The current release and the four before it stay in `benchmarks/`. Older

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -61,6 +61,16 @@ require_env() {
 require_env CANDIDATE_BIN CANDIDATE_REF OUT_DIR DATASET_DIR LOG_DIR \
   REMOTE_BASE BENCH_HOST BENCH_USERNAME BENCH_PASSWORD BENCH_KNOWN_HOSTS
 
+# Checked because the benchmark runs on a self-hosted runner, where a
+# GitHub-hosted image's preinstalled tools are not a given. Better here than
+# after minutes of measuring.
+for cmd in jq nproc; do
+  command -v "$cmd" >/dev/null || {
+    echo "::error::$cmd is required but not installed on this runner" >&2
+    exit 1
+  }
+done
+
 REPEATS=${REPEATS:-3}
 BENCH_PORT=${BENCH_PORT:-22}
 BASELINE_BIN=${BASELINE_BIN:-}
@@ -264,7 +274,7 @@ jq -n \
   --arg candidate_ref "$CANDIDATE_REF" \
   --arg baseline_ref "$BASELINE_REF" \
   --argjson repeats "$REPEATS" \
-  --arg runner "$(uname -sr), $(nproc) cpu" \
+  --arg runner "${RUNNER_ENVIRONMENT:-local}, $(uname -sr), $(nproc) cpu" \
   '{
      candidate_ref: $candidate_ref,
      baseline_ref: $baseline_ref,


### PR DESCRIPTION
## What & why

We now have a fixed self-hosted runner for the SFTP benchmark, so results stop
carrying "whichever GitHub-hosted region was free" in every delta. This wires
it up and, more importantly, keeps everything else off that machine.

The benchmark job is the only job that uses it (`runs-on: [self-hosted, Linux,
X64]`); every other workflow stays on GitHub-hosted runners.

Three layers keep untrusted code off the runner, and all three are needed:

1. `workflow_dispatch` and `workflow_call` require write access anyway, and the
   `benchmark` environment gate (required reviewer) sits in front of manual and
   release-PR runs.
2. The `pull_request` path was gated on the branch name alone
   (`startsWith(github.head_ref, 'release-please--')`), which a fork can simply
   name that way. It now also requires
   `github.event.pull_request.head.repo.full_name == github.repository`, so no
   fork PR can reach the job.
3. Repository setting **Actions -> Fork pull request workflows from outside
   collaborators** was changed from "first-time contributors" to **"Require
   approval for all external contributors"** (done, outside this diff). This is
   the layer that actually matters: a `pull_request` run uses the workflow
   files *from the PR*, so without it anyone with one merged PR could add
   `runs-on: self-hosted` to any workflow in a fork and execute arbitrary code
   on the machine. No YAML in this repository can prevent that.

Two side effects of leaving the GitHub-hosted images behind:

- `scripts/benchmark.sh` now checks `jq` and `nproc` up front instead of
  failing after minutes of measuring on a runner that lacks them.
- The `runner` field in `results.json` now leads with `RUNNER_ENVIRONMENT`
  (`self-hosted` / `github-hosted`), so a stored result says where it was
  measured. `benchmarks/README.md` documents the boundary: v3.3.1 and earlier
  have the old format and were all GitHub-hosted, so a delta across that line
  is not a code change.

## Checklist

- [x] `go test ./...`, `go vet ./...` and `gofmt -l .` are clean
- [x] Behavior changes have a test (bug fixes: one that fails without the fix)
- [x] Docs updated where affected: `README.md`, `docs/`, `action.yml` input
      descriptions, `schema/easysftp.schema.json`
- [x] New external dependency in CI is pinned by full commit SHA / `@sha256:` digest
- [x] `CHANGELOG.md` **not** hand-edited (release-please generates it)

## Notes for the reviewer

- No Go code is touched, hence no new test; the changed logic is workflow YAML
  and two shell lines. `scripts/test-benchmark-store.sh` is unaffected (the
  `runner` field is passed through, never parsed).
- Nothing here has been exercised end to end yet: the next manual run is what
  proves the runner has `jq` and can build Go. It fails in seconds now if it
  cannot, instead of after the measurement.
- Deliberately not added: a per-workflow allowlist for the runner. Repo-level
  self-hosted runners cannot be restricted that way (runner *groups* are an
  org/enterprise feature), so the workflow gating plus the fork-approval
  setting is the whole mechanism available here.
- The `benchmark-release` environment stays unprotected on purpose, so the
  post-release run does not wait for a click. It is only ever reachable from
  `release-please.yml`.
