### PR TITLE
fix: store nanosecond mtimes in the sync manifest so same-second edits deploy

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -105,9 +105,12 @@ for it last time, its stored hash is reused and the file is never re-read.
 This is the same trade rsync's "quick check" makes.
 
 **The trade-off, precisely:** a file whose content changed *without* its size
-or modification time changing is invisible to this check and will be missed;
-for example, two edits that happen to produce the same file size within the
-same mtime second (mtimes have one-second resolution on most filesystems).
+or modification time changing is invisible to this check and will be missed.
+Modification times are compared at nanosecond resolution, so on common
+filesystems (ext4, APFS, NTFS) that takes two same-size edits with
+bit-identical timestamps; on filesystems with coarse timestamps (FAT stores
+2-second mtimes, and some network filesystems round to seconds), the window
+stays as wide as the filesystem's own clock.
 Without `fast_path`, `sync` never misses a content change, because it
 always compares actual content hashes; this is what you give up in exchange
 for skipping local reads.
@@ -124,9 +127,10 @@ If you suspect a stale hash was reused for the wrong reason, delete the
 target's `.easysftp-manifest.json` (or run `mode: clean` once) to force a
 full re-hash on the next sync.
 
-Manifests written before this option existed have no recorded modification
-time; the first sync after upgrading re-hashes everything once and then
-starts recording it. (A v2 manifest is read seamlessly.)
+Manifests written by older easySFTP versions are read seamlessly, but their
+recorded modification times are not comparable (v1 recorded none, v2 recorded
+whole seconds); the first sync after upgrading re-hashes everything once and
+then records nanosecond times from there on.
 
 ## `clean`
 

--- a/internal/uploader/planner.go
+++ b/internal/uploader/planner.go
@@ -22,7 +22,7 @@ type fileItem struct {
 	remotePath string // slash-separated remote path
 	rel        string // slash path relative to the remote base (manifest key)
 	size       int64
-	mtime      int64 // local modification time, unix seconds
+	mtime      int64 // local modification time, unix nanoseconds
 	mode       fs.FileMode
 	hash       string // sha256 hex of the local content; only set for the sync strategy
 }
@@ -111,7 +111,7 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, opts planOption
 			remotePath: remotePath,
 			rel:        filepath.Base(pair.Local),
 			size:       info.Size(),
-			mtime:      info.ModTime().Unix(),
+			mtime:      info.ModTime().UnixNano(),
 			mode:       info.Mode(),
 		})
 		p.remoteDirs = parentDirs(remotePath)
@@ -162,7 +162,7 @@ func buildPlan(pair config.UploadPair, strategy config.Strategy, opts planOption
 			remotePath: path.Join(remoteBase, rel),
 			rel:        rel,
 			size:       fi.Size(),
-			mtime:      fi.ModTime().Unix(),
+			mtime:      fi.ModTime().UnixNano(),
 			mode:       fi.Mode(),
 		}
 		p.files = append(p.files, item)
