### PR TITLE
fix(benchmarks): stop using the jq keyword "label" as a variable

### DIFF
--- a/scripts/benchmark-store.sh
+++ b/scripts/benchmark-store.sh
@@ -92,10 +92,14 @@ done
 
 # The envelope keeps the measurement verbatim under .benchmark and adds only
 # provenance around it, so a reader never has to guess which run a number is.
+# The variable is "run_label", not "label": "label" is a jq keyword, and jq 1.6
+# (what Debian/Ubuntu LTS and therefore the self-hosted runner ship) rejects
+# "$label" in a filter with "unexpected label, expecting IDENT or __loc__".
+# The *key* stays "label", which every jq parses.
 jq -n \
   --arg kind "$KIND" \
   --arg version "$VERSION" \
-  --arg label "$slug" \
+  --arg run_label "$slug" \
   --arg recorded_at "$RECORDED_AT" \
   --arg commit "$COMMIT" \
   --arg run_url "$RUN_URL" \
@@ -104,7 +108,7 @@ jq -n \
      schema_version: 1,
      kind: $kind,
      version: (if $version == "" then null else $version end),
-     label: (if $label == "" then null else $label end),
+     label: (if $run_label == "" then null else $run_label end),
      official: ($kind == "release"),
      recorded_at: $recorded_at,
      commit: (if $commit == "" then null else $commit end),


### PR DESCRIPTION
## What broke

The first benchmark run on the new self-hosted runner
([run 30284837138](https://github.com/eiserv/easySFTP/actions/runs/30284837138/job/90039960500))
measured fine and then failed in *Store the result*:

```
jq: error: syntax error, unexpected label, expecting IDENT or __loc__ (Unix shell quoting issues?) at <top-level>, line 5:
     label: (if $label == "" then null else $label end),
```

## Why

`label` is a jq keyword. jq 1.6 (Debian/Ubuntu LTS, and therefore the
self-hosted runner) rejects `$label` as a variable reference; jq 1.7, which
the GitHub-hosted runners ship, accepts it. So the envelope filter in
`scripts/benchmark-store.sh` had always been jq-1.7-only and only broke once
the job moved to the fixed machine.

`scripts/benchmark.sh` also binds `--arg label`, but its filter is
`$ARGS.named` and never dereferences it, so the measurement step passed and
only the store step failed. Nothing else in the two scripts references a
keyword-named variable.

## The fix

Rename the jq variable to `$run_label`. The stored key stays `label`, which
every jq version parses (jq 1.6 accepts keywords as object keys, just not as
variable names), so no stored file, `index.json` entry or reader changes.

## Verification

`scripts/test-benchmark-store.sh` run with a jq 1.6 binary on `PATH`:

- before: same syntax error, first store fails
- after: `all benchmark-store checks passed`

## Nothing to change on the runner

No jq upgrade needed; the script now works on jq 1.6 and later. Re-running the
benchmark workflow should get past the store step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
