### PR TITLE
feat(uploader): optional connection pool for parallel uploads

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -85,6 +85,10 @@ on:
         required: false
         default: "3"
         type: string
+      connections:
+        description: "Also measure the candidate with advanced.connections set to this many SSH connections (issue #158), as a third build. Empty = single connection only."
+        required: false
+        type: string
       remote-base:
         description: "Remote directory the benchmark owns. Everything below it is disposable."
         required: false
@@ -241,6 +245,7 @@ jobs:
           BASELINE_REF: ${{ steps.build.outputs.baseline-ref }}
           REPEATS: ${{ inputs.repeats || '3' }}
           REMOTE_BASE: ${{ inputs.remote-base || '/easysftp-benchmark' }}
+          BENCH_CONNECTIONS: ${{ inputs.connections }}
           # OUT_DIR is uploaded as an artifact; LOG_DIR (which holds logs that
           # name the host and user) deliberately is not.
           OUT_DIR: ${{ runner.temp }}/benchmark-results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,12 +99,20 @@ granularity is a separate, later decision; don't build it speculatively.
   (`withDropOnRequest(method, path)`, which kills the live connection the
   first time a matching SFTP request arrives; use it to simulate a drop
   during a non-transfer phase like a delete sweep or remote scan) and
-  request-triggered hangs (`withStallOnRequest`). Follow that pattern (wrap
+  request-triggered hangs (`withStallOnRequest`) and refused connections
+  (`withMaxConns(n)`, which closes everything accepted beyond the first n; the
+  connection pool's degradation path uses it). Follow that pattern (wrap
   the relevant `Handlers` field, add a `serverOption`) for new
   fault-injection needs instead of building a new fake server. Note that
   `withDropOnRequest` closes *every* live connection, including any
   `verifyClient` session opened before the drop fires; open verification
   clients after the run, not before.
+- A run may hold more than one connection (`advanced.connections`, issue
+  #158). Only the per-file upload path spreads over them, by file index;
+  `session.do` and therefore everything else always uses the first one. A
+  connection the server refuses is not an error: that pool slot falls back to
+  the first connection after one warning. The reconnect budget stays run-wide
+  and the stall watchdog closes every connection.
 - Every remote operation outside the per-file upload path must go through
   `session.do` (see `internal/uploader/session.go`): it redials on
   connection-class errors sharing the `retries` reconnect budget and marks

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -96,6 +96,12 @@ request, or a `candidate-ref` plus an optional `baseline-ref` to compare two
 refs in the same run. A manual run needs an approval on the `benchmark`
 environment first, which only a maintainer can give.
 
+Setting `connections` measures a third build labelled `poolN`: the candidate
+binary again, this time with `advanced.connections: N` (issue #158). It runs
+interleaved with the others, since two numbers from two separate runs against a
+shared host are not comparable. The `Delta` column then compares every build
+against the baseline, or against the candidate when no baseline was given.
+
 If a release ended up without its official result, the same workflow repairs
 it: set `release-version` to that tag (for example `v3.3.0`). The run measures
 the tag and stores it as the official reference, and it fails rather than

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,7 @@ advanced:
   stall_timeout: 0
   concurrency: auto            # or a number
   request_concurrency: auto
+  connections: 1               # SSH connections uploads spread over
   skip_unchanged: false
 
 permissions:
@@ -221,7 +222,39 @@ sync:
 | `stall_timeout` | `0` (off) | Abort when active remote operations make no progress for this many seconds. |
 | `concurrency` | `auto` (4) | Files uploaded in parallel. Also bounds the sync hashing worker pool. `auto` uses the built-in default. |
 | `request_concurrency` | `auto` (16) | Max in-flight SFTP requests per file (pipelining within one transfer). |
+| `connections` | `1` | SSH connections the parallel uploads spread over. Never more than `concurrency`. See below. |
 | `skip_unchanged` | `false` | For `overlay`, skip a file whose remote counterpart has the same size (coarse; `sync` compares content hashes). |
+
+##### `connections`: more than one TCP flow
+
+By default a run does everything over a single SSH connection, so the whole
+deploy shares one TCP congestion window and one cipher stream, no matter how
+high `concurrency` and `request_concurrency` are. On a long-distance link that
+window is what caps throughput, and neither knob can lift it.
+
+`connections: 4` opens up to four connections and spreads the parallel uploads
+over them. Everything else (remote scans, deletes, the sync manifest) stays on
+the first one.
+
+It is off by default because it is not free:
+
+- **Server limits are real.** sshd's `MaxStartups` and per-account connection
+  limits on shared hosting will refuse the extra connections. easySFTP then
+  warns once per refused connection and finishes the deploy on the ones it
+  has, so a too-high value costs a warning, not a failed deploy.
+- **Each connection repeats the handshake**, including host key verification.
+  A short run of a few files pays that for nothing, which is why connections
+  past the first are only opened when a file actually needs one.
+- **The `retries` budget is shared.** Reconnects are counted per run, not per
+  connection.
+- **The stall watchdog closes all of them.** `stall_timeout` only knows that
+  the run stopped moving bytes, not which connection stalled.
+
+Worth trying when the server is far away or the link has real latency, and the
+transfer is clearly not saturating it. On a nearby server, or with many small
+files where per-file round-trips dominate, expect little or nothing: measure
+before you keep it. easySFTP's own numbers live in
+[`benchmarks/`](../benchmarks/README.md).
 
 #### `permissions`
 

--- a/docs/easysftp.example.yml
+++ b/docs/easysftp.example.yml
@@ -74,6 +74,9 @@ advanced:
   stall_timeout: 0 # abort after this many seconds without progress; 0 = off
   concurrency: auto # files uploaded in parallel ("auto" = built-in default)
   request_concurrency: auto # in-flight SFTP requests per file
+  # SSH connections uploads spread over. >1 lifts the single-TCP-flow ceiling
+  # on high-latency links; some servers limit connections per account.
+  connections: 1
   skip_unchanged: false # overlay only: skip same-size remote files
 
 # Remote permission and timestamp handling (all best-effort).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,9 +160,17 @@ type Config struct {
 	DryRun                 bool
 	Concurrency            int
 	SftpRequestConcurrency int
-	Retries                int
-	Timeout                time.Duration
-	SyncFastPath           bool
+
+	// Connections is how many SSH connections a run may open, so uploads can
+	// use more than one TCP flow and more than one cipher stream (issue #158).
+	// 1 (the default) keeps the single-connection behavior. Never more than
+	// Concurrency: a connection without a worker on it is a handshake for
+	// nothing.
+	Connections int
+
+	Retries      int
+	Timeout      time.Duration
+	SyncFastPath bool
 
 	// StallTimeout, if positive, aborts the run when active transfers make
 	// no progress for this long, instead of hanging until the job-level
@@ -228,6 +236,7 @@ const envPrefix = "EASYSFTP_"
 const (
 	defaultConcurrency        = 4
 	defaultRequestConcurrency = 16
+	defaultConnections        = 1
 	defaultRetries            = 2
 	defaultTimeoutSec         = 30
 )
@@ -309,6 +318,7 @@ func Load() (*Config, error) {
 		Passphrase:             os.Getenv(envPrefix + "PASSPHRASE"),
 		Concurrency:            defaultConcurrency,
 		SftpRequestConcurrency: defaultRequestConcurrency,
+		Connections:            defaultConnections,
 		Retries:                defaultRetries,
 		Timeout:                defaultTimeoutSec * time.Second,
 		ManifestName:           DefaultManifestName,
@@ -432,6 +442,8 @@ func (c *Config) validate() error {
 		return fmt.Errorf("advanced.concurrency must be at least 1, got %d", c.Concurrency)
 	case c.SftpRequestConcurrency < 1:
 		return fmt.Errorf("advanced.request_concurrency must be at least 1, got %d", c.SftpRequestConcurrency)
+	case c.Connections < 1:
+		return fmt.Errorf("advanced.connections must be at least 1, got %d", c.Connections)
 	case c.Retries < 0:
 		return fmt.Errorf("advanced.retries must not be negative, got %d", c.Retries)
 	case c.Timeout < 0:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,8 +84,9 @@ func TestLoadInlineDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Retries != 2 ||
-		cfg.DryRun || cfg.SyncFastPath || cfg.SkipUnchanged || cfg.AllowAnyHostKey || cfg.LogLevel != LogNormal {
+	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Connections != 1 ||
+		cfg.Retries != 2 || cfg.DryRun || cfg.SyncFastPath || cfg.SkipUnchanged || cfg.AllowAnyHostKey ||
+		cfg.LogLevel != LogNormal {
 		t.Errorf("unexpected defaults: %+v", cfg)
 	}
 	if cfg.Timeout != 30*time.Second {
@@ -306,6 +307,7 @@ advanced:
   stall_timeout: 120
   concurrency: 8
   request_concurrency: 4
+  connections: 3
   skip_unchanged: true
 permissions:
   files: "0644"
@@ -349,7 +351,7 @@ sync:
 		t.Errorf("expected max_deletes 500, got %d", cfg.Safety.MaxDeletes)
 	}
 	if cfg.Retries != 4 || cfg.Timeout != 60*time.Second || cfg.StallTimeout != 120*time.Second ||
-		cfg.Concurrency != 8 || cfg.SftpRequestConcurrency != 4 || !cfg.SkipUnchanged {
+		cfg.Concurrency != 8 || cfg.SftpRequestConcurrency != 4 || cfg.Connections != 3 || !cfg.SkipUnchanged {
 		t.Errorf("unexpected advanced settings: %+v", cfg)
 	}
 	if cfg.FileMode == nil || *cfg.FileMode != 0o644 || cfg.DirMode == nil || *cfg.DirMode != 0o755 || !cfg.PreserveTimes {
@@ -366,8 +368,8 @@ func TestLoadConfigModeDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Retries != 2 ||
-		cfg.Timeout != 30*time.Second || cfg.StallTimeout != 0 || cfg.Safety.MaxDeletes != 0 {
+	if cfg.Port != 22 || cfg.Concurrency != 4 || cfg.SftpRequestConcurrency != 16 || cfg.Connections != 1 ||
+		cfg.Retries != 2 || cfg.Timeout != 30*time.Second || cfg.StallTimeout != 0 || cfg.Safety.MaxDeletes != 0 {
 		t.Errorf("unexpected config-mode defaults: %+v", cfg)
 	}
 	if cfg.Uploads[0].Strategy != StrategyOverlay {
@@ -417,6 +419,25 @@ advanced:
 	}
 	if cfg.Concurrency != 4 {
 		t.Errorf("expected 'auto' to resolve to the default concurrency, got %d", cfg.Concurrency)
+	}
+}
+
+func TestLoadConfigModeRejectsZeroConnections(t *testing.T) {
+	setConfigModeEnv(t, `version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: SHA256:abc
+deployments:
+  website:
+    source: ./dist/
+    target: /www/
+advanced:
+  connections: 0
+`)
+	_, err := Load()
+	if err == nil || !strings.Contains(err.Error(), "advanced.connections must be at least 1") {
+		t.Fatalf("expected a connections validation error, got %v", err)
 	}
 }
 

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -68,6 +68,7 @@ type yamlAdvanced struct {
 	StallTimeout       *int    `yaml:"stall_timeout"`
 	Concurrency        autoInt `yaml:"concurrency"`
 	RequestConcurrency autoInt `yaml:"request_concurrency"`
+	Connections        autoInt `yaml:"connections"`
 	SkipUnchanged      bool    `yaml:"skip_unchanged"`
 }
 
@@ -119,7 +120,7 @@ var allowedKeys = map[string][]string{
 	"defaults":         {"mode", "exclude"},
 	"deployments.*":    {"source", "target", "mode", "exclude"},
 	"safety":           {"max_deletes"},
-	"advanced":         {"retries", "timeout", "stall_timeout", "concurrency", "request_concurrency", "skip_unchanged"},
+	"advanced":         {"retries", "timeout", "stall_timeout", "concurrency", "request_concurrency", "connections", "skip_unchanged"},
 	"permissions":      {"files", "directories", "preserve_times"},
 	"sync":             {"fast_path", "manifest"},
 }
@@ -346,6 +347,7 @@ func applyYAML(cfg *Config, yc *yamlConfig) error {
 	}
 	cfg.Concurrency = yc.Advanced.Concurrency.or(defaultConcurrency)
 	cfg.SftpRequestConcurrency = yc.Advanced.RequestConcurrency.or(defaultRequestConcurrency)
+	cfg.Connections = yc.Advanced.Connections.or(defaultConnections)
 	cfg.SkipUnchanged = yc.Advanced.SkipUnchanged
 
 	var err error

--- a/internal/uploader/connection.go
+++ b/internal/uploader/connection.go
@@ -19,14 +19,15 @@ import (
 // different value.
 const keepaliveInterval = 30 * time.Second
 
-// sendKeepalives periodically sends an SSH keepalive request until ctx is
-// canceled. This keeps long or idle-looking transfers alive across NAT
-// gateways and firewalls that drop idle TCP connections, and answers sshd's
-// own ClientAliveInterval probes so the server doesn't disconnect us first.
-// client is a getter (not a fixed *ssh.Client) so one loop follows the
-// session across reconnects; interval is a parameter so tests can drive it
-// with a short tick instead of waiting 30s.
-func sendKeepalives(ctx context.Context, client func() *ssh.Client, interval time.Duration) {
+// sendKeepalives periodically sends an SSH keepalive request on every live
+// connection until ctx is canceled. This keeps long or idle-looking transfers
+// alive across NAT gateways and firewalls that drop idle TCP connections, and
+// answers sshd's own ClientAliveInterval probes so the server doesn't
+// disconnect us first. clients is a getter (not a fixed slice) so one loop
+// follows the session across reconnects and picks up connections the pool
+// opens later; interval is a parameter so tests can drive it with a short tick
+// instead of waiting 30s.
+func sendKeepalives(ctx context.Context, clients func() []*ssh.Client, interval time.Duration) {
 	t := time.NewTicker(interval)
 	defer t.Stop()
 	for {
@@ -34,7 +35,9 @@ func sendKeepalives(ctx context.Context, client func() *ssh.Client, interval tim
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			_, _, _ = client().SendRequest("keepalive@openssh.com", true, nil)
+			for _, c := range clients() {
+				_, _, _ = c.SendRequest("keepalive@openssh.com", true, nil)
+			}
 		}
 	}
 }

--- a/internal/uploader/pool_test.go
+++ b/internal/uploader/pool_test.go
@@ -1,0 +1,123 @@
+package uploader
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// poolTree writes n small files, enough of them that every pool slot is used
+// (files are spread over the pool by their plan index).
+func poolTree(t *testing.T, root string, n int) {
+	t.Helper()
+	files := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		files[fmt.Sprintf("file%02d.txt", i)] = fmt.Sprintf("content %d", i)
+	}
+	writeTree(t, root, files)
+}
+
+// TestConnectionPoolOpensConfiguredConnections pins the point of issue #158:
+// advanced.connections opens that many SSH connections, and the default of one
+// keeps the single-connection behavior. The count is read before any
+// verifyClient runs, since those dial the same server.
+func TestConnectionPoolOpensConfiguredConnections(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		connections int
+		want        int32
+	}{
+		{"default is one connection", 0, 1},
+		{"explicit single connection", 1, 1},
+		{"pool of three", 3, 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := startTestServer(t)
+			local := t.TempDir()
+			poolTree(t, local, 9)
+
+			cfg := baseConfig(srv)
+			cfg.Concurrency = 3
+			cfg.Connections = tc.connections
+			cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+			stats, err := Run(context.Background(), cfg, testLogger{t})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := atomic.LoadInt32(&srv.accepted); got != tc.want {
+				t.Errorf("expected %d connection(s), got %d", tc.want, got)
+			}
+			if stats.FilesUploaded != 9 {
+				t.Fatalf("expected 9 uploads, got %d", stats.FilesUploaded)
+			}
+			if got := readRemote(t, srv, "/www/file08.txt"); got != "content 8" {
+				t.Errorf("unexpected content: %q", got)
+			}
+		})
+	}
+}
+
+// TestConnectionPoolNeverExceedsConcurrency: a connection no worker ever picks
+// is a handshake for nothing, so the pool is capped at the number of parallel
+// uploads and says so.
+func TestConnectionPoolNeverExceedsConcurrency(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 6)
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 2
+	cfg.Connections = 8
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&srv.accepted); got != 2 {
+		t.Errorf("expected the pool to be capped at concurrency (2), got %d connection(s)", got)
+	}
+	if !containsSubstring(log.infos, "only 2 file(s) upload in parallel") {
+		t.Errorf("expected an info line about the cap, got %v", log.infos)
+	}
+}
+
+// TestConnectionPoolDegradesWhenServerRefusesConnections: sshd's MaxStartups
+// and per-account limits on shared hosting are real, so a refused extra
+// connection must cost a warning and not the deploy.
+func TestConnectionPoolDegradesWhenServerRefusesConnections(t *testing.T) {
+	srv := startTestServer(t, withMaxConns(1))
+	local := t.TempDir()
+	poolTree(t, local, 6)
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 3
+	cfg.Connections = 3
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	stats, err := Run(context.Background(), cfg, log)
+	if err != nil {
+		t.Fatalf("a server refusing extra connections must not fail the run: %v", err)
+	}
+	if stats.FilesUploaded != 6 {
+		t.Errorf("expected 6 uploads, got %d", stats.FilesUploaded)
+	}
+	if !containsSubstring(log.warnings, "continues on its first connection") {
+		t.Errorf("expected a warning about the refused connection, got %v", log.warnings)
+	}
+}
+
+func containsSubstring(lines []string, want string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/uploader/retry.go
+++ b/internal/uploader/retry.go
@@ -15,10 +15,10 @@ import (
 // When a failure looks connection-class, the session is asked to reconnect
 // first, so the retry runs against a live client instead of the dead one.
 //
-// index is the file's position in the plan and is folded into the temp
-// path (see uploadFile) so two planned transfers never race over the same
-// temporary name, even if one target's path happens to literally be
-// another's plus tmpSuffix.
+// index is the file's position in the plan. It is folded into the temp path
+// (see uploadFile) so two planned transfers never race over the same temporary
+// name, even if one target's path happens to literally be another's plus
+// tmpSuffix, and it picks the file's connection out of the pool.
 func uploadFileWithRetry(ctx context.Context, env *transferEnv, f fileItem, index int, mode fs.FileMode) (int64, error) {
 	sess, watch, log, retries := env.sess, env.watch, env.log, env.cfg.Retries
 	var lastErr error
@@ -30,7 +30,7 @@ func uploadFileWithRetry(ctx context.Context, env *transferEnv, f fileItem, inde
 				return 0, err
 			}
 		}
-		client, gen := sess.current()
+		client, c, gen := sess.acquire(index)
 		if attempt > 0 {
 			// A previous attempt may have left its temp file behind (a dead
 			// connection cannot run the normal cleanup). Clear it so the
@@ -53,7 +53,7 @@ func uploadFileWithRetry(ctx context.Context, env *transferEnv, f fileItem, inde
 			break
 		}
 		if isConnError(err) && attempt < retries {
-			if _, rerr := sess.reconnect(ctx, gen); rerr != nil {
+			if _, rerr := sess.reconnect(ctx, c, gen); rerr != nil {
 				return 0, fmt.Errorf("uploading %q to %q: %w (%v)", f.localPath, f.remotePath, lastErr, rerr)
 			}
 		}

--- a/internal/uploader/session.go
+++ b/internal/uploader/session.go
@@ -16,19 +16,35 @@ import (
 	"github.com/eiserv/easySFTP/internal/config"
 )
 
-// session holds the run's SSH/SFTP client pair and can transparently redial
-// it when the connection drops mid-run, so per-file retries run against a
-// live client instead of burning their backoff on a dead one.
+// conn is one live SSH/SFTP client pair.
+type conn struct {
+	ssh       *ssh.Client
+	sftp      *sftp.Client
+	closeJump func() // closes the jump-host transport; no-op for direct connections
+	gen       int    // bumped on every successful reconnect of this connection
+}
+
+// session holds the run's connections and can transparently redial one when it
+// drops mid-run, so per-file retries run against a live client instead of
+// burning their backoff on a dead one.
+//
+// A run opens advanced.connections of them (1 by default). Everything above
+// that number is one connection's ceiling: one TCP congestion window and one
+// cipher stream carry the whole run, which neither concurrency nor
+// request_concurrency can lift (issue #158). Parallel uploads spread over the
+// pool; every other remote operation (remote scans, delete sweeps, manifest
+// writes, directory setup) stays on the first connection, where its reconnect
+// behavior is exactly what it was before the pool existed.
 type session struct {
 	cfg *config.Config
 	log Logger
 
-	mu         sync.Mutex
-	sshClient  *ssh.Client
-	sftpClient *sftp.Client
-	closeJump  func() // closes the jump-host transport; no-op for direct connections
-	gen        int    // bumped on every successful reconnect
-	reconnects int    // spent so far; bounded by cfg.Retries
+	mu    sync.Mutex
+	conns []*conn // slot 0 is dialed up front, the rest on first use
+	// reconnects spent so far, bounded by cfg.Retries and shared by every
+	// connection: the input is a run-wide budget, and a server that drops
+	// connections drops them faster with more of them open.
+	reconnects int
 }
 
 // newSession dials the server and opens the initial SFTP session, retrying
@@ -51,7 +67,9 @@ func newSession(ctx context.Context, cfg *config.Config, log Logger) (*session, 
 		}
 		sshClient, sftpClient, closeJump, err := connect(cfg, log)
 		if err == nil {
-			return &session{cfg: cfg, log: log, sshClient: sshClient, sftpClient: sftpClient, closeJump: closeJump}, nil
+			s := &session{cfg: cfg, log: log, conns: make([]*conn, poolSize(cfg, log))}
+			s.conns[0] = &conn{ssh: sshClient, sftp: sftpClient, closeJump: closeJump}
+			return s, nil
 		}
 		lastErr = err
 		if !isRetryableConnect(err) {
@@ -59,6 +77,25 @@ func newSession(ctx context.Context, cfg *config.Config, log Logger) (*session, 
 		}
 	}
 	return nil, lastErr
+}
+
+// poolSize is how many connections the run may open. It never exceeds the
+// number of files uploaded in parallel: a connection no worker ever picks is a
+// handshake for nothing.
+func poolSize(cfg *config.Config, log Logger) int {
+	n := cfg.Connections
+	if n < 1 {
+		n = 1 // a directly constructed config (tests) leaves this at zero
+	}
+	if cfg.Concurrency > 0 && n > cfg.Concurrency {
+		log.Infof("advanced.connections is %d but only %d file(s) upload in parallel; opening at most %d connection(s)",
+			n, cfg.Concurrency, cfg.Concurrency)
+		n = cfg.Concurrency
+	}
+	if n > 1 {
+		log.Infof("uploads may use up to %d connections", n)
+	}
+	return n
 }
 
 // permanentError marks a connect() failure that must never be retried: local
@@ -82,37 +119,75 @@ func isRetryableConnect(err error) bool {
 	return !strings.Contains(err.Error(), "ssh: unable to authenticate")
 }
 
-// current returns the live SFTP client and its generation. The generation is
+// acquire returns the live SFTP client serving the given file index, the
+// connection behind it and that connection's generation. The generation is
 // handed back to reconnect so that concurrent workers failing on the same
 // dead connection trigger only one redial between them.
-func (s *session) current() (*sftp.Client, int) {
+//
+// Files are spread over the pool round-robin. Connections past the first are
+// dialed on first use, so a run that uploads three files never pays for four
+// handshakes, and a server that refuses one (sshd's MaxSessions/MaxStartups,
+// a per-account connection limit on shared hosting) costs a warning rather
+// than the run: that slot falls back to the first connection.
+func (s *session) acquire(index int) (*sftp.Client, *conn, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.sftpClient, s.gen
+	slot := index % len(s.conns)
+	if s.conns[slot] == nil {
+		c, err := s.dial()
+		if err != nil {
+			s.log.Warningf("could not open connection %d of %d (%v); this run continues on its first connection",
+				slot+1, len(s.conns), err)
+			c = s.conns[0]
+		}
+		s.conns[slot] = c
+	}
+	c := s.conns[slot]
+	return c.sftp, c, c.gen
 }
 
-// currentSSH returns the live SSH client (used by the keepalive loop, which
-// must follow reconnects to the fresh transport).
-func (s *session) currentSSH() *ssh.Client {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.sshClient
+// dial opens one additional pooled connection. Must be called with s.mu held,
+// which also serializes the handshakes of a starting run: the alternative is
+// several workers dialing the same slot at once.
+//
+// Everything connect() logs is a property of the host and the configuration,
+// so an extra connection can only repeat what the first one already said (the
+// "connecting ..." line, the host key verdict). Outside debug mode those
+// repeats are dropped; a dial that actually fails comes back as an error, not
+// as a log line, and host key verification itself still runs per connection,
+// inside connect().
+func (s *session) dial() (*conn, error) {
+	log := s.log
+	if !s.cfg.Debug() {
+		log = quietLogger{s.log}
+	}
+	sshClient, sftpClient, closeJump, err := connect(s.cfg, log)
+	if err != nil {
+		return nil, err
+	}
+	return &conn{ssh: sshClient, sftp: sftpClient, closeJump: closeJump}, nil
 }
 
-// reconnect redials after a connection-class failure. gen is the generation
-// of the caller's failed client: when another worker already reconnected, the
-// fresh client is returned without dialing again. Reconnects are bounded by
-// the retries input; past that budget, or when the redial itself fails, an
-// error is returned and the caller gives up.
+// quietLogger swallows the log output of a repeat dial; see session.dial.
+type quietLogger struct{ Logger }
+
+func (quietLogger) Infof(string, ...any)    {}
+func (quietLogger) Warningf(string, ...any) {}
+
+// reconnect redials c after a connection-class failure. gen is the generation
+// of the caller's failed client: when another worker already reconnected it,
+// the fresh client is returned without dialing again. Reconnects are bounded
+// by the retries input (one budget for the whole pool); past that budget, or
+// when the redial itself fails, an error is returned and the caller gives up.
 //
 // The lock is held across the backoff and redial on purpose: workers that
-// fail in the meantime block in current()/reconnect() until the fresh client
+// fail in the meantime block in acquire()/reconnect() until the fresh client
 // is up, instead of hammering the dead one.
-func (s *session) reconnect(ctx context.Context, gen int) (*sftp.Client, error) {
+func (s *session) reconnect(ctx context.Context, c *conn, gen int) (*sftp.Client, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.gen != gen {
-		return s.sftpClient, nil
+	if c.gen != gen {
+		return c.sftp, nil
 	}
 	if s.reconnects >= s.cfg.Retries {
 		return nil, fmt.Errorf("connection lost and the reconnect budget is spent (%d, from the retries input)", s.cfg.Retries)
@@ -123,20 +198,57 @@ func (s *session) reconnect(ctx context.Context, gen int) (*sftp.Client, error) 
 	if err := sleepCtx(ctx, backoff); err != nil {
 		return nil, err
 	}
-	s.sftpClient.Close()
-	s.sshClient.Close()
-	s.closeJump()
+	c.sftp.Close()
+	c.ssh.Close()
+	c.closeJump()
 	sshClient, sftpClient, closeJump, err := connect(s.cfg, s.log)
 	if err != nil {
 		return nil, fmt.Errorf("reconnecting: %w", err)
 	}
-	s.sshClient, s.sftpClient, s.closeJump = sshClient, sftpClient, closeJump
-	s.gen++
-	return s.sftpClient, nil
+	c.ssh, c.sftp, c.closeJump = sshClient, sftpClient, closeJump
+	c.gen++
+	return c.sftp, nil
 }
 
-// do runs op against the live client, redialing on a connection-class failure
-// so the retried op runs against a fresh client instead of the dead one.
+// eachConn calls fn once per opened connection, skipping slots that were never
+// dialed and counting a connection shared by several slots (see acquire) once.
+// Must be called with s.mu held.
+func (s *session) eachConn(fn func(*conn)) {
+	seen := make(map[*conn]bool, len(s.conns))
+	for _, c := range s.conns {
+		if c == nil || seen[c] {
+			continue
+		}
+		seen[c] = true
+		fn(c)
+	}
+}
+
+// liveSSH returns the SSH client of every opened connection. Snapshotted under
+// the lock because reconnect swaps those fields; callers (the keepalive loop
+// and the stall watchdog) act on every connection the run has open.
+func (s *session) liveSSH() []*ssh.Client {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*ssh.Client
+	s.eachConn(func(c *conn) { out = append(out, c.ssh) })
+	return out
+}
+
+// closeSSH closes every live transport. The stall watchdog fires this: a
+// server that stalls one transfer has stalled the run (all connections share
+// its answer time), and closing the transports is what unblocks the SFTP
+// operations stuck on it.
+func (s *session) closeSSH() {
+	for _, c := range s.liveSSH() {
+		c.Close()
+	}
+}
+
+// do runs op against the first connection, redialing on a connection-class
+// failure so the retried op runs against a fresh client instead of the dead one.
+// Everything outside the per-file upload path goes through here, which keeps
+// remote scans, delete sweeps and manifest writes on one connection.
 // Reconnects share the run-wide budget (the retries input) with the upload
 // path; past that budget the original failure is returned. Non-connection
 // errors are returned as-is, untouched.
@@ -148,7 +260,7 @@ func (s *session) reconnect(ctx context.Context, gen int) (*sftp.Client, error) 
 // the connection died.
 func (s *session) do(ctx context.Context, watch *stallWatchdog, op func(*sftp.Client) error) error {
 	for {
-		client, gen := s.current()
+		client, c, gen := s.acquire(0)
 		if watch != nil {
 			watch.begin()
 		}
@@ -165,19 +277,21 @@ func (s *session) do(ctx context.Context, watch *stallWatchdog, op func(*sftp.Cl
 		if watch != nil && watch.fired.Load() {
 			return err
 		}
-		if _, rerr := s.reconnect(ctx, gen); rerr != nil {
+		if _, rerr := s.reconnect(ctx, c, gen); rerr != nil {
 			return fmt.Errorf("%w (%v)", err, rerr)
 		}
 	}
 }
 
-// close tears the session down at the end of the run.
+// close tears every connection of the session down at the end of the run.
 func (s *session) close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.sftpClient.Close()
-	s.sshClient.Close()
-	s.closeJump()
+	s.eachConn(func(c *conn) {
+		c.sftp.Close()
+		c.ssh.Close()
+		c.closeJump()
+	})
 }
 
 // isConnError reports whether err looks like the connection itself died (as

--- a/internal/uploader/stall.go
+++ b/internal/uploader/stall.go
@@ -10,15 +10,17 @@ import (
 // progress. Transfers mark themselves active for the duration of each upload
 // attempt and tick the watchdog on every read that moved bytes. A monitor
 // goroutine fires when transfers are active but no tick arrived for the
-// configured timeout; firing closes the SSH connection, which unblocks every
-// SFTP operation stuck on the stalled server with an error, so the run fails
-// in minutes with a clear message instead of hanging until the job-level
+// configured timeout; firing closes the run's SSH connections, which unblocks
+// every SFTP operation stuck on the stalled server with an error, so the run
+// fails in minutes with a clear message instead of hanging until the job-level
 // timeout.
 //
-// Closing the whole connection (rather than aborting just the stalled file)
-// is deliberate: all transfers share one SSH session, and a write blocked on
-// an exhausted SSH channel window cannot be interrupted any other way. A
-// server that stalls one transfer has stalled the session.
+// Closing whole connections (rather than aborting just the stalled file) is
+// deliberate: transfers share a connection, and a write blocked on an
+// exhausted SSH channel window cannot be interrupted any other way. With a
+// connection pool every connection goes, since the watchdog only knows that
+// the run as a whole stopped moving bytes: a server that stalls one transfer
+// has stalled the run.
 type stallWatchdog struct {
 	timeout time.Duration
 	kill    func() // closes the SSH connection

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -39,6 +39,7 @@ type testServer struct {
 	dropped       int32 // whether the first connection was already wrapped
 	stallAfter    int64 // if >0, stop reading (but stay connected) after this many bytes
 	refuseFirst   int32 // if >0, close this many first accepted connections immediately
+	maxConns      int32 // if >0, close every connection accepted beyond this many
 	accepted      int32 // total connections accepted, for asserting attempt counts
 
 	keepalives *int64 // if set, counts "keepalive@openssh.com" global requests received
@@ -114,6 +115,11 @@ func withFailSetstat() serverOption { return func(s *testServer) { s.failSetstat
 // handshake, simulating a transient outage (restarting sshd, network blip)
 // that clears after a moment.
 func withRefuseFirstConns(n int32) serverOption { return func(s *testServer) { s.refuseFirst = n } }
+
+// withMaxConns closes every connection accepted beyond the first n,
+// simulating a server that caps concurrent connections (sshd's MaxStartups,
+// or a per-account limit on shared hosting).
+func withMaxConns(n int32) serverOption { return func(s *testServer) { s.maxConns = n } }
 
 // withKeepaliveCounter makes the server tally every "keepalive@openssh.com"
 // global request it receives into c, instead of just discarding it.
@@ -546,7 +552,12 @@ func (s *testServer) acceptLoop() {
 		if err != nil {
 			return
 		}
-		if atomic.AddInt32(&s.accepted, 1) <= s.refuseFirst {
+		n := atomic.AddInt32(&s.accepted, 1)
+		if n <= s.refuseFirst {
+			conn.Close()
+			continue
+		}
+		if s.maxConns > 0 && n-s.refuseFirst > s.maxConns {
 			conn.Close()
 			continue
 		}

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -98,7 +98,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 			// The stat is read-only, so it also runs in dry-run mode: the
 			// preview then reports the same skips the real run would.
 			if skipUnchanged {
-				client, _ := sess.current()
+				client, _, _ := sess.acquire(i)
 				if fi, err := client.Stat(f.remotePath); err == nil && fi.Mode().IsRegular() && fi.Size() == f.size {
 					if cfg.LogPerFile() {
 						log.Infof("%sskip %s (remote file has the same size)", verb, f.remotePath)

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -5,8 +5,8 @@
 // transfer.go performs the uploads, retry.go wraps a single upload in the
 // retry/reconnect loop, remote.go holds the remote-path and remote-directory
 // helpers, connection.go dials the server (optionally through a jump host),
-// hostkeys.go verifies host keys, session.go owns the live client pair and
-// its reconnects, sync.go implements the sync strategy and its manifest, and
+// hostkeys.go verifies host keys, session.go owns the run's connections and
+// their reconnects, sync.go implements the sync strategy and its manifest, and
 // stall.go the stall watchdog. This file ties them together: Run and the
 // per-strategy dispatch.
 package uploader
@@ -101,11 +101,11 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 
 	keepaliveCtx, stopKeepalives := context.WithCancel(ctx)
 	defer stopKeepalives()
-	go sendKeepalives(keepaliveCtx, sess.currentSSH, keepaliveInterval)
+	go sendKeepalives(keepaliveCtx, sess.liveSSH, keepaliveInterval)
 
 	var watch *stallWatchdog
 	if cfg.StallTimeout > 0 {
-		watch = startStallWatchdog(cfg.StallTimeout, func() { sess.currentSSH().Close() }, log)
+		watch = startStallWatchdog(cfg.StallTimeout, sess.closeSSH, log)
 		defer watch.stop()
 	}
 

--- a/internal/uploader/uploader_test.go
+++ b/internal/uploader/uploader_test.go
@@ -776,7 +776,7 @@ func TestSendKeepalivesPingsUntilCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		sendKeepalives(ctx, func() *ssh.Client { return sshClient }, 10*time.Millisecond)
+		sendKeepalives(ctx, func() []*ssh.Client { return []*ssh.Client{sshClient} }, 10*time.Millisecond)
 		close(done)
 	}()
 

--- a/schema/easysftp.schema.json
+++ b/schema/easysftp.schema.json
@@ -160,6 +160,10 @@
           "description": "Maximum in-flight SFTP requests per file (pipelining within one file's transfer), or \"auto\" for the built-in default.",
           "$ref": "#/$defs/autoInt"
         },
+        "connections": {
+          "description": "Number of SSH connections uploads may spread over (default 1, never more than concurrency). More connections lift the single-TCP-flow and single-cipher-stream ceiling on high-latency links, but some servers and shared hosts limit concurrent connections per account.",
+          "$ref": "#/$defs/autoInt"
+        },
         "skip_unchanged": {
           "description": "For overlay deployments, skip uploading a file when the remote file already exists with the same size (coarse; use mode sync for exact content comparison).",
           "type": "boolean"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -12,6 +12,10 @@
 #
 #   CANDIDATE_BIN, CANDIDATE_REF  build under test and the ref it was built from
 #   BASELINE_BIN,  BASELINE_REF   optional comparison build (may be empty)
+#   BENCH_CONNECTIONS             optional: measure the candidate a second time
+#                                 with advanced.connections set to this many SSH
+#                                 connections (issue #158), as a third build
+#                                 label "poolN"
 #   REPEATS                       measured repeats per scenario (default 3)
 #   REMOTE_BASE                   remote directory this benchmark owns
 #   OUT_DIR                       results.json and summary.md land here
@@ -75,9 +79,15 @@ REPEATS=${REPEATS:-3}
 BENCH_PORT=${BENCH_PORT:-22}
 BASELINE_BIN=${BASELINE_BIN:-}
 BASELINE_REF=${BASELINE_REF:-}
+BENCH_CONNECTIONS=${BENCH_CONNECTIONS:-}
 
 if [[ ! "$REPEATS" =~ ^[1-9][0-9]*$ ]]; then
   echo "::error::REPEATS must be a positive integer, got '$REPEATS'" >&2
+  exit 1
+fi
+
+if [[ -n "$BENCH_CONNECTIONS" && ! "$BENCH_CONNECTIONS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::BENCH_CONNECTIONS must be a positive integer, got '$BENCH_CONNECTIONS'" >&2
   exit 1
 fi
 
@@ -132,24 +142,53 @@ generate_dataset() {
   done
 }
 
-# run_easysftp <binary> <source> <remote> <mode> <log> <outputs-file>
+# run_easysftp <binary> <source> <remote> <mode> <log> <outputs-file> [connections]
+#
+# Without a connections value this is an inline run, exactly what a workflow
+# with source/target inputs does. With one, the run goes through a generated
+# config file instead: advanced.connections has no input (every non-secret
+# setting has exactly one home in v3), and inline inputs may not be combined
+# with a config file. That file names the host and the user, so it is written
+# to LOG_DIR, which is never uploaded as an artifact.
+#
 # BENCH_* are never assigned here: they come from the environment and
 # require_env has already refused an empty one.
 # shellcheck disable=SC2153
 run_easysftp() {
-  local binary=$1 source=$2 remote=$3 mode=$4 log=$5 outputs=$6
+  local binary=$1 source=$2 remote=$3 mode=$4 log=$5 outputs=$6 connections=${7:-}
   : >"$outputs"
-  env \
-    GITHUB_OUTPUT="$outputs" \
-    EASYSFTP_HOST="$BENCH_HOST" \
-    EASYSFTP_PORT="$BENCH_PORT" \
-    EASYSFTP_USERNAME="$BENCH_USERNAME" \
-    EASYSFTP_PASSWORD="$BENCH_PASSWORD" \
-    EASYSFTP_KNOWN_HOSTS="$BENCH_KNOWN_HOSTS" \
-    EASYSFTP_SOURCE="$source" \
-    EASYSFTP_TARGET="$remote" \
-    EASYSFTP_MODE="$mode" \
-    "$binary" >"$log" 2>&1
+  local -a vars=(GITHUB_OUTPUT="$outputs" EASYSFTP_PASSWORD="$BENCH_PASSWORD")
+  if [[ -n "$connections" ]]; then
+    local config="$LOG_DIR/config.yml"
+    {
+      echo "version: 3"
+      echo "connection:"
+      echo "  host: \"$BENCH_HOST\""
+      echo "  port: $BENCH_PORT"
+      echo "  username: \"$BENCH_USERNAME\""
+      echo "  known_hosts: |"
+      printf '%s\n' "$BENCH_KNOWN_HOSTS" | sed 's/^/    /'
+      echo "deployments:"
+      echo "  benchmark:"
+      echo "    source: \"$source\""
+      echo "    target: \"$remote\""
+      echo "    mode: $mode"
+      echo "advanced:"
+      echo "  connections: $connections"
+    } >"$config"
+    vars+=(EASYSFTP_CONFIG="$config")
+  else
+    vars+=(
+      EASYSFTP_HOST="$BENCH_HOST"
+      EASYSFTP_PORT="$BENCH_PORT"
+      EASYSFTP_USERNAME="$BENCH_USERNAME"
+      EASYSFTP_KNOWN_HOSTS="$BENCH_KNOWN_HOSTS"
+      EASYSFTP_SOURCE="$source"
+      EASYSFTP_TARGET="$remote"
+      EASYSFTP_MODE="$mode"
+    )
+  fi
+  env "${vars[@]}" "$binary" >"$log" 2>&1
 }
 
 # step_number <outputs-file> <name>: reads a number written in the
@@ -177,9 +216,9 @@ count_matches() {
   fi
 }
 
-# measure <label> <binary> <ref> <scenario> <repeat>
+# measure <label> <binary> <ref> <scenario> <repeat> <connections>
 measure() {
-  local label=$1 binary=$2 ref=$3 scenario=$4 repeat=$5
+  local label=$1 binary=$2 ref=$3 scenario=$4 repeat=$5 connections=$6
   local remote="$REMOTE_BASE/$label/$scenario"
   local stem="$LOG_DIR/$label-$scenario-$repeat"
   local code=0
@@ -187,12 +226,12 @@ measure() {
   # Unmeasured: every repeat starts from the same empty remote directory, so
   # repeat 1 (uploading into nothing) measures the same thing as the repeats
   # after it (which would otherwise overwrite existing files).
-  if ! run_easysftp "$binary" "$DATASET_DIR/empty" "$remote" clean "$stem.clean.log" "$stem.clean.out"; then
+  if ! run_easysftp "$binary" "$DATASET_DIR/empty" "$remote" clean "$stem.clean.log" "$stem.clean.out" "$connections"; then
     echo "::warning::pre-clean of $label/$scenario repeat $repeat failed"
     cat "$stem.clean.log"
   fi
 
-  run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" overlay "$stem.log" "$stem.out" || code=$?
+  run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" overlay "$stem.log" "$stem.out" "$connections" || code=$?
   if ((code != 0)); then
     # Into the job log, which masks secrets. Never into the artifact.
     echo "::warning::$label/$scenario repeat $repeat exited $code"
@@ -210,6 +249,7 @@ measure() {
     --argjson bytes "$(step_number "$stem.out" bytes-uploaded)" \
     --argjson retries "$(count_matches "$stem.log" -e retrying -e reconnecting)" \
     --argjson errors "$(count_matches "$stem.log" '^::error::')" \
+    --argjson refused "$(count_matches "$stem.log" -e 'could not open connection')" \
     '$ARGS.named' >>"$runs_file"
 
   echo "$label/$scenario repeat $repeat: $(step_number "$stem.out" duration-ms) ms, exit $code"
@@ -218,10 +258,21 @@ measure() {
 labels=(candidate)
 binaries=("$CANDIDATE_BIN")
 refs=("$CANDIDATE_REF")
+conns=("")
 if [[ -n "$BASELINE_BIN" ]]; then
   labels+=(baseline)
   binaries+=("$BASELINE_BIN")
   refs+=("${BASELINE_REF:-unknown}")
+  conns+=("")
+fi
+# The connection pool is measured as a third build of the *same* binary, not
+# as a separate workflow run: the two numbers are only comparable when they
+# are interleaved on the same host in the same minutes.
+if [[ -n "$BENCH_CONNECTIONS" ]]; then
+  labels+=("pool$BENCH_CONNECTIONS")
+  binaries+=("$CANDIDATE_BIN")
+  refs+=("$CANDIDATE_REF")
+  conns+=("$BENCH_CONNECTIONS")
 fi
 
 generate_dataset
@@ -229,7 +280,7 @@ generate_dataset
 for scenario in "${SCENARIOS[@]}"; do
   for ((repeat = 1; repeat <= REPEATS; repeat++)); do
     for i in "${!labels[@]}"; do
-      measure "${labels[$i]}" "${binaries[$i]}" "${refs[$i]}" "$scenario" "$repeat"
+      measure "${labels[$i]}" "${binaries[$i]}" "${refs[$i]}" "$scenario" "$repeat" "${conns[$i]}"
     done
   done
 done
@@ -240,7 +291,7 @@ for scenario in "${SCENARIOS[@]}"; do
   for i in "${!labels[@]}"; do
     stem="$LOG_DIR/cleanup-${labels[$i]}-$scenario"
     run_easysftp "${binaries[$i]}" "$DATASET_DIR/empty" \
-      "$REMOTE_BASE/${labels[$i]}/$scenario" clean "$stem.log" "$stem.out" ||
+      "$REMOTE_BASE/${labels[$i]}/$scenario" clean "$stem.log" "$stem.out" "${conns[$i]}" ||
       echo "::warning::cleanup of ${labels[$i]}/$scenario failed"
   done
 done
@@ -261,7 +312,8 @@ jq -s '
       min_ms: (map(.duration_ms) | min),
       max_ms: (map(.duration_ms) | max),
       retries: (map(.retries) | add),
-      errors: (map(.errors) | add)
+      errors: (map(.errors) | add),
+      refused_connections: (map(.refused) | add)
     })
   | map(. + {
       mib_per_s: (if .median_ms > 0 then (.bytes / 1048576) / (.median_ms / 1000) else 0 end),
@@ -269,18 +321,24 @@ jq -s '
     })
 ' "$runs_file" >"$aggregate_file"
 
+settings="easySFTP defaults (no advanced.* overrides): concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay"
+if [[ -n "$BENCH_CONNECTIONS" ]]; then
+  settings="$settings; the pool$BENCH_CONNECTIONS build is the same binary with advanced.connections: $BENCH_CONNECTIONS"
+fi
+
 jq -n \
   --slurpfile results "$aggregate_file" \
   --arg candidate_ref "$CANDIDATE_REF" \
   --arg baseline_ref "$BASELINE_REF" \
   --argjson repeats "$REPEATS" \
   --arg runner "${RUNNER_ENVIRONMENT:-local}, $(uname -sr), $(nproc) cpu" \
+  --arg settings "$settings" \
   '{
      candidate_ref: $candidate_ref,
      baseline_ref: $baseline_ref,
      repeats: $repeats,
      runner: $runner,
-     settings: "easySFTP defaults (no advanced.* overrides): concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay",
+     settings: $settings,
      scenarios: {
        small: "300 files x 4 KiB",
        mixed: "40 x 16 KiB + 12 x 256 KiB + 4 x 2 MiB",
@@ -289,8 +347,14 @@ jq -n \
      results: $results[0]
    }' >"$OUT_DIR/results.json"
 
-# summary.md carries the same numbers, readable. The delta column compares the
-# candidate's median against the baseline's; negative means faster.
+# summary.md carries the same numbers, readable. The delta column compares
+# every build's median against the reference build's; negative means faster.
+# The reference is the baseline when one was measured, otherwise the candidate,
+# so a pool run without a baseline is still compared against something.
+reference_label=candidate
+if [[ -n "$BASELINE_BIN" ]]; then
+  reference_label=baseline
+fi
 {
   echo "## easySFTP benchmark"
   echo
@@ -300,13 +364,13 @@ jq -n \
   echo "| Baseline | \`${BASELINE_REF:-none}\` |"
   echo "| Repeats per scenario | $REPEATS |"
   echo "| Runner | $(uname -sr), $(nproc) cpu |"
-  echo "| Settings | easySFTP defaults: concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay |"
+  echo "| Settings | $settings |"
   echo
   echo "| Scenario | Build | Files | Size | Median | Min | Max | MiB/s | files/s | Retries | Errors | Failed runs | Delta |"
   echo "|---|---|---|---|---|---|---|---|---|---|---|---|---|"
   for scenario in "${SCENARIOS[@]}"; do
-    baseline_median=$(jq -r --arg s "$scenario" \
-      'map(select(.scenario == $s and .label == "baseline")) | .[0].median_ms // empty' "$aggregate_file")
+    baseline_median=$(jq -r --arg s "$scenario" --arg r "$reference_label" \
+      'map(select(.scenario == $s and .label == $r)) | .[0].median_ms // empty' "$aggregate_file")
     for label in "${labels[@]}"; do
       row=$(jq -r --arg s "$scenario" --arg l "$label" '
         map(select(.scenario == $s and .label == $l)) | .[0]
@@ -317,12 +381,21 @@ jq -n \
         | @tsv' "$aggregate_file")
       IFS=$'\t' read -r files mib median min max mibs fps retries errors failed <<<"$row"
       delta='-'
-      if [[ "$label" == candidate && -n "$baseline_median" && "$baseline_median" != 0 ]]; then
+      if [[ "$label" != "$reference_label" && -n "$baseline_median" && "$baseline_median" != 0 ]]; then
         delta=$(awk -v c="$median" -v b="$baseline_median" 'BEGIN { printf "%+.1f%%", (c - b) / b * 100 }')
       fi
       echo "| $scenario | $label | $files | ${mib} MiB | ${median} ms | ${min} ms | ${max} ms | $mibs | $fps | $retries | $errors | $failed | $delta |"
     done
   done
+  echo
+  echo "Delta compares each build's median against the \`$reference_label\` build; negative is faster."
+  # Without this line a pool run whose extra connections the server refused
+  # reads as "the pool did nothing", which is the wrong conclusion entirely.
+  refused=$(jq '[.[].refused_connections] | add' "$aggregate_file")
+  if [[ "$refused" != 0 ]]; then
+    echo
+    echo "**$refused connection(s) were refused by the server** and fell back to the run's first connection, so a pool build measured here had fewer connections than configured."
+  fi
   echo
   echo "Data only: these numbers set no threshold and fail no build. Collected to evaluate the single-connection ceiling discussed in issue #158."
 } >"$OUT_DIR/summary.md"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -391,7 +391,7 @@ fi
   echo "Delta compares each build's median against the \`$reference_label\` build; negative is faster."
   # Without this line a pool run whose extra connections the server refused
   # reads as "the pool did nothing", which is the wrong conclusion entirely.
-  refused=$(jq '[.[].refused_connections] | add' "$aggregate_file")
+  refused=$(jq '[.[].refused_connections] | add // 0' "$aggregate_file")
   if [[ "$refused" != 0 ]]; then
     echo
     echo "**$refused connection(s) were refused by the server** and fell back to the run's first connection, so a pool build measured here had fewer connections than configured."


### PR DESCRIPTION
Closes #158.

## What

`advanced.connections: N` (config file only, default `1`) spreads a
deployment's parallel uploads over up to N SSH connections instead of one.
Everything else about a run is unchanged.

The issue's own sequencing was "measure first, and only build the pool if the
numbers show the single connection is actually the binding constraint". The
benchmark on the self-hosted runner exists now but could not answer that
question, because answering it needs a build that can open more than one
connection. So this PR builds the pool **and** the measurement for it, keeps
it off by default, and the benchmark numbers below decide whether it is worth
turning on.

## Design decisions (the ones #158 asked about)

| Question from the issue | Answer here |
|---|---|
| One reconnect budget or one per connection? | One, run-wide, as `retries` always was. More connections drop faster, and a per-connection budget would multiply a failing run's patience by N. |
| Which connection does the stall watchdog close? | All of them. The watchdog only knows the run stopped moving bytes, not which connection stalled. |
| Server-side limits (`MaxSessions`, `MaxStartups`, shared hosting) | The default stays 1, so nothing changes unless asked. A refused extra connection warns once and that slot falls back to the first connection: a too-high value costs a warning, never the deploy. |
| Authentication cost on short runs | Connections past the first are dialed on first use, so a three-file deploy opens one connection even with `connections: 8`. |
| Host key verification per connection | Yes, every connection goes through `connect()`. Its repeated log lines are dropped outside debug mode (same host, same verdict); warnings about a *failed* dial still surface. |

Two more, decided the same conservative way:

- The pool is capped at `advanced.concurrency`: a connection no worker ever
  picks is a handshake for nothing.
- Only the per-file upload path uses the pool. Remote scans, delete sweeps,
  manifest writes and directory setup stay on the first connection, so
  `sess.do`'s reconnect behavior (issues #107, #115) is untouched.

Where the setting lives follows the v3 rule: it is a sibling of
`advanced.concurrency` and `advanced.request_concurrency`, so it is a config
file field, not an input. No `action.yml` change.

## Measuring it

`scripts/benchmark.sh` gained `BENCH_CONNECTIONS` (workflow input
`connections`). It adds a third build labelled `poolN`: the **same candidate
binary**, run through a generated config file with `advanced.connections: N`,
interleaved repeat by repeat with the others, because two numbers from two
separate runs against a shared host are not comparable. Refused connections
are counted and called out under the table, since a pool run whose extra
connections the server rejected would otherwise read as "the pool did
nothing".

## Numbers

Measured on the self-hosted runner, candidate `perf/connection-pool` vs
baseline `main`, `connections: 4`, 3 repeats, interleaved:
[run 30298465159](https://github.com/eiserv/easySFTP/actions/runs/30298465159),
stored as
[`benchmarks/manual-20260727T193100Z-perf-connection-pool.md`](../blob/main/benchmarks/manual-20260727T193100Z-perf-connection-pool.md).

| Scenario | baseline (median) | candidate, 1 conn | **pool4** | pool4 vs baseline |
|---|---|---|---|---|
| small (300 x 4 KiB) | 12531 ms | 13404 ms (+7.0%) | **11457 ms** | **-8.6%** |
| mixed (40x16 KiB + 12x256 KiB + 4x2 MiB) | 30615 ms | 27665 ms (-9.6%) | **18503 ms** | **-39.6%** |
| large (2 x 16 MiB) | 71267 ms | 70694 ms (-0.8%) | **48094 ms** | **-32.5%** |

Reading it:

- **The single connection was the binding constraint on this host.** Four
  connections cut a website-shaped payload by ~40% and a bulk transfer by
  ~33%, with `concurrency` and `request_concurrency` untouched at their
  defaults. That is exactly the ceiling #158 described, and it is real, not
  theoretical.
- **The small-file case barely moves (-8.6%)**, also as predicted: 300 files
  of 4 KiB are per-file round-trips, not bandwidth, so more flows buy little.
- **The default path did not regress.** The candidate at its default of one
  connection lands within run-to-run noise of the baseline in all three
  scenarios (+7.0% / -9.6% / -0.8%; the small-file spread alone is 12.6-14.6 s
  across three repeats).
- **`large` only ever used two connections**, not four: the scenario has two
  files and files are what spread over the pool. The -32.5% there comes from
  two flows.
- Zero refused connections, zero retries, zero errors across all 27 runs, so
  the degradation path was not exercised here (its unit test is).

One host, one day, one payload shape: worth reading as "this lever works and
is worth offering", not as a number anyone should expect on their own server.
Which is why it stays off by default and the documentation says to measure.

## Tests

- `internal/uploader/pool_test.go`: the configured number of connections is
  actually opened (and exactly one by default), the pool is capped at
  concurrency, and a server that refuses extra connections still gets a
  complete, successful deploy plus a warning.
- `internal/config`: `advanced.connections` parses, defaults to 1 in both
  modes, and `0` is rejected.
- `go test ./...` passes. **Not** run with `-race` locally (no C toolchain on
  this machine, and `-race` needs cgo); CI runs it.

