### PR TITLE
fix: sweep stale temp files left behind by a killed run

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -81,7 +81,7 @@ Markdown:
 | `results[]` | one row per (build, scenario): the aggregate |
 | `results[].duration_ms` | `values`, `median`, `min`, `max`, `mad`, `samples` |
 | `results[].process` | CPU time, peak RSS, Go allocations, GC count and pause, peak goroutines, disk and network bytes |
-| `results[].phases[]` | wall clock per phase (connect, local_scan, remote_scan, hash, create_dirs, upload, delete_sweep, manifest_read, manifest_write, prune_dirs, cleanup) |
+| `results[].phases[]` | wall clock per phase (connect, local_scan, remote_scan, hash, create_dirs, sweep_stale_temps, upload, delete_sweep, manifest_read, manifest_write, prune_dirs, cleanup) |
 | `results[].operations[]` | per round-trip: count, cumulative total, average, p50/p90/p99, max, errors |
 | `results[].counters` | connections opened/used/refused, reconnects, retries, stalls, errors |
 | `comparison[]` | each build against the reference build: `delta_ms`, `delta_percent`, and `within_noise` (is the delta smaller than the reference's MAD?) |

--- a/docs/security.md
+++ b/docs/security.md
@@ -122,6 +122,30 @@ Changing the name mid-life starts a fresh manifest: the next sync re-uploads
 everything, tracks deletions from scratch, and leaves the old manifest file
 behind; delete the old file manually.
 
+## Temporary upload files in web roots
+
+Uploads stream into a temporary sibling file (`<name>.easysftp-tmp.<n>`) that
+is renamed over the target on success. A run killed hard (cancelled workflow,
+job timeout, reclaimed runner) can leave such files behind, and until the
+next deploy sweeps them (see
+[troubleshooting.md](troubleshooting.md#replacing-path--or-leftover-easysftp-tmp-files))
+a partially written copy of the file sits in the target, served over HTTP
+when the target is a public web root, possibly as plain text depending on
+MIME handling. Deny the pattern in the web server, next to the manifest rule
+above. nginx:
+
+```nginx
+location ~ \.easysftp-tmp(\.\d+)?$ { deny all; }
+```
+
+Apache (vhost or `.htaccess`):
+
+```apache
+<FilesMatch "\.easysftp-tmp(\.[0-9]+)?$">
+    Require all denied
+</FilesMatch>
+```
+
 ## Least privilege on the server
 
 - Use a dedicated deploy user that can only write to the deployment target,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -132,10 +132,19 @@ appears to work.
 easySFTP uploads to a temporary sibling file (named `<path>.easysftp-tmp.<n>`)
 and renames it over the target (atomic on servers supporting the
 `posix-rename@openssh.com` extension, with a remove+rename fallback
-otherwise). A hard crash mid-upload can leave such a file behind; it is safe
-to delete manually. It usually gets overwritten by the next upload of the
-same file too, but that isn't guaranteed if the deployment's file set changed
-in the meantime and shifted its plan position.
+otherwise). A hard kill mid-upload (a cancelled workflow past its grace
+period, a job timeout, a reclaimed runner) can leave such a file behind; it
+is safe to delete manually.
+
+Later deploys clean these up automatically: before uploading, every run
+sweeps the directories it touches and removes temp files older than an hour
+(logged as `removed stale temporary file ...`). The age margin keeps the
+sweep from deleting a concurrently running deploy's in-progress upload. An
+orphan in a directory that no later deploy touches (possible with `sync`,
+which only visits directories receiving changed files) stays until one does,
+or until you delete it manually. If the target is a public web root, also add
+a deny rule for these names next to the manifest rule; see
+[security.md](security.md#temporary-upload-files-in-web-roots).
 
 ### Ignored files are uploaded anyway / patterns don't match
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,14 +137,18 @@ period, a job timeout, a reclaimed runner) can leave such a file behind; it
 is safe to delete manually.
 
 Later deploys clean these up automatically: before uploading, every run
-sweeps the directories it touches and removes temp files older than an hour
-(logged as `removed stale temporary file ...`). The age margin keeps the
-sweep from deleting a concurrently running deploy's in-progress upload. An
-orphan in a directory that no later deploy touches (possible with `sync`,
-which only visits directories receiving changed files) stays until one does,
-or until you delete it manually. If the target is a public web root, also add
-a deny rule for these names next to the manifest rule; see
-[security.md](security.md#temporary-upload-files-in-web-roots).
+sweeps the directories receiving files in that run, plus the deployment's
+target directory itself, and removes temp files older than an hour (logged
+as `removed stale temporary file ...`). Nothing above the target directory
+is ever listed or touched. The age margin keeps the sweep from deleting a
+concurrently running deploy's in-progress upload. The sweep intentionally
+runs in every mode, `overlay` included, and is on by default: even though
+overlay never deletes your files, the sweep only ever removes the action's
+own `*.easysftp-tmp` / `*.easysftp-tmp.<n>` debris, never a file it did not
+name itself. An orphan in a directory that no later deploy uploads into
+stays until one does, or until you delete it manually. If the target is a
+public web root, also add a deny rule for these names next to the manifest
+rule; see [security.md](security.md#temporary-upload-files-in-web-roots).
 
 ### Ignored files are uploaded anyway / patterns don't match
 

--- a/internal/uploader/staletemp_test.go
+++ b/internal/uploader/staletemp_test.go
@@ -1,0 +1,287 @@
+package uploader
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// shrinkStaleTempMaxAge makes every existing temp file immediately eligible
+// for the sweep, restoring the production margin when the test ends. The
+// in-memory test server stamps files with their creation time and ignores
+// time changes in Setstat (see CLAUDE.md), so aging a file for real is not
+// possible; shrinking the threshold is.
+func shrinkStaleTempMaxAge(t *testing.T) {
+	t.Helper()
+	old := staleTempMaxAge
+	staleTempMaxAge = 0
+	t.Cleanup(func() { staleTempMaxAge = old })
+}
+
+// writeRemoteFile creates a remote file with the given content, so tests can
+// plant orphaned temp files as a killed earlier run would have left them.
+func writeRemoteFile(t *testing.T, client *sftp.Client, path, content string) {
+	t.Helper()
+	f, err := client.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIsTempFileName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"app.js" + tmpSuffix + ".0", true},           // file upload temp
+		{"app.js" + tmpSuffix + ".417", true},         // higher plan index
+		{manifestName + tmpSuffix, true},              // manifest write temp (no index)
+		{"app.js", false},                             // ordinary file
+		{".easysftp-manifest.json", false},            // the manifest itself
+		{"app.js" + tmpSuffix + ".backup", false},     // non-numeric suffix
+		{"app.js" + tmpSuffix + ".", false},           // dot but no index
+		{"app.js" + tmpSuffix + ".1a", false},         // trailing garbage
+		{"app.js" + tmpSuffix + ".3" + ".txt", false}, // renamed by a user
+	}
+	for _, c := range cases {
+		if got := isTempFileName(c.name); got != c.want {
+			t.Errorf("isTempFileName(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// The core of issue #160: temp files a killed run left behind are removed by
+// the next deploy touching their directories, on both non-destructive modes,
+// and each removal is logged so the debris is explained.
+func TestSweepRemovesStaleTempFiles(t *testing.T) {
+	shrinkStaleTempMaxAge(t)
+
+	srv := startTestServer(t)
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/www/sub"); err != nil {
+		t.Fatal(err)
+	}
+	// What a SIGKILLed earlier run leaves: an indexed file-upload temp in two
+	// directories, a manifest-write temp (no index), and an unrelated file
+	// that must survive the sweep.
+	writeRemoteFile(t, client, "/www/index.html"+tmpSuffix+".417", "partial")
+	writeRemoteFile(t, client, "/www/sub/app.js"+tmpSuffix+".3", "partial")
+	writeRemoteFile(t, client, "/www/"+manifestName+tmpSuffix, "partial")
+	writeRemoteFile(t, client, "/www/human.txt", "do not touch")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "hi", "sub/app.js": "x"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, orphan := range []string{
+		"/www/index.html" + tmpSuffix + ".417",
+		"/www/sub/app.js" + tmpSuffix + ".3",
+		"/www/" + manifestName + tmpSuffix,
+	} {
+		if remoteExists(t, srv, orphan) {
+			t.Errorf("stale temp file %s survived the sweep", orphan)
+		}
+	}
+	if got := readRemote(t, srv, "/www/human.txt"); got != "do not touch" {
+		t.Errorf("unrelated file was touched by the sweep: %q", got)
+	}
+	if got := readRemote(t, srv, "/www/index.html"); got != "hi" {
+		t.Errorf("deploy did not complete normally: %q", got)
+	}
+	removals := 0
+	for _, msg := range log.infos {
+		if strings.Contains(msg, "removed stale temporary file") {
+			removals++
+		}
+	}
+	if removals != 3 {
+		t.Errorf("expected 3 removal log lines, got %d: %v", removals, log.infos)
+	}
+}
+
+// A temp file younger than staleTempMaxAge is plausibly another live run's
+// in-progress upload; deleting it would turn an (unsupported but real)
+// concurrent deploy race into a corrupted deploy, so it must survive.
+func TestSweepKeepsFreshTempFiles(t *testing.T) {
+	srv := startTestServer(t)
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/www"); err != nil {
+		t.Fatal(err)
+	}
+	writeRemoteFile(t, client, "/www/index.html"+tmpSuffix+".9", "in progress")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "hi"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	if !remoteExists(t, srv, "/www/index.html"+tmpSuffix+".9") {
+		t.Error("a fresh temp file (possibly a live concurrent upload) was swept")
+	}
+}
+
+// A real deployed file whose name happens to match the temp pattern (see the
+// literal-name coverage in atomic_test.go) is a planned target of the run and
+// must never be swept, even once it is old enough.
+func TestSweepKeepsPlannedTargetsNamedLikeTempFiles(t *testing.T) {
+	shrinkStaleTempMaxAge(t)
+
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"app.js" + tmpSuffix + ".3": "real content"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	// First deploy puts the literal-named file on the server; the second
+	// deploy's sweep then sees it as an existing, age-eligible temp name.
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readRemote(t, srv, "/www/app.js"+tmpSuffix+".3"); got != "real content" {
+		t.Errorf("planned literal-named file was lost: %q", got)
+	}
+	for _, msg := range log.infos {
+		if strings.Contains(msg, "removed stale temporary file") {
+			t.Errorf("a planned target was swept as a stale temp file: %q", msg)
+		}
+	}
+}
+
+// The sync strategy uploads through the same path, so a directory a sync run
+// touches is swept too, and the orphan does not linger despite sync's
+// manifest never having known about it.
+func TestSweepRunsForSyncUploads(t *testing.T) {
+	shrinkStaleTempMaxAge(t)
+
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "1"})
+
+	cfg := syncConfig(srv, local)
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	writeRemoteFile(t, srv.verifyClient(t), "/www/a.txt"+tmpSuffix+".42", "partial")
+	// a.txt changes, so the next sync uploads into /www and sweeps it.
+	writeTree(t, local, map[string]string{"a.txt": "2"})
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	if remoteExists(t, srv, "/www/a.txt"+tmpSuffix+".42") {
+		t.Error("stale temp file survived a sync deploy touching its directory")
+	}
+	if got := readRemote(t, srv, "/www/a.txt"); got != "2" {
+		t.Errorf("sync deploy did not complete normally: %q", got)
+	}
+}
+
+// Dry runs must not delete anything, orphaned temp files included.
+func TestSweepSkippedInDryRun(t *testing.T) {
+	shrinkStaleTempMaxAge(t)
+
+	srv := startTestServer(t)
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/www"); err != nil {
+		t.Fatal(err)
+	}
+	writeRemoteFile(t, client, "/www/index.html"+tmpSuffix+".7", "partial")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "hi"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+	cfg.DryRun = true
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	if !remoteExists(t, srv, "/www/index.html"+tmpSuffix+".7") {
+		t.Error("dry-run swept a temp file")
+	}
+}
+
+// A directory listing failure must degrade to "sweep nothing there", never
+// fail the deploy: the sweep is a cleanup courtesy, not part of the upload.
+func TestSweepListFailureDoesNotFailDeploy(t *testing.T) {
+	shrinkStaleTempMaxAge(t)
+
+	srv := startTestServer(t, withFailList("/www"))
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/www"); err != nil {
+		t.Fatal(err)
+	}
+	writeRemoteFile(t, client, "/www/index.html"+tmpSuffix+".2", "partial")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "hi"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatalf("an unlistable directory must not fail the deploy: %v", err)
+	}
+	if got := readRemote(t, srv, "/www/index.html"); got != "hi" {
+		t.Errorf("deploy did not complete: %q", got)
+	}
+}
+
+// The sweep must not double as a stall: a healthy but slow listing pass ticks
+// the watchdog per directory, mirroring createRemoteDirs. This is a cheap
+// guard that the wiring passes the watchdog through (a nil watchdog is the
+// common case and is covered by every other test in this file).
+func TestSweepTicksWatchdog(t *testing.T) {
+	shrinkStaleTempMaxAge(t)
+
+	srv := startTestServer(t)
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/www"); err != nil {
+		t.Fatal(err)
+	}
+	writeRemoteFile(t, client, "/www/index.html"+tmpSuffix+".1", "partial")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "hi"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+	cfg.StallTimeout = 10 * time.Second
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	if remoteExists(t, srv, "/www/index.html"+tmpSuffix+".1") {
+		t.Error("sweep did not run with the stall watchdog armed")
+	}
+}

