### PR TITLE
ci(benchmark): attach release benchmarks to the GitHub Release

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,8 +15,9 @@ name: SFTP benchmark
 #                      stored: the release is not real yet.
 #   workflow_call      release-please.yml calls this after it created a release,
 #                      passing the tag as "release-version". The tagged code is
-#                      measured once more and committed as the official
-#                      reference.
+#                      measured once more, committed as the official reference,
+#                      and attached to the GitHub Release as an asset (the
+#                      "attach" job below).
 #
 # That last one is a "uses:" call and not an "on: release" trigger on purpose.
 # release-please creates the GitHub Release with the GITHUB_TOKEN, and events
@@ -310,3 +311,34 @@ jobs:
           # files are added here, so replaying them on top is safe.
           git pull --rebase origin main
           git push origin HEAD:main
+
+  # A release's numbers belong on its release page, next to the binaries. This
+  # is a separate job on a GitHub-hosted runner: it needs nothing but "gh" and
+  # a checkout, and the self-hosted runner stays reserved for the measurement.
+  # It reads the files from main, which the job above pushed there, so it can
+  # only run once that finished.
+  attach:
+    name: Attach the result to the release
+    needs: benchmark
+    if: inputs.release-version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+
+      - name: Upload the benchmark as a release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.release-version }}
+        run: |
+          set -euo pipefail
+          # Renamed for the release page: "release-v3.3.2.json" reads like a
+          # second copy of the release next to the binaries, "benchmark-" says
+          # what it is. The file in benchmarks/ keeps its own naming.
+          cp "benchmarks/release-$VERSION.json" "benchmark-$VERSION.json"
+          cp "benchmarks/release-$VERSION.md" "benchmark-$VERSION.md"
+          gh release upload "$VERSION" "benchmark-$VERSION.json" "benchmark-$VERSION.md" \
+            --clobber --repo "$GITHUB_REPOSITORY"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -57,7 +57,9 @@ per scenario, so a reader (human or agent) does not have to open every file.
 
 - **Official** results are `kind: "release"`. They are measured automatically
   after release-please created a tag, against exactly that tag, and they are
-  the only results `latest.*` is ever copied from.
+  the only results `latest.*` is ever copied from. Both files are also attached
+  to that GitHub Release as `benchmark-vX.Y.Z.json` and `benchmark-vX.Y.Z.md`,
+  so the numbers sit next to the binaries they describe.
 - **Manual** results are `kind: "manual"`, produced by a manually started run
   (a branch, a tag, or a pull request). They are kept alongside the official
   ones and are clearly named, but they never become a reference and never


### PR DESCRIPTION
Two things were reported: manual benchmark runs never land in `benchmarks/`, and release benchmarks are not attached to the release.

## Manual runs: already fixed, no change here

Root cause was the jq keyword bug, not the storing logic. Run [30284837138](https://github.com/eiserv/easySFTP/actions/runs/30284837138) (the only manual run since storing exists) died in `Store the result`:

```
jq: error: syntax error, unexpected label, expecting IDENT or __loc__
     label: (if $label == "" then null else $label end),
```

Release runs were unaffected only by timing: v3.3.1 was stored from a GitHub-hosted runner with jq 1.7, while #175 moved the job to the self-hosted runner and its jq 1.6. #176 fixed exactly this and is on main; no manual run has exercised the fixed script yet. Nothing left to change, so this PR does not touch it.

## Release assets: fixed here

`benchmark.yml` committed the official result to `benchmarks/` and stopped there. A new `attach` job uploads it to the GitHub Release:

- runs after the measuring job pushed the file to main, and reads it from there (the tag itself does not contain it, it is committed afterwards)
- GitHub-hosted, not self-hosted: it needs only `gh` and a checkout, and the self-hosted runner stays reserved for the measurement
- `if: inputs.release-version != ${{ "" }}`, so it covers the post-release call and a manual repair run, and is skipped for release-PR and ordinary manual runs
- uploads as `benchmark-vX.Y.Z.json` / `.md`; `release-v3.3.2.json` next to the binaries would read like a second copy of the release

`benchmarks/README.md` documents the assets.

## Verification

YAML parses, job graph is `benchmark` -> `attach`. The path itself can only be exercised by a real release; v3.3.1 and v3.3.2 are still without assets and can be backfilled by hand with `gh release upload` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)