### PR TITLE
feat(benchmark): keep per-cell metrics and add a canary cell (#184)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -107,11 +107,37 @@ same thing in version 2.
 | `axes` | the grid, declared: `link_profiles`, `connections`, `concurrency`, `request_concurrency` |
 | `link` | the same object a standard run carries, one probe pair per swept profile |
 | `cells[]` | one row per (link profile, scenario, build, connections, concurrency, request_concurrency) with duration, throughput, files/s, network bytes, CPU, peak RSS, connections opened/used/refused, reconnects, retries, errors |
+| `cells[].phases[]` | wall clock per phase, the same list a standard run's `results[].phases[]` carries |
+| `cells[].operations[]` | per round-trip: count, cumulative total, average, p50/p90/p99, max, errors |
 | `scaling[]` | the same cells pre-grouped per link profile, scenario and build, ordered along the axes, plus the `best` cell |
 | `comparison[]` | candidate against baseline at identical coordinates, **including the same link profile** |
+| `canary[]` | the fixed cell, measured at the `start`, the `mid` and the `end` of each profile's grid |
+
+A matrix run has no `runs[]`: a cell is its finest grain, which is why the cell
+itself carries the phase and round-trip detail rather than only the
+`upload_phase_ms` it used to keep (issue #184, phase 2). Results stored before
+that change have `upload_phase_ms` alone.
 
 The CSV next to it is the same `cells[]` flattened, one row per cell, which is
-what a heatmap or a scaling plot reads.
+what a heatmap or a scaling plot reads. The nested `phases[]` and
+`operations[]` stay out of it and live in the JSON only.
+
+### The canary
+
+A sweep runs for hours against a server that is fixed but not constant, and
+nothing in a grid says whether the machine that measured the last cell was still
+the machine that measured the first. So one fixed cell (`small`, `connections: 1`,
+`concurrency: 4`, candidate build) is measured three times per link profile: at
+the start of that profile's grid, in the middle of it, and at the end. All three
+are stored, and `matrix.md` reports them with the spread between the fastest and
+the slowest.
+
+Read it before reading the grid: when the spread is larger than the deltas in
+the grid, the run measured drift and not settings. The cell is a constant on
+purpose, so canaries are comparable both within one run and across runs.
+
+The middle canary needs a middle to sit in; a grid of a single measured run per
+profile only gets a start and an end.
 
 ### The link profile
 
@@ -254,6 +280,12 @@ shared host, moves it far less than it moves a standard deviation. A candidate
 whose delta is smaller than the baseline's MAD has not been shown to be
 faster or slower, and `comparison[].within_noise` says so directly.
 
+A single repeat has no measured spread, so `mad_ms` is then `null` (empty in the
+CSV) rather than 0, which would read as perfect precision. That is the normal
+case for a matrix run, whose `REPEATS` default is 1 because the grid is already
+hours: its deltas have no noise floor to compare against, and the canary above is
+what stands in for one. Results stored before this change carry 0 there.
+
 Before reading a delta at all, check the run's single-stream control against the
 scenario's own MiB/s. A scenario sitting at the control was limited by the path,
 not by the code, and no delta measured there means anything. Every
@@ -310,7 +342,7 @@ Candidate and baseline are measured cell by cell, back to back, for the same
 reason the standard benchmark interleaves its repeats. The default grid is over a
 hundred measured runs and takes hours, and each extra link profile multiplies
 that; shrink the axes for a quick look. The script prints its run count before it
-starts.
+starts, canary runs included.
 
 ### About `connections` above `concurrency`
 

--- a/scripts/benchmark-lib.sh
+++ b/scripts/benchmark-lib.sh
@@ -221,13 +221,16 @@ metrics_json() {
 # odd number of repeats is the better choice. "mad" is the median absolute
 # deviation: a spread metric that a single slow repeat (the normal failure mode
 # of a shared host) does not blow up, unlike a standard deviation.
+#
+# "mad" is null below two samples rather than 0: a single repeat has no measured
+# spread at all, and a 0 there reads as perfect precision (issue #184, phase 2).
 # SC2034: used by the scripts that source this file. SC2016: the "$xs"/"$m" in
 # here are jq variables, so single quotes are exactly right.
 # shellcheck disable=SC2034,SC2016
 JQ_STATS='
   def median: if length == 0 then 0 else (sort | .[(((length - 1) / 2) | floor)]) end;
   def mad: . as $xs
-    | if length == 0 then 0
+    | if length < 2 then null
       else ($xs | median) as $m
         | ($xs | map(if . - $m < 0 then $m - . else . - $m end) | median)
       end;

--- a/scripts/benchmark-matrix.sh
+++ b/scripts/benchmark-matrix.sh
@@ -35,6 +35,12 @@
 # scenarios and two builds is 120 measured runs plus 120 unmeasured pre-cleans.
 # The script prints its own run count before it starts; shrink the axes rather
 # than letting a job time out halfway.
+#
+# On top of the grid, three canary runs per link profile (issue #184, phase 2):
+# one fixed cell measured at the start, the middle and the end of that profile's
+# grid. A sweep takes hours against a server that is fixed but not constant, and
+# three values that disagree are the only signal that the whole run is not a
+# comparison basis.
 
 set -euo pipefail
 
@@ -57,6 +63,13 @@ MATRIX_CONCURRENCY=${MATRIX_CONCURRENCY:-"1 2 4 8 16"}
 MATRIX_REQUEST_CONCURRENCY=${MATRIX_REQUEST_CONCURRENCY:-}
 MATRIX_SCENARIOS=${MATRIX_SCENARIOS:-"small large single"}
 MATRIX_LINK_PROFILES=${MATRIX_LINK_PROFILES:-}
+
+# The canary cell. Deliberately constants and not environment: three canaries of
+# one run are compared against each other, and two runs' canaries against each
+# other, which only works while the cell stays the same everywhere.
+CANARY_SCENARIO=small
+CANARY_CONNECTIONS=1
+CANARY_CONCURRENCY=4
 
 read -r -a connections_axis <<<"$MATRIX_CONNECTIONS"
 read -r -a concurrency_axis <<<"$MATRIX_CONCURRENCY"
@@ -93,8 +106,10 @@ check_log_dir
 
 runs_file="$LOG_DIR/matrix-runs.jsonl"
 probes_file="$LOG_DIR/link-probes.jsonl"
+canary_file="$LOG_DIR/canary.jsonl"
 : >"$runs_file"
 : >"$probes_file"
+: >"$canary_file"
 
 # The profile every cell below is measured on; set by the profile loop.
 link_profile=baseline
@@ -112,10 +127,18 @@ if [[ -n "$BASELINE_BIN" ]]; then
   reference_label=baseline
 fi
 
-total=$((${#scenarios[@]} * ${#connections_axis[@]} * ${#concurrency_axis[@]} * ${#request_axis[@]} * ${#labels[@]} * ${#link_profiles[@]} * REPEATS))
-echo "matrix: ${#scenarios[@]} scenario(s) x ${#connections_axis[@]} connection value(s) x ${#concurrency_axis[@]} concurrency value(s) x ${#request_axis[@]} request-concurrency value(s) x ${#link_profiles[@]} link profile(s) x ${#labels[@]} build(s) x $REPEATS repeat(s) = $total measured run(s)"
+# Cells of one profile's grid, which is also what the middle canary counts to.
+cells_per_profile=$((${#scenarios[@]} * ${#connections_axis[@]} * ${#concurrency_axis[@]} * ${#request_axis[@]} * ${#labels[@]} * REPEATS))
+total=$((cells_per_profile * ${#link_profiles[@]}))
+canary_total=$((3 * ${#link_profiles[@]}))
+echo "matrix: ${#scenarios[@]} scenario(s) x ${#connections_axis[@]} connection value(s) x ${#concurrency_axis[@]} concurrency value(s) x ${#request_axis[@]} request-concurrency value(s) x ${#link_profiles[@]} link profile(s) x ${#labels[@]} build(s) x $REPEATS repeat(s) = $total measured run(s), plus up to $canary_total canary run(s)"
 
-generate_dataset "${scenarios[@]}"
+# The canary payload has to exist even when its scenario is not swept.
+dataset_scenarios=("${scenarios[@]}")
+if [[ " ${scenarios[*]} " != *" $CANARY_SCENARIO "* ]]; then
+  dataset_scenarios+=("$CANARY_SCENARIO")
+fi
+generate_dataset "${dataset_scenarios[@]}"
 
 # measure_cell <label> <binary> <ref> <scenario> <connections> <concurrency> <request> <repeat>
 #
@@ -172,6 +195,45 @@ request_concurrency: $request"
   echo "$link_profile $label/$scenario connections=$conns concurrency=$conc request=${request:-default} repeat $repeat: $(step_number "$stem.out" duration-ms) ms, exit $code"
 }
 
+# measure_canary <at>: the fixed cell, always the candidate build, run three
+# times per profile ("start", "mid", "end"). Its numbers are kept apart from
+# cells[] on purpose: they measure the server's steadiness, not a coordinate of
+# the grid, and mixing them into an aggregate would hide exactly what they are
+# there to show.
+measure_canary() {
+  local at=$1 slug stem code=0
+  slug=$(link_profile_slug "$link_profile")
+  stem="$LOG_DIR/canary-$slug-$at"
+  local remote="$REMOTE_BASE/matrix/canary"
+  local advanced="connections: $CANARY_CONNECTIONS
+concurrency: $CANARY_CONCURRENCY"
+
+  if ! METRICS_FILE='' run_easysftp "$CANDIDATE_BIN" "$DATASET_DIR/empty" "$remote" clean \
+    "$stem.clean.log" "$stem.clean.out" "$advanced"; then
+    echo "::warning::pre-clean of the $at canary on $link_profile failed"
+  fi
+
+  METRICS_FILE='' run_easysftp "$CANDIDATE_BIN" "$DATASET_DIR/$CANARY_SCENARIO" "$remote" \
+    overlay "$stem.log" "$stem.out" "$advanced" || code=$?
+  if ((code != 0)); then
+    echo "::warning::the $at canary on $link_profile exited $code"
+  fi
+
+  jq -nc \
+    --arg link_profile "$link_profile" \
+    --arg at "$at" \
+    --arg scenario "$CANARY_SCENARIO" \
+    --argjson connections "$CANARY_CONNECTIONS" \
+    --argjson concurrency "$CANARY_CONCURRENCY" \
+    --argjson exit_code "$code" \
+    --argjson duration_ms "$(step_number "$stem.out" duration-ms)" \
+    --argjson files "$(step_number "$stem.out" files-uploaded)" \
+    --argjson bytes "$(step_number "$stem.out" bytes-uploaded)" \
+    '$ARGS.named' >>"$canary_file"
+
+  echo "$link_profile canary $at: $(step_number "$stem.out" duration-ms) ms, exit $code"
+}
+
 # Shaping is only probed for when a profile actually asks for it, so a sweep of
 # the real line needs neither tc nor NET_ADMIN.
 if link_shape_needed "${link_profiles[@]}"; then
@@ -188,6 +250,11 @@ fi
 for link_profile in "${link_profiles[@]}"; do
   link_shape_apply "$link_profile" || true
   link_probe "$link_profile" start "$probes_file"
+  measure_canary start
+  # Counted in measured runs rather than in wall clock, so the middle canary
+  # sits in the middle of the work and not of an estimate. A grid of one cell
+  # has no middle, and then there are two canaries instead of three.
+  runs_done=0
   for scenario in "${scenarios[@]}"; do
     for ((repeat = 1; repeat <= REPEATS; repeat++)); do
       for conns in "${connections_axis[@]}"; do
@@ -198,12 +265,17 @@ for link_profile in "${link_profiles[@]}"; do
             for i in "${!labels[@]}"; do
               measure_cell "${labels[$i]}" "${binaries[$i]}" "${refs[$i]}" \
                 "$scenario" "$conns" "$conc" "$request" "$repeat"
+              runs_done=$((runs_done + 1))
+              if ((runs_done == cells_per_profile / 2)); then
+                measure_canary mid
+              fi
             done
           done
         done
       done
     done
   done
+  measure_canary end
   link_probe "$link_profile" end "$probes_file"
 done
 
@@ -221,6 +293,9 @@ for scenario in "${scenarios[@]}"; do
       echo "::warning::cleanup of ${labels[$i]}/$scenario failed"
   done
 done
+METRICS_FILE='' run_easysftp "$CANDIDATE_BIN" "$DATASET_DIR/empty" \
+  "$REMOTE_BASE/matrix/canary" clean "$LOG_DIR/cleanup-canary.log" "$LOG_DIR/cleanup-canary.out" "" ||
+  echo "::warning::cleanup of the canary directory failed"
 # A probe that was killed mid-write leaves its payload behind, and the next
 # run's remote scan would count it.
 if [[ -n "${LINKPROBE_BIN:-}" ]]; then
@@ -266,7 +341,25 @@ jq -s "
         connections_refused: (\$m | map(.counters.connections_refused // 0) | add),
         reconnects: (\$m | map(.counters.reconnects // 0) | add),
         upload_phase_ms: (\$m | map(.phases // []) | add // []
-          | map(select(.name == \"upload\") | .wall_ms) | median)
+          | map(select(.name == \"upload\") | .wall_ms) | median),
+        phases: (\$m | map(.phases // []) | add // []
+          | group_by(.name)
+          | map({name: .[0].name, median_ms: (map(.wall_ms) | median)})
+          | sort_by(-.median_ms)),
+        operations: (\$m | map(.operations // []) | add // []
+          | group_by(.name)
+          | map({
+              name: .[0].name,
+              count: (map(.count) | median),
+              median_total_ms: (map(.total_ms) | median),
+              avg_ms: (map(.avg_ms) | median),
+              p50_ms: (map(.p50_ms) | median),
+              p90_ms: (map(.p90_ms) | median),
+              p99_ms: (map(.p99_ms) | median),
+              max_ms: (map(.max_ms) | median),
+              errors: (map(.errors) | add)
+            })
+          | sort_by(-.median_total_ms))
       })
   | map(. + {
       mib_per_s: (if .median_ms > 0 then ((.bytes / 1048576) / (.median_ms / 1000) | round2) else 0 end),
@@ -288,8 +381,14 @@ done | jq -s 'from_entries')
 # infer it from the cells that happen to be present, "cells" is one row per
 # combination, "scaling" is the same data pre-grouped into the curve a reader
 # usually wants (per scenario and build, ordered by connections then
-# concurrency), and "comparison" pairs each candidate cell with the reference
-# build's cell at the same coordinates.
+# concurrency), "comparison" pairs each candidate cell with the reference
+# build's cell at the same coordinates, and "canary" holds the fixed cell's
+# three measurements per profile.
+#
+# A matrix run has no "runs[]" the way a standard result does, so a cell is the
+# finest grain there is. That is why it carries its own phases[] and
+# operations[] and not just upload_phase_ms: those are hours of measurement that
+# used to be aggregated and then dropped (issue #184, phase 2).
 jq -n \
   --slurpfile cells "$cells_file" \
   --arg candidate_ref "$CANDIDATE_REF" \
@@ -299,6 +398,7 @@ jq -n \
   --arg runner "${RUNNER_ENVIRONMENT:-local}, $(uname -sr), $(nproc) cpu" \
   --argjson environment "$(bench_environment)" \
   --argjson link "$(link_json "$probes_file")" \
+  --argjson canary "$(jq -s '.' "$canary_file")" \
   --arg settings "$settings" \
   --argjson scenarios "$scenario_docs" \
   --argjson link_axis "$(printf '%s\n' "${link_profiles[@]}" | jq -Rs 'split("\n") | map(select(. != ""))')" \
@@ -318,6 +418,7 @@ jq -n \
      runner: \$runner,
      environment: \$environment,
      link: \$link,
+     canary: \$canary,
      settings: \$settings,
      scenarios: \$scenarios,
      note: \"one cell per (link_profile, scenario, build, connections, concurrency, request_concurrency); median_ms is wall clock over the cell's repeats\",
@@ -464,13 +565,29 @@ jq -r '
       "$OUT_DIR/matrix.json"
   fi
 
+  echo
+  echo "### Canary"
+  echo
+  echo "One fixed cell (\`$CANARY_SCENARIO\`, connections $CANARY_CONNECTIONS, concurrency $CANARY_CONCURRENCY, candidate build) measured at the start, the middle and the end of each profile's grid. Spread is the gap between the fastest and the slowest of them. A spread larger than the deltas below it means the server or the line moved during the sweep, and the whole run is a poor comparison basis."
+  echo
+  echo "| Profile | Start | Middle | End | Spread |"
+  echo "|---|---|---|---|---|"
+  jq -r '
+    def pick($a): [.[] | select(.at == $a) | .duration_ms] | first;
+    def ms: if . == null then "-" else "\(.) ms" end;
+    .canary | group_by(.link_profile)[]
+    | (map(.duration_ms)) as $d
+    | "| \(.[0].link_profile) | \(pick("start") | ms) | \(pick("mid") | ms) | \(pick("end") | ms) "
+      + "| \(if ($d | min) > 0 then ((($d | max) - ($d | min)) / ($d | min) * 100 | round | tostring) + "%" else "-" end) |"
+  ' "$OUT_DIR/matrix.json"
+
   refused=$(jq '[.cells[].connections_refused] | add // 0' "$OUT_DIR/matrix.json")
   if [[ "$refused" != 0 ]]; then
     echo
     echo "**$refused connection(s) were refused by the server** across the sweep and fell back to the run's first connection. Those cells had fewer connections than configured, which is the server's limit showing up in the data, not easySFTP's."
   fi
   echo
-  echo "Raw data: \`matrix.json\` (every cell, plus the pre-grouped \`scaling\` view), \`matrix.csv\` (one flat row per cell). Data only: nothing here fails a build."
+  echo "Raw data: \`matrix.json\` (every cell with its own phases and round-trip percentiles, plus the pre-grouped \`scaling\` view and the \`canary\` runs), \`matrix.csv\` (one flat row per cell). Data only: nothing here fails a build."
 } >"$OUT_DIR/matrix.md"
 
 cat "$OUT_DIR/matrix.md"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -426,7 +426,7 @@ jq -r '
         # bare "as" over an empty generator would drop its whole row.
         | ([.comparison[] | select(.scenario == $s and .label == $l and .link_profile == $p) | .delta_percent] | first) as $delta
         | "| \($s) | \($l) | \($p) | \($row.files) | \((($row.bytes / 1048576) * 10 | round / 10)) MiB "
-          + "| \($row.median_ms) ms | \($row.min_ms) ms | \($row.max_ms) ms | \($row.mad_ms) ms "
+          + "| \($row.median_ms) ms | \($row.min_ms) ms | \($row.max_ms) ms | \(if $row.mad_ms == null then "-" else "\($row.mad_ms) ms" end) "
           + "| \($row.mib_per_s) | \($row.files_per_s) | \($row.retries) | \($row.errors) | \($row.failed_runs) "
           + "| \(if $delta == null then "-" else (if $delta > 0 then "+" else "" end) + ($delta | tostring) + "%" end) |"
         ' "$OUT_DIR/results.json"

--- a/scripts/test-benchmark.sh
+++ b/scripts/test-benchmark.sh
@@ -215,7 +215,7 @@ else
   fail "the pool build should be faster than the baseline, got delta $pool_delta%"
 fi
 expect_equal 'the MAD of the repeats is reported' 3 \
-  "$(jq '[.results[] | select(.label == "candidate") | .mad_ms] | length' "$results")"
+  "$(jq '[.results[] | select(.label == "candidate") | .mad_ms | select(. != null)] | length' "$results")"
 
 expect_equal 'the CSV has a header plus one row per build and scenario' 10 \
   "$(line_count "$OUT_DIR/results.csv")"
@@ -337,6 +337,35 @@ expect_equal 'cells carry CPU and RSS' 16 \
 expect_equal 'the scaling view is grouped per scenario and build' 4 \
   "$(jq '.scaling | length' "$matrix")"
 
+# A matrix run has no runs[], so a cell is the finest grain there is: the phase
+# and round-trip detail has to survive into it (issue #184, phase 2).
+expect_equal 'every cell keeps its phases' 16 \
+  "$(jq '[.cells[] | select((.phases | length) > 0)] | length' "$matrix")"
+expect_equal 'a cell keeps the phases that are not the upload' 'connect create_dirs local_scan upload' \
+  "$(jq -r '[.cells[0].phases[].name] | sort | join(" ")' "$matrix")"
+expect_equal 'every cell keeps its round-trip percentiles' 16 \
+  "$(jq '[.cells[] | select(([.operations[] | select(.name == "sftp_open") | .p90_ms] | first) != null)] | length' "$matrix")"
+expect_nonempty 'upload_phase_ms is still there for anything reading it' \
+  "$(jq -r '.cells[0].upload_phase_ms' "$matrix")"
+
+# A single repeat has no measured spread; 0 there would read as precision.
+expect_equal 'a one-repeat cell reports no MAD' 16 \
+  "$(jq '[.cells[] | select(.mad_ms == null)] | length' "$matrix")"
+
+# Start, middle and end of the grid: 2 connections x 2 concurrency x 2 scenarios
+# x 2 builds is 16 cells, so the middle canary has a middle to sit in.
+expect_equal 'the canary is measured three times' 3 \
+  "$(jq '.canary | length' "$matrix")"
+expect_equal 'the canary says when each run happened' 'start mid end' \
+  "$(jq -r '[.canary[].at] | join(" ")' "$matrix")"
+expect_equal 'the canary is one fixed cell' 'small/1/4' \
+  "$(jq -r '[.canary[] | "\(.scenario)/\(.connections)/\(.concurrency)"] | unique | join(" ")' "$matrix")"
+if grep -qF '### Canary' "$OUT_DIR/matrix.md"; then
+  pass "matrix.md reports the canary"
+else
+  fail "matrix.md is missing its canary section"
+fi
+
 # The heatmap axes must be explicit: a plot should not have to infer the grid
 # from the cells it happens to find.
 expect_equal 'the axes are declared' '1 2' "$(jq -r '.axes.connections | join(" ")' "$matrix")"
@@ -388,6 +417,11 @@ expect_equal 'the comparison pairs cells of the same profile' 2 \
   "$(jq '[.comparison[] | select(.link_profile != null)] | length' "$matrix_link")"
 expect_equal 'each profile got its own pair of probes' 4 \
   "$(jq '.link.probes | length' "$matrix_link")"
+# The canary axis multiplies with the profiles: drift inside one profile is what
+# it detects, and a canary of another profile is not a comparison for it.
+expect_equal 'each profile gets its own canary triple' \
+  'baseline/start baseline/mid baseline/end +150ms/start +150ms/mid +150ms/end' \
+  "$(jq -r '[.canary[] | "\(.link_profile)/\(.at)"] | join(" ")' "$matrix_link")"
 expect_equal 'the matrix CSV carries the link columns' \
   '"link_profile","rtt_p50_ms","control_single_mib_per_s"' \
   "$(head -1 "$OUT_DIR/matrix.csv" | cut -d, -f4-6)"


### PR DESCRIPTION
Phase 2 of #184: "stop discarding what is already measured".

## What changed

**Per-cell detail survives.** `runs.jsonl` always held the complete metrics document per cell; the stored matrix JSON kept only `upload_phase_ms`. Cells now carry `phases[]` and `operations[]` (count, cumulative total, avg, p50/p90/p99, max, errors), aggregated exactly the way a standard run aggregates them. `upload_phase_ms` stays, so anything reading it keeps working. A matrix run has no `runs[]`, so the cell is the finest grain there is; this is what phase 5 needs and it was being dropped after hours of measuring.

**A canary cell.** One fixed cell (`small`, `connections: 1`, `concurrency: 4`, candidate build) measured at the start, the middle and the end of each link profile's grid, stored under `canary[]` and rendered in `matrix.md` with the spread between fastest and slowest. With a single fixed server this is the only way to notice server-side drift over a multi-hour sweep. The middle point is counted in measured runs, not wall clock; a one-run grid has no middle and gets two canaries instead of three. The canary directory is cleaned up like the rest.

**`mad` is `null` below two samples**, not 0. That was the checkbox "at 1 repeat `mad` is 0, which looks like precision". Chosen over raising the matrix `REPEATS` default, which would multiply an already hours-long sweep to fix a display problem. `benchmarks/README.md` says what `null` means and that older results carry 0; `summary.md` prints `-`; `trend.csv` already used `// null`.

`net_write_bytes` in the matrix CSV was the remaining phase 2 checkbox, and #185 already shipped it.

## Cost

Three extra runs per link profile (plus their pre-cleans). Against a default grid of 120 measured runs, that is under 3%.

## Checks

`scripts/test-benchmark.sh` passes, extended with: cells keep phases, cells keep round-trip percentiles, `upload_phase_ms` survives, a one-repeat cell reports no MAD, the canary runs three times at the right points and is one fixed cell in every profile, and `matrix.md` renders its section. `scripts/test-benchmark-store.sh` passes unchanged. No Go code is touched.

`benchmarks/README.md` documents the new keys, the canary and how to read a `null` MAD.

Closes nothing: #184 stays open for phases 3 to 5.