--- a/internal/uploader/staletemp_test.go
+++ b/internal/uploader/staletemp_test.go
@@ -49,6 +49,7 @@ func TestIsTempFileName(t *testing.T) {
 		{manifestName + tmpSuffix, true},              // manifest write temp (no index)
 		{"app.js", false},                             // ordinary file
 		{".easysftp-manifest.json", false},            // the manifest itself
+		{tmpSuffix, false},                            // bare suffix, no name before it
 		{"app.js" + tmpSuffix + ".backup", false},     // non-numeric suffix
 		{"app.js" + tmpSuffix + ".", false},           // dot but no index
 		{"app.js" + tmpSuffix + ".1a", false},         // trailing garbage
@@ -171,6 +172,64 @@ func TestSweepKeepsPlannedTargetsNamedLikeTempFiles(t *testing.T) {
 	for _, msg := range log.infos {
 		if strings.Contains(msg, "removed stale temporary file") {
 			t.Errorf("a planned target was swept as a stale temp file: %q", msg)
+		}
+	}
+}
+
+// The sweep's scope guarantee: a deploy to a target several levels deep must
+// not list (let alone delete in) any ancestor of that target. Age-eligible
+// temp debris planted above the base survives untouched, the only directories
+// ever listed are the base and the directories receiving files this run, and
+// the debris inside those is removed.
+func TestSweepStaysWithinDeploymentBase(t *testing.T) {
+	shrinkStaleTempMaxAge(t)
+
+	rec := &listRecorder{}
+	srv := startTestServer(t, withListRecorder(rec))
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/var/www/html/blog/sub"); err != nil {
+		t.Fatal(err)
+	}
+	// Temp debris in every ancestor of the base; the sweep has no business
+	// there, so all of it must survive.
+	writeRemoteFile(t, client, "/var/a"+tmpSuffix+".1", "above")
+	writeRemoteFile(t, client, "/var/www/b"+tmpSuffix+".2", "above")
+	writeRemoteFile(t, client, "/var/www/html/c"+tmpSuffix+".3", "above")
+	// Debris inside the deployment: in the base (where a manifest temp would
+	// live) and in a directory receiving a file this run.
+	writeRemoteFile(t, client, "/var/www/html/blog/index.html"+tmpSuffix+".4", "stale")
+	writeRemoteFile(t, client, "/var/www/html/blog/sub/app.js"+tmpSuffix+".5", "stale")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "hi", "sub/app.js": "x"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/var/www/html/blog"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, kept := range []string{
+		"/var/a" + tmpSuffix + ".1",
+		"/var/www/b" + tmpSuffix + ".2",
+		"/var/www/html/c" + tmpSuffix + ".3",
+	} {
+		if !remoteExists(t, srv, kept) {
+			t.Errorf("temp file above the deployment base was swept: %s", kept)
+		}
+	}
+	for _, swept := range []string{
+		"/var/www/html/blog/index.html" + tmpSuffix + ".4",
+		"/var/www/html/blog/sub/app.js" + tmpSuffix + ".5",
+	} {
+		if remoteExists(t, srv, swept) {
+			t.Errorf("stale temp file inside the deployment survived: %s", swept)
+		}
+	}
+	for _, dir := range rec.listed() {
+		if dir != "/var/www/html/blog" && dir != "/var/www/html/blog/sub" {
+			t.Errorf("a directory outside the deployment was listed: %s", dir)
 		}
 	}
 }

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -120,7 +120,7 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 	}
 	// skip-unchanged is always off here: sync already decided what changed
 	// from the manifest hashes, which is strictly more precise.