@@ -199,11 +199,13 @@ func dirsForFiles(files []fileItem) []string {
 // the sync strategy, whose changed-file detection compares content hashes.
 //
 // cached is the previous sync's manifest entries, keyed by relative path. When
-// a file's size and mtime still match its cached entry, its hash is reused
-// instead of re-reading the file (the same fast path rsync's "quick check"
-// uses). A cached entry with mtime 0 (a manifest written before this fast
-// path existed) never matches, so upgrading from an older manifest costs one
-// full re-hash and nothing more.
+// a file's size and mtime (nanosecond resolution, see fileItem.mtime) still
+// match its cached entry, its hash is reused instead of re-reading the file
+// (the same fast path rsync's "quick check" uses). A cached entry with mtime 0
+// never matches; readManifest hands over v1 entries (no mtime recorded) and
+// v2 entries (whole-second mtimes, not comparable to the nanosecond values
+// recorded now) that way, so upgrading from an older manifest costs one full
+// re-hash and nothing more.
 func hashPlanFiles(ctx context.Context, files []fileItem, concurrency int, cached map[string]manifestEntry) error {
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(concurrency)

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -19,18 +19,23 @@ import (
 )
 
 // manifestVersion is written to every manifest this version of easySFTP
-// produces. v1 manifests (hash only, no size/mtime) are still read; see
-// readManifest.
-const manifestVersion = 2
+// produces. Older manifests are still read: v1 (hash only, no size/mtime)
+// and v2 (mtime in whole seconds); see readManifest.
+const manifestVersion = 3
 
 // manifestEntry records what is known about one file from the last sync.
-// Size and MTime enable the size+mtime fast path in hashPlanFiles: a v1
-// manifest entry has MTime 0, which never matches and always falls back to a
-// full re-hash.
+// Size and MTime enable the size+mtime fast path in hashPlanFiles: an entry
+// with MTime 0 never matches and always falls back to a full re-hash.
+//
+// v3 records MTime in nanoseconds. v2 recorded whole seconds, which made a
+// same-size edit landing in the same wall-clock second as the recorded time
+// invisible to the fast path, so the file was silently never re-uploaded
+// (issue #162). Nanoseconds narrow that window to the filesystem's actual
+// timestamp granularity.
 type manifestEntry struct {
 	Hash  string `json:"hash"`
 	Size  int64  `json:"size"`
-	MTime int64  `json:"mtime"` // local modification time at upload, unix seconds
+	MTime int64  `json:"mtime"` // local modification time at upload, unix nanoseconds
 }
 
 // manifest records what the last sync uploaded, keyed by relative path.
@@ -237,10 +242,12 @@ func writeRecoveryManifest(ctx context.Context, cfg *config.Config, sess *sessio
 // into "first sync": the caller (sess.do) reconnects and retries the read, so
 // a mid-run drop cannot silently discard the manifest.
 //
-// Both the current (v2: hash+size+mtime) and old (v1: hash only) formats are
-// accepted; a v1 entry decodes with MTime 0, which never matches the fast
-// path in hashPlanFiles, so upgrading from a v1 manifest costs one full
-// re-hash and then writes v2 from then on.
+// All three formats are accepted: v3 (hash+size+mtime in nanoseconds), v2
+// (hash+size+mtime in whole seconds) and v1 (hash only). A v1 entry decodes
+// with MTime 0 and a v2 entry has its whole-second MTime dropped to 0, since
+// it must never be compared against the nanosecond values recorded now.
+// MTime 0 never matches the fast path in hashPlanFiles, so upgrading from an
+// older manifest costs one full re-hash and then writes v3 from then on.
 func readManifest(client *sftp.Client, dir, name string, log Logger) (manifest, error) {
 	empty := manifest{Version: manifestVersion, Files: map[string]manifestEntry{}}
 	f, err := client.Open(path.Join(dir, name))
@@ -264,9 +271,19 @@ func readManifest(client *sftp.Client, dir, name string, log Logger) (manifest, 
 		return empty, nil
 	}
 
-	var v2 manifest
-	if err := json.Unmarshal(data, &v2); err == nil && v2.Files != nil {
-		return v2, nil
+	var m manifest
+	if err := json.Unmarshal(data, &m); err == nil && m.Files != nil {
+		if m.Version < 3 {
+			// A v2 manifest recorded mtimes in whole seconds. Zero them so
+			// the fast path in hashPlanFiles never takes a second-resolution
+			// value for a nanosecond one; the hashes stay valid, only the
+			// one-time full re-hash is paid (exactly like the v1 upgrade).
+			for rel, e := range m.Files {
+				e.MTime = 0
+				m.Files[rel] = e
+			}
+		}
+		return m, nil
 	}
 
 	var v1 struct {

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -253,9 +253,9 @@ func TestHashPlanFilesFastPathReusesCachedHash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	files := []fileItem{{localPath: p, rel: "a.txt", size: fi.Size(), mtime: fi.ModTime().Unix()}}
+	files := []fileItem{{localPath: p, rel: "a.txt", size: fi.Size(), mtime: fi.ModTime().UnixNano()}}
 	cached := map[string]manifestEntry{
-		"a.txt": {Hash: "stale-cached-hash", Size: fi.Size(), MTime: fi.ModTime().Unix()},
+		"a.txt": {Hash: "stale-cached-hash", Size: fi.Size(), MTime: fi.ModTime().UnixNano()},
 	}
 
 	if err := hashPlanFiles(context.Background(), files, 4, cached); err != nil {
@@ -284,12 +284,13 @@ func TestHashPlanFilesFastPathMissOnMismatch(t *testing.T) {
 	}
 
 	cases := []manifestEntry{
-		{Hash: "stale", Size: fi.Size() + 1, MTime: fi.ModTime().Unix()}, // size mismatch
-		{Hash: "stale", Size: fi.Size(), MTime: fi.ModTime().Unix() + 1}, // mtime mismatch
-		{Hash: "stale", Size: fi.Size(), MTime: 0},                       // v1 upgrade: MTime unknown
+		{Hash: "stale", Size: fi.Size() + 1, MTime: fi.ModTime().UnixNano()}, // size mismatch
+		{Hash: "stale", Size: fi.Size(), MTime: fi.ModTime().UnixNano() + 1}, // mtime mismatch (one nanosecond off)
+		{Hash: "stale", Size: fi.Size(), MTime: fi.ModTime().Unix()},         // v2 upgrade: whole seconds, never comparable
+		{Hash: "stale", Size: fi.Size(), MTime: 0},                           // v1 upgrade: MTime unknown
 	}
 	for _, entry := range cases {
-		files := []fileItem{{localPath: p, rel: "a.txt", size: fi.Size(), mtime: fi.ModTime().Unix()}}
+		files := []fileItem{{localPath: p, rel: "a.txt", size: fi.Size(), mtime: fi.ModTime().UnixNano()}}
 		cached := map[string]manifestEntry{"a.txt": entry}
 		if err := hashPlanFiles(context.Background(), files, 4, cached); err != nil {
 			t.Fatal(err)
@@ -340,13 +341,60 @@ func TestSyncFastPathSkipsUnchangedFile(t *testing.T) {
 	}
 }
 
-// Documents the known limitation: with sync-fast-path on, a same-size edit
-// that lands within the same mtime second as the file it replaces is
-// invisible to the size+mtime check and is missed, which is exactly the
-// tradeoff action.yml and docs/strategies.md describe. This is not a "should"
-// test; it pins the documented behavior so a future change to the comparison
-// doesn't silently alter it either way.
-func TestSyncFastPathMissesSameSecondSameSizeEdit(t *testing.T) {
+// The regression #162 fixes: with sync-fast-path on, a same-size edit landing
+// in the same wall-clock second as the recorded upload was invisible to the
+// old whole-second mtime comparison and silently never deployed. Nanosecond
+// mtimes make the second run see the changed timestamp, re-hash and upload.
+func TestSyncFastPathCatchesSameSecondSameSizeEdit(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1"})
+	file := filepath.Join(local, "a.txt")
+
+	// Pin the first upload's mtime to a known sub-second timestamp, and skip
+	// on filesystems that round it away (FAT and some network filesystems):
+	// there the window simply stays as wide as the filesystem's clock.
+	first := time.Now().Truncate(time.Second).Add(100 * time.Millisecond)
+	if err := os.Chtimes(file, first, first); err != nil {
+		t.Fatal(err)
+	}
+	if fi, err := os.Stat(file); err != nil || fi.ModTime().Nanosecond() == 0 {
+		t.Skipf("filesystem stores whole-second mtimes (stat err %v); sub-second detection cannot apply here", err)
+	}
+
+	cfg := syncConfig(srv, local)
+	cfg.SyncFastPath = true
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same size ("1" -> "2"), 200ms later within the same second: exactly the
+	// build-then-postprocess churn CI produces.
+	writeTree(t, local, map[string]string{"a.txt": "2"})
+	second := first.Add(200 * time.Millisecond)
+	if err := os.Chtimes(file, second, second); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 1 {
+		t.Fatalf("same-second same-size edit: got %d uploads, want 1", stats.FilesUploaded)
+	}
+	if got := readRemote(t, srv, "/www/a.txt"); got != "2" {
+		t.Fatalf("same-second same-size edit was not deployed: remote content %q", got)
+	}
+}
+
+// Documents the remaining (much narrower) limitation: a same-size edit whose
+// mtime is bit-for-bit identical to the recorded one, down to the nanosecond,
+// is still invisible to the size+mtime check, which is the tradeoff
+// docs/strategies.md describes. This is not a "should" test; it pins the
+// documented behavior so a future change to the comparison doesn't silently
+// alter it either way.
+func TestSyncFastPathMissesIdenticalMtimeSameSizeEdit(t *testing.T) {
 	srv := startTestServer(t)
 	local := t.TempDir()
 	writeTree(t, local, map[string]string{"a.txt": "1"})
@@ -365,8 +413,7 @@ func TestSyncFastPathMissesSameSecondSameSizeEdit(t *testing.T) {
 	mtime := fi.ModTime()
 
 	// Same size ("1" -> "2"), mtime forced back to exactly what the manifest
-	// already recorded, simulating two same-size edits landing in the same
-	// mtime second, which second-granularity filesystem clocks make common.
+	// already recorded, nanoseconds included.
 	writeTree(t, local, map[string]string{"a.txt": "2"})
 	if err := os.Chtimes(filepath.Join(local, "a.txt"), mtime, mtime); err != nil {
 		t.Fatal(err)
@@ -376,7 +423,7 @@ func TestSyncFastPathMissesSameSecondSameSizeEdit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got := readRemote(t, srv, "/www/a.txt"); got != "1" {
-		t.Fatalf("expected the fast path to miss the edit and leave the old content, got %q", got)
+		t.Fatalf("expected the fast path to miss the identical-mtime edit and leave the old content, got %q", got)
 	}
 }
 
@@ -439,6 +486,66 @@ func TestSyncUpgradesV1Manifest(t *testing.T) {
 	}
 	if e := got.Files["a.txt"]; e.Size == 0 || e.MTime == 0 {
 		t.Errorf("rewritten manifest entry missing size/mtime: %+v", e)
+	}
+}
+
+// A v2 manifest recorded mtimes in whole seconds; those must never be taken
+// for the nanosecond values v3 records, or a stale hash could be reused. Here
+// the v2 entry carries a stale hash with a matching size and (whole-second)
+// mtime: the upgrade must drop the second-resolution mtime, re-hash the file
+// for real, catch the mismatch and re-upload, then write a v3 manifest with
+// the nanosecond mtime recorded.
+func TestSyncUpgradesV2ManifestWithFullRehash(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "2"})
+	fi, err := os.Stat(filepath.Join(local, "a.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/www"); err != nil {
+		t.Fatal(err)
+	}
+	// What a pre-v3 easySFTP left behind after uploading the old content "1":
+	// its hash, the (same) size, and the mtime truncated to whole seconds.
+	v2 := fmt.Sprintf(`{"version":2,"files":{"a.txt":{"hash":"stale-hash-of-old-content","size":%d,"mtime":%d}}}`,
+		fi.Size(), fi.ModTime().Unix())
+	f, err := client.Create("/www/" + manifestName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte(v2)); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	wf, err := client.Create("/www/a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf.Write([]byte("1"))
+	wf.Close()
+
+	cfg := syncConfig(srv, local)
+	cfg.SyncFastPath = true
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 1 {
+		t.Fatalf("upgrading a v2 manifest: got %d uploads, want 1 (the stale hash must not be reused)", stats.FilesUploaded)
+	}
+	if got := readRemote(t, srv, "/www/a.txt"); got != "2" {
+		t.Fatalf("changed file was not deployed during the v2 upgrade: %q", got)
+	}
+
+	m := readRemoteManifest(t, srv)
+	if m.Version != manifestVersion {
+		t.Errorf("rewritten manifest version = %d, want %d", m.Version, manifestVersion)
+	}
+	if e := m.Files["a.txt"]; e.MTime != fi.ModTime().UnixNano() {
+		t.Errorf("rewritten manifest mtime = %d, want the nanosecond %d", e.MTime, fi.ModTime().UnixNano())
 	}
 }
 

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -224,8 +224,10 @@ func uploadFile(ctx context.Context, env *transferEnv, f fileItem, index int, mo
 	// preserve-times (timesWarned non-nil): keep the local modification time
 	// instead of "now". After the rename, so the request targets the final
 	// path; a failure warns once per deployment and never fails the deploy.
+	// f.mtime is unix nanoseconds; the SFTP SETSTAT request carries whole
+	// seconds, so the sub-second part is truncated on the wire either way.
 	if env.timesWarned != nil {
-		mtime := time.Unix(f.mtime, 0)
+		mtime := time.Unix(0, f.mtime)
 		doneTimes := metrics.Op("sftp_chtimes")
 		cerr := client.Chtimes(f.remotePath, mtime, mtime)
 		doneTimes(cerr)

--- a/schema/easysftp.schema.json
+++ b/schema/easysftp.schema.json
@@ -197,7 +197,7 @@
       "additionalProperties": false,
       "properties": {
         "fast_path": {
-          "description": "Reuse a file's manifest hash instead of re-reading it when size and modification time still match (rsync-style quick check; can miss same-size same-second edits).",
+          "description": "Reuse a file's manifest hash instead of re-reading it when size and modification time (nanosecond resolution) still match (rsync-style quick check; can miss a same-size edit only when the timestamp is also identical).",
           "type": "boolean"
         },
         "manifest": {


### PR DESCRIPTION
## Summary
- store `fi.ModTime().UnixNano()` in the plan and the sync manifest instead of whole seconds, so with `sync.fast_path` a same-size edit landing in the same wall-clock second as the recorded upload is re-hashed and deployed instead of silently skipped
- bump `manifestVersion` to 3; a v2 manifest's whole-second mtimes are zeroed on read so a second-resolution value is never compared against a nanosecond one, making the upgrade cost one full re-hash, exactly like the v1 to v2 upgrade
- `preserve-times` reads the same field, now via `time.Unix(0, f.mtime)`; the SETSTAT request carries whole seconds on the wire either way, so servers see the same values as before
- docs follow the issue's note: the `fast_path` tradeoff in `docs/strategies.md` and the schema description now describe the nanosecond comparison, the remaining identical-timestamp window, and the coarse-timestamp caveat (FAT stores 2-second mtimes, some network filesystems round)

## Tests
- new regression test: a same-size edit 200ms later within the same second is uploaded (this is the exact failure from the issue; it fails on main)
- the old `TestSyncFastPathMissesSameSecondSameSizeEdit` pin becomes `TestSyncFastPathMissesIdenticalMtimeSameSizeEdit`, pinning the much narrower documented window that remains
- new v2 upgrade test: a v2 entry carrying a stale hash with matching size and whole-second mtime is re-hashed for real, the change is deployed, and the rewritten manifest is v3 with nanosecond mtimes
- `TestHashPlanFilesFastPathMissOnMismatch` gains a whole-seconds case alongside the v1 zero case

## Verification
- `go test ./...`
- `go test -race ./internal/uploader`
- `go vet ./...`
- `gofmt -l .`
- `go build ./cmd/easysftp`

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cFhMyHwVAQ9GieYbi3aUb