-	completed, err := uploadFiles(ctx, cfg, sess, upload, dirs, stats, verb, watch, false, log)
+	completed, err := uploadFiles(ctx, cfg, sess, upload, dirs, base, stats, verb, watch, false, log)
 	if err != nil {
 		writeRecoveryManifest(ctx, cfg, sess, watch, base, mergedManifest(old, upload, completed, nil), log)
 		return err

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -84,6 +84,26 @@ func withFailOpen(path string) serverOption {
 	}
 }
 
+// faultyList rejects directory listings ("List" requests) of one exact path
+// while delegating everything else, Stat included, to the in-memory handler.
+type faultyList struct {
+	inner sftp.FileLister
+	path  string
+}
+
+func (f *faultyList) Filelist(r *sftp.Request) (sftp.ListerAt, error) {
+	if r.Method == "List" && r.Filepath == f.path {
+		return nil, errors.New("injected list failure")
+	}
+	return f.inner.Filelist(r)
+}
+
+func withFailList(path string) serverOption {
+	return func(s *testServer) {
+		s.handlers.FileList = &faultyList{inner: s.handlers.FileList, path: path}
+	}
+}
+
 // withFailRename makes the server reject every (Posix)Rename, simulating a
 // server that lets the temp upload through but cannot swap it into place.
 func withFailRename() serverOption { return func(s *testServer) { s.failRename = true } }

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -104,6 +104,39 @@ func withFailList(path string) serverOption {
 	}
 }
 
+// listRecorder records the path of every directory listing ("List") request
+// while delegating everything else to the in-memory handler, so a test can
+// assert which directories a run actually read (the stale-temp sweep's scope
+// guarantee needs exactly that).
+type listRecorder struct {
+	mu    sync.Mutex
+	inner sftp.FileLister
+	dirs  []string
+}
+
+func (l *listRecorder) Filelist(r *sftp.Request) (sftp.ListerAt, error) {
+	if r.Method == "List" {
+		l.mu.Lock()
+		l.dirs = append(l.dirs, r.Filepath)
+		l.mu.Unlock()
+	}
+	return l.inner.Filelist(r)
+}
+
+// listed returns a copy of the directory paths listed so far.
+func (l *listRecorder) listed() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.dirs...)
+}
+
+func withListRecorder(rec *listRecorder) serverOption {
+	return func(s *testServer) {
+		rec.inner = s.handlers.FileList
+		s.handlers.FileList = rec
+	}
+}
+
 // withFailRename makes the server reject every (Posix)Rename, simulating a
 // server that lets the temp upload through but cannot swap it into place.
 func withFailRename() serverOption { return func(s *testServer) { s.failRename = true } }

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -58,7 +59,7 @@ type transferEnv struct {
 // It returns which files completed, indexed like files, so that on a partial
 // failure the caller knows what actually made it to the server (the sync
 // strategy uses this to persist a recovery manifest).
-func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, stats *Stats, verb string, watch *stallWatchdog, skipUnchanged bool, log Logger) ([]bool, error) {
+func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, base string, stats *Stats, verb string, watch *stallWatchdog, skipUnchanged bool, log Logger) ([]bool, error) {
 	// Declared before the first failure point: callers index the returned
 	// slice by file, so it must be sized even when nothing was uploaded.
 	completed := make([]bool, len(files))
@@ -78,9 +79,10 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 		}
 
 		// Before any upload starts, remove temp files that an earlier killed
-		// run left in the directories this run touches; see sweepStaleTemps.
+		// run left in the directories this run uploads into; see
+		// sweepStaleTemps.
 		endSweep := metrics.Phase("sweep_stale_temps")
-		sweepStaleTemps(ctx, sess, watch, dirs, files, log)
+		sweepStaleTemps(ctx, sess, watch, base, files, log)
 		endSweep()
 	}
 
@@ -281,10 +283,11 @@ var staleTempMaxAge = time.Hour
 // isTempFileName reports whether name looks like a temporary upload file this
 // action writes: "<name>.easysftp-tmp.<n>" for a file upload (n being the
 // plan index, see uploadFile) or "<name>.easysftp-tmp" for a manifest write
-// (see writeManifest).
+// (see writeManifest). The suffix is always appended to an existing name, so
+// a file named exactly ".easysftp-tmp" (i == 0) is not one of ours.
 func isTempFileName(name string) bool {
 	i := strings.LastIndex(name, tmpSuffix)
-	if i < 0 {
+	if i <= 0 {
 		return false
 	}
 	rest := name[i+len(tmpSuffix):]
@@ -307,24 +310,58 @@ func isTempFileName(name string) bool {
 // file up, but SIGKILL, a cancelled workflow past its grace period or a
 // reclaimed runner skip all deferred code, and neither overlay nor sync ever
 // deletes a file it did not just write, so the orphans would otherwise sit in
-// the target forever, publicly served when the target is a web root. Only the
-// directories this run touches anyway are listed, keeping the added
-// round-trips proportional to the run instead of the whole tree.
+// the target forever, publicly served when the target is a web root.
+//
+// The swept set is exactly the directories that receive files this run (the
+// parent directory of every planned remote path) plus the deployment's remote
+// base, where the sync manifest's temp file lives even when no changed file
+// does. Nothing above the base is ever listed or touched: a deploy to
+// /var/www/html/blog has no business reading /var. That keeps the added
+// round-trips proportional to the run and the sweep's reach inside the
+// deployment.
 //
 // Three guards bound what the sweep may remove: the name must match the temp
 // pattern (isTempFileName), the entry must be older than staleTempMaxAge (a
 // younger one is plausibly another live run's in-progress upload), and it
 // must not be a planned target of this run (a real deployed file can be named
-// like a temp file; see the literal-name test in atomic_test.go). Everything
-// is best-effort: each directory runs through sess.do so a dropped connection
-// redials, but a listing or removal failure only warns and never fails the
-// deploy. Removals are logged, so a user who wondered what those files were
-// gets an answer.
-func sweepStaleTemps(ctx context.Context, sess *session, watch *stallWatchdog, dirs []string, files []fileItem, log Logger) {
+// like a temp file; see the literal-name test in atomic_test.go). Staleness
+// compares the runner's clock against the mtime the server reports
+// (time.Since of the entry's ModTime), so a server clock running behind the
+// runner's can make a fresh temp file look older than it is; concurrent
+// deploys to one target are unsupported anyway, so such skew weakens a
+// mitigation rather than creating a new hazard.
+//
+// The sweep deliberately runs for every strategy, the non-destructive overlay
+// included, and has no opt-out: it only ever removes this action's own
+// "*.easysftp-tmp" and "*.easysftp-tmp.<n>" debris, never a file it did not
+// name itself. For the same reason its removals deliberately do not count
+// against safety.max_deletes (which budgets deletions of deployed files) and
+// are not reported in the run's delete stats.
+//
+// Everything is best-effort: each directory runs through sess.do so a dropped
+// connection redials, but a listing or removal failure only warns and never
+// fails the deploy. Removals are logged, so a user who wondered what those
+// files were gets an answer.
+func sweepStaleTemps(ctx context.Context, sess *session, watch *stallWatchdog, base string, files []fileItem, log Logger) {
 	keep := make(map[string]struct{}, len(files))
 	for _, f := range files {
 		keep[f.remotePath] = struct{}{}
 	}
+	touched := make(map[string]struct{}, len(files)+1)
+	// A single-file overlay deploy without a trailing slash resolves base to
+	// the planned file itself, not a directory; its parent joins the set via
+	// path.Dir below, so the file path is skipped here.
+	if _, isPlannedFile := keep[base]; !isPlannedFile {
+		touched[base] = struct{}{}
+	}
+	for _, f := range files {
+		touched[path.Dir(f.remotePath)] = struct{}{}
+	}
+	dirs := make([]string, 0, len(touched))
+	for dir := range touched {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
 	for _, dir := range dirs {
 		_ = sess.do(ctx, watch, func(client *sftp.Client) error {
 			return sweepDirStaleTemps(client, dir, keep, watch, log)

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -74,6 +76,12 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 		if err != nil {
 			return completed, err
 		}
+
+		// Before any upload starts, remove temp files that an earlier killed
+		// run left in the directories this run touches; see sweepStaleTemps.
+		endSweep := metrics.Phase("sweep_stale_temps")
+		sweepStaleTemps(ctx, sess, watch, dirs, files, log)
+		endSweep()
 	}
 
 	defer metrics.Phase("upload")()
@@ -260,6 +268,114 @@ func cleanupTmp(client *sftp.Client, tmpPath string, log Logger) {
 	if err := client.Remove(tmpPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Warningf("could not remove temporary file %s: %v", tmpPath, err)
 	}
+}
+
+// staleTempMaxAge is how old (by remote modification time) a leftover temp
+// upload file must be before sweepStaleTemps removes it. Concurrent deploys
+// to one target are unsupported, but a sweep that deleted another live run's
+// in-progress temp file would turn that race into a corrupted deploy; the
+// age margin keeps any plausibly-live temp file safe without locking. A
+// variable only so tests can shrink it.
+var staleTempMaxAge = time.Hour
+
+// isTempFileName reports whether name looks like a temporary upload file this
+// action writes: "<name>.easysftp-tmp.<n>" for a file upload (n being the
+// plan index, see uploadFile) or "<name>.easysftp-tmp" for a manifest write
+// (see writeManifest).
+func isTempFileName(name string) bool {
+	i := strings.LastIndex(name, tmpSuffix)
+	if i < 0 {
+		return false
+	}
+	rest := name[i+len(tmpSuffix):]
+	if rest == "" {
+		return true
+	}
+	if rest[0] != '.' || len(rest) < 2 {
+		return false
+	}
+	for _, c := range rest[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// sweepStaleTemps removes temp upload files that an earlier killed run left
+// behind (issue #160). Every in-process failure path already cleans its temp
+// file up, but SIGKILL, a cancelled workflow past its grace period or a
+// reclaimed runner skip all deferred code, and neither overlay nor sync ever
+// deletes a file it did not just write, so the orphans would otherwise sit in
+// the target forever, publicly served when the target is a web root. Only the
+// directories this run touches anyway are listed, keeping the added
+// round-trips proportional to the run instead of the whole tree.
+//
+// Three guards bound what the sweep may remove: the name must match the temp
+// pattern (isTempFileName), the entry must be older than staleTempMaxAge (a
+// younger one is plausibly another live run's in-progress upload), and it
+// must not be a planned target of this run (a real deployed file can be named
+// like a temp file; see the literal-name test in atomic_test.go). Everything
+// is best-effort: each directory runs through sess.do so a dropped connection
+// redials, but a listing or removal failure only warns and never fails the
+// deploy. Removals are logged, so a user who wondered what those files were
+// gets an answer.
+func sweepStaleTemps(ctx context.Context, sess *session, watch *stallWatchdog, dirs []string, files []fileItem, log Logger) {
+	keep := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		keep[f.remotePath] = struct{}{}
+	}
+	for _, dir := range dirs {
+		_ = sess.do(ctx, watch, func(client *sftp.Client) error {
+			return sweepDirStaleTemps(client, dir, keep, watch, log)
+		})
+	}
+}
+
+// sweepDirStaleTemps sweeps a single remote directory; see sweepStaleTemps.
+// Connection-class errors are returned so sess.do redials and reruns the
+// directory (removals are idempotent); anything else is swallowed after a
+// warning.
+func sweepDirStaleTemps(client *sftp.Client, dir string, keep map[string]struct{}, watch *stallWatchdog, log Logger) error {
+	doneList := metrics.Op("sftp_readdir")
+	entries, err := client.ReadDir(dir)
+	doneList(err)
+	if err != nil {
+		if isConnError(err) {
+			return err
+		}
+		// Best-effort: a directory that cannot be listed is left alone. Not
+		// worth a warning; the run itself has not lost anything.
+		return nil
+	}
+	watch.tick()
+	for _, e := range entries {
+		if e.IsDir() || !isTempFileName(e.Name()) {
+			continue
+		}
+		if time.Since(e.ModTime()) < staleTempMaxAge {
+			continue
+		}
+		full := path.Join(dir, e.Name())
+		if _, ok := keep[full]; ok {
+			continue
+		}
+		done := metrics.Op("sftp_remove")
+		err := client.Remove(full)
+		done(err)
+		if err != nil {
+			if isConnError(err) {
+				return err
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				log.Warningf("could not remove stale temporary file %s: %v", full, err)
+			}
+			continue
+		}
+		log.Infof("removed stale temporary file %s (left behind by an earlier interrupted run)", full)
+		watch.tick()
+	}
+	return nil
 }
 
 // ctxReader makes an io.Copy abort as soon as the context is cancelled.

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -197,9 +197,9 @@ func executePlan(ctx context.Context, cfg *config.Config, sess *session, p plan,
 // the strategy is clean.
 func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, watch *stallWatchdog, log Logger) error {
 	verb := planVerb(cfg)
+	base := normalizeRemote(p.pair.Remote)
 
 	if p.strategy == config.StrategyClean {
-		base := normalizeRemote(p.pair.Remote)
 		if err := checkRemoteRoot(p.pair.Remote); err != nil {
 			return err
 		}
@@ -267,7 +267,7 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 	}
 
 	skipUnchanged := cfg.SkipUnchanged && p.strategy == config.StrategyOverlay
-	_, err := uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, stats, verb, watch, skipUnchanged, log)
+	_, err := uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, base, stats, verb, watch, skipUnchanged, log)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- before any upload starts, each deployment sweeps the remote directories it touches anyway (the same set the directory-setup phase creates) and removes leftover `.easysftp-tmp` files that a SIGKILLed run, a cancelled workflow past its grace period or a reclaimed runner left behind
- three guards bound what may be removed, following the points the issue raised:
  - the name must match the temp pattern: `<name>.easysftp-tmp.<n>` (file uploads) or `<name>.easysftp-tmp` (the manifest write, which the issue notes has the same exposure)
  - the entry must be older than an hour by remote mtime, so a concurrent run's live in-progress temp file is never deleted (no locking needed)
  - it must not be a planned target of this run, so a real deployed file literally named like a temp file (the issue #42 collision case covered in `atomic_test.go`) survives
- every removal is logged (`removed stale temporary file ...`), so a user who wondered what those files were gets an answer; the sweep is fully best-effort and a listing or removal failure never fails the deploy (connection-class errors redial through `sess.do`, like the other phases)
- dry runs skip the sweep along with the rest of the write path
- docs, per the issue's "worth doing regardless" note: `docs/troubleshooting.md` explains the debris and the automatic sweep, and `docs/security.md` gains web server deny rules for the temp pattern next to the existing manifest rules

One residual case is left open by design: an orphan in a directory that no later deploy touches (possible with `sync`, which only visits directories receiving changed files) stays until one does. Sweeping every directory of the full plan would reintroduce the per-directory round-trips the leaf-only `MkdirAll` work (#11, #31) removed; the troubleshooting doc says so.

## Tests
- removal of orphans across directories, manifest-write temp included, with log assertions
- a fresh temp file (plausibly a concurrent run's) survives
- a planned target named like a temp file survives and is never logged as swept
- sync deployments sweep the directories they touch
- dry-run leaves orphans alone
- an unlistable directory degrades to "sweep nothing there" without failing the deploy (new `withFailList` fault-injection option, following the existing wrapper pattern)
- the sweep ticks the stall watchdog per directory, mirroring `createRemoteDirs`

## Verification
- `go test ./...`
- `go test -race ./internal/uploader`
- `go vet ./...`
- `gofmt -l .`
- `go build ./cmd/easysftp`

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cFhMyHwVAQ9GieYbi3aUb