### PR TITLE
feat(benchmark): measure the deploys that actually happen (#184)

### DIFF
--- a/.github/workflows/benchmark-matrix.yml
+++ b/.github/workflows/benchmark-matrix.yml
@@ -54,7 +54,7 @@ on:
         default: ""
         type: string
       scenarios:
-        description: "Payloads to sweep: any of small, mixed, large, single."
+        description: "Scenarios to sweep: small, mixed, large, single, plus the deploy shapes redeploy, sync, deep, bulk and the calibration family calib-<count>x<size> (for example calib-100x64k). redeploy and sync deploy their tree twice per cell, only the second one measured."
         required: false
         default: "small large single"
         type: string

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,11 @@ granularity is a separate, later decision; don't build it speculatively.
 `advanced.concurrency`, both on top of the shared `scripts/benchmark-lib.sh`
 (payload generation, running a build, reading its outputs, the jq statistics)
 and `scripts/benchmark-link.sh` (the probed link profile and `tc` shaping).
+A scenario there carries a *shape* as well as a payload (`scenario_shape`: mode,
+whether the measured run redeploys over an unmeasured one, flat or deep
+layout). The deploy-shape scenarios (`redeploy`, `sync`, `deep`, `bulk`,
+`calib-*`) are matrix-only: `benchmark.sh`'s set is fixed, because adding to it
+makes every stored release result incomparable.
 `scripts/benchmark-store.sh` files a result under `benchmarks/`;
 `benchmarks/README.md` documents the layout and the JSON schema and is the page
 to keep in sync when any of those change. Read `benchmarks/index.json` before

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -139,6 +139,45 @@ purpose, so canaries are comparable both within one run and across runs.
 The middle canary needs a middle to sit in; a grid of a single measured run per
 profile only gets a start and an end.
 
+### The deploy shapes
+
+A scenario is not only a payload. Every result up to issue #184 was a full
+upload into an empty target in `mode: overlay`, which is the rarest deploy there
+is; phase 3 added the shapes a real deploy actually has. The mode and the
+layout live in `scenario_shape`
+([`scripts/benchmark-lib.sh`](../scripts/benchmark-lib.sh)), and `matrix.md`
+prints them in a table next to the grids so a number is readable without going
+back to the script.
+
+| Scenario | What it is | Why |
+|---|---|---|
+| `small`, `mixed`, `large`, `single` | full upload into an empty target, `overlay` | the original set, unchanged, so stored results stay comparable |
+| `redeploy` | 500 x 4 KiB deployed twice, 3 files changed, `overlay` plus `advanced.skip_unchanged` | the common CI case; the only shape where `remote_scan` and the skip path are measured against a populated target |
+| `sync` | the same, in `mode: sync` | `manifest_read`, `hash`, `manifest_write` and `prune_dirs` are empty in every result measured in `overlay`, and sync is the only CPU-bound path in the product |
+| `deep` | 400 x 4 KiB, 7 directory levels, a handful of files per directory | separates `create_dirs` and `sftp_mkdirall` cost from transfer cost, which at this RTT is a large share of a `node_modules`-shaped deploy |
+| `bulk` | 2000 x 4 KiB | enough files for the per-run fixed costs to fall away against the per-file cost |
+| `calib-<count>x<size>` | uniform, e.g. `calib-100x64k`, `calib-10x16m` | not meant to be realistic: one size per scenario is what `t_file = r · RTT + size / B` can be fitted against, and `mixed` mixes three sizes and structurally cannot give that |
+
+Only the matrix benchmark takes them, through `MATRIX_SCENARIOS` (the
+`scenarios` workflow input); the standard benchmark's set stays fixed, because
+adding to it would make every stored release result incomparable.
+
+Two things to know before reading a `redeploy` or `sync` cell:
+
+- **Its cell cost roughly twice its measured time.** The tree is deployed once
+  unmeasured to create the state the measured run redeploys over, and only the
+  second run is measured. The script says which scenarios do this before it
+  starts.
+- **Its MiB/s is over the changed files, not over the tree.** Three files
+  changed out of 500 is the point; the duration is mostly scan and manifest
+  work, and reading its throughput as transfer throughput is a mistake.
+
+The change between the two deploys appends a few hundred bytes rather than
+rewriting in place, because it has to be visible to both detectors:
+`mode: sync` compares content hashes, but `advanced.skip_unchanged` compares the
+remote file's *size* only, and a same-size rewrite would be skipped as
+unchanged.
+
 ### The link profile
 
 `environment` says which machine measured. It said nothing at all about the path
@@ -338,6 +377,9 @@ The **`SFTP benchmark matrix`** workflow
 ([`.github/workflows/benchmark-matrix.yml`](../.github/workflows/benchmark-matrix.yml))
 runs the sweep. Its `connections` and `concurrency` inputs are the axes,
 `request-concurrency` adds an optional third one and `link-profiles` a fourth.
+Its `scenarios` input is where the deploy shapes above are requested; the
+default stays `small large single`, since each added scenario multiplies the
+grid the same way a link profile does.
 Candidate and baseline are measured cell by cell, back to back, for the same
 reason the standard benchmark interleaves its repeats. The default grid is over a
 hundred measured runs and takes hours, and each extra link profile multiplies

--- a/scripts/benchmark-lib.sh
+++ b/scripts/benchmark-lib.sh
@@ -21,12 +21,24 @@
 # "single" exists for the matrix benchmark: one large file cannot be spread
 # over connections at all, which makes it the control against which a
 # connections/concurrency curve is read.
+#
+# The scenarios below "single" are issue #184, phase 3: every result before them
+# was a full upload into an empty target in mode overlay, which is the rarest
+# real deploy. They cover the redeploy, the sync mode, a deep tree, a file count
+# high enough for the per-run fixed costs to fall away, and a calibration family
+# that is uniform by construction. See scenario_shape for how a scenario is run,
+# which for these is as much of the measurement as the payload is.
 scenario_spec() {
   case $1 in
   small) echo '300:4' ;;               # per-file round-trip overhead dominates
   mixed) echo '40:16 12:256 4:2048' ;; # roughly a built website
   large) echo '2:16384' ;;             # raw transfer throughput
   single) echo '1:32768' ;;            # one 32 MiB file, no parallelism to find
+  redeploy) echo '500:4' ;;            # the CI case: almost nothing changed
+  sync) echo '500:4' ;;                # the same payload, through mode sync
+  deep) echo '400:4' ;;                # node_modules-shaped, see scenario_shape
+  bulk) echo '2000:4' ;;               # per-file cost past the fixed costs
+  calib-*) calib_spec "$1" ;;
   *)
     echo "::error::unknown scenario $1" >&2
     return 1
@@ -34,15 +46,77 @@ scenario_spec() {
   esac
 }
 
+# calib_spec <name>: the calibration family, "calib-<count>x<size>" with the
+# size as <n>k or <n>m, e.g. calib-100x64k. One size per scenario, so
+# "t_file = r * RTT + size / B" can be fitted against it; "mixed" mixes three
+# sizes and structurally cannot give that (issue #184, phase 3).
+calib_spec() {
+  local rest=${1#calib-} count size
+  count=${rest%%x*}
+  size=${rest#*x}
+  if [[ "$rest" != *x* || ! "$count" =~ ^[1-9][0-9]*$ || ! "$size" =~ ^[1-9][0-9]*[km]$ ]]; then
+    echo "::error::calibration scenario '$1' must look like calib-<count>x<size>, size in k or m (for example calib-100x64k)" >&2
+    return 1
+  fi
+  case $size in
+  *k) echo "$count:${size%k}" ;;
+  *m) echo "$count:$((${size%m} * 1024))" ;;
+  esac
+}
+
 scenario_description() {
+  local spec
   case $1 in
   small) echo '300 files x 4 KiB' ;;
   mixed) echo '40 x 16 KiB + 12 x 256 KiB + 4 x 2 MiB' ;;
   large) echo '2 files x 16 MiB' ;;
   single) echo '1 file x 32 MiB' ;;
+  redeploy) echo '500 x 4 KiB, redeployed over itself with 3 files changed, overlay plus advanced.skip_unchanged' ;;
+  sync) echo '500 x 4 KiB, redeployed over itself with 3 files changed, mode sync' ;;
+  deep) echo '400 x 4 KiB in a tree 7 directories deep, 1 to 3 files per directory' ;;
+  bulk) echo '2000 files x 4 KiB' ;;
+  calib-*)
+    spec=$(calib_spec "$1") || {
+      echo unknown
+      return
+    }
+    echo "${spec%%:*} files x ${spec##*:} KiB, uniform (calibration)"
+    ;;
   *) echo 'unknown' ;;
   esac
 }
+
+# scenario_shape <name>: "<mode> <prepopulate> <layout>", the three things that
+# make a scenario a *deploy* rather than a payload. Everything not listed keeps
+# the shape every stored result was measured with, so the existing scenarios are
+# untouched by this table existing.
+#
+#   mode         the easySFTP mode the measured run uses
+#   prepopulate  1: the measured run is preceded by an unmeasured full deploy of
+#                the same tree, of which scenario_mutate then changes a few
+#                files. That is what makes remote_scan, hash, manifest_read /
+#                manifest_write and the skip path measurable at all; without it
+#                every one of them runs against an empty target
+#   layout       flat (8 sibling directories) or deep (7 levels, few files each)
+#
+# A prepopulated overlay scenario is measured with advanced.skip_unchanged on:
+# an overlay redeploy without it re-uploads everything, which is the fresh
+# upload the other scenarios already measure.
+scenario_shape() {
+  case $1 in
+  redeploy) echo 'overlay 1 flat' ;;
+  sync) echo 'sync 1 flat' ;;
+  deep) echo 'overlay 0 deep' ;;
+  *) echo 'overlay 0 flat' ;;
+  esac
+}
+
+# SCENARIO_CHANGED_FILES: how many files scenario_mutate changes between the
+# unmeasured deploy and the measured one. Small on purpose: "500 files, 3
+# changed" is the CI case, and a larger number would measure the upload again
+# instead of the scan.
+# shellcheck disable=SC2034  # used by the scripts that source this file
+SCENARIO_CHANGED_FILES=3
 
 require_env() {
   local name missing=0
@@ -100,7 +174,7 @@ check_log_dir() {
 # generate_dataset <scenario>...: writes each scenario's payload under
 # DATASET_DIR, plus an empty directory used for the pre-clean and cleanup runs.
 generate_dataset() {
-  local scenario dir spec count size index sub
+  local scenario dir spec count size index sub layout level rest planned
   local -a specs
   mkdir -p "$DATASET_DIR/empty"
   for scenario in "$@"; do
@@ -108,13 +182,39 @@ generate_dataset() {
     rm -rf "$dir"
     index=0
     read -r -a specs <<<"$(scenario_spec "$scenario")"
+    read -r _ _ layout <<<"$(scenario_shape "$scenario")"
+    # Before writing, not after: the calibration family takes a count and a size
+    # from whoever typed it, and "calib-1000x16m" is 16 GiB of local disk plus
+    # the hours to upload it. Said early, and not refused, because a deliberate
+    # large run is a legitimate thing to ask this for.
+    planned=0
+    for spec in "${specs[@]}"; do
+      planned=$((planned + ${spec%%:*} * ${spec##*:}))
+    done
+    echo "dataset $scenario: generating $((planned / 1024)) MiB"
+    if ((planned > 2 * 1024 * 1024)); then
+      echo "::warning::the $scenario payload is $((planned / 1024 / 1024)) GiB; that is local disk on the runner and upload time in every cell that uses it" >&2
+    fi
     for spec in "${specs[@]}"; do
       count=${spec%%:*}
       size=${spec##*:}
       while ((count-- > 0)); do
-        # Spread over subdirectories so remote directory creation is part of
-        # the measurement, as it is in a real site upload.
-        sub="$dir/part$((index % 8))"
+        if [[ "$layout" == deep ]]; then
+          # One directory per 7-bit pattern of the index: 128 leaf directories
+          # holding a handful of files each, which is the node_modules shape.
+          # It separates create_dirs and sftp_mkdirall cost from transfer cost,
+          # and at this RTT that is a large share of a real deploy.
+          sub="$dir"
+          rest=$index
+          for ((level = 0; level < 7; level++)); do
+            sub="$sub/d$((rest % 2))"
+            rest=$((rest / 2))
+          done
+        else
+          # Spread over subdirectories so remote directory creation is part of
+          # the measurement, as it is in a real site upload.
+          sub="$dir/part$((index % 8))"
+        fi
         mkdir -p "$sub"
         head -c "$((size * 1024))" /dev/urandom >"$sub/file$index.bin"
         index=$((index + 1))
@@ -122,6 +222,23 @@ generate_dataset() {
     done
     echo "dataset $scenario: $index file(s), $(du -sh "$dir" | cut -f1)"
   done
+}
+
+# scenario_mutate <dir> <count>: changes the first <count> files of a payload,
+# in sorted order, so a prepopulated scenario's measured run has something to
+# deploy. Called between the unmeasured deploy and the measured one.
+#
+# The change appends rather than rewriting in place, because it has to be
+# visible to both detectors: the sync manifest compares content hashes, but
+# advanced.skip_unchanged compares the remote *size* only (see uploadFiles in
+# internal/uploader/transfer.go), and a same-size rewrite would be skipped. The
+# files therefore grow by a few hundred bytes per repeat, which is deliberate
+# and negligible against the payload.
+scenario_mutate() {
+  local dir=$1 count=$2 file
+  while IFS= read -r file; do
+    head -c 512 /dev/urandom >>"$file"
+  done < <(find "$dir" -type f | sort | head -n "$count")
 }
 
 # run_easysftp <binary> <source> <remote> <mode> <log> <outputs-file> [advanced-yaml]

--- a/scripts/benchmark-matrix.sh
+++ b/scripts/benchmark-matrix.sh
@@ -20,7 +20,13 @@
 #   MATRIX_REQUEST_CONCURRENCY  optional third axis; empty (default) leaves
 #                               advanced.request_concurrency at easySFTP's own
 #                               default and keeps the grid two-dimensional
-#   MATRIX_SCENARIOS            default "small large single"
+#   MATRIX_SCENARIOS            default "small large single". Beyond those:
+#                               "mixed", plus the deploy shapes of issue #184
+#                               phase 3, "redeploy", "sync", "deep", "bulk" and
+#                               the "calib-<count>x<size>" family (for example
+#                               "calib-100x64k"). See scenario_shape in
+#                               scripts/benchmark-lib.sh: a scenario carries a
+#                               mode and a layout, not only a payload
 #   MATRIX_LINK_PROFILES        optional network profiles to sweep over (issue
 #                               #184); empty means the real line only. See
 #                               scripts/benchmark-link.sh for the grammar. This
@@ -133,6 +139,19 @@ total=$((cells_per_profile * ${#link_profiles[@]}))
 canary_total=$((3 * ${#link_profiles[@]}))
 echo "matrix: ${#scenarios[@]} scenario(s) x ${#connections_axis[@]} connection value(s) x ${#concurrency_axis[@]} concurrency value(s) x ${#request_axis[@]} request-concurrency value(s) x ${#link_profiles[@]} link profile(s) x ${#labels[@]} build(s) x $REPEATS repeat(s) = $total measured run(s), plus up to $canary_total canary run(s)"
 
+# A prepopulated scenario deploys its tree twice per cell, and only the second
+# one is measured. Worth saying before the hours start rather than after.
+prepopulated=()
+for scenario in "${scenarios[@]}"; do
+  read -r _ prepopulate _ <<<"$(scenario_shape "$scenario")"
+  if ((prepopulate)); then
+    prepopulated+=("$scenario")
+  fi
+done
+if ((${#prepopulated[@]} > 0)); then
+  echo "matrix: ${prepopulated[*]} are redeploy scenarios; each of their cells runs an unmeasured full deploy first, so those cells cost roughly twice their measured time"
+fi
+
 # The canary payload has to exist even when its scenario is not swept.
 dataset_scenarios=("${scenarios[@]}")
 if [[ " ${scenarios[*]} " != *" $CANARY_SCENARIO "* ]]; then
@@ -145,6 +164,10 @@ generate_dataset "${dataset_scenarios[@]}"
 # The remote path is per (build, scenario) rather than per cell: every run is
 # preceded by an unmeasured clean anyway, so a path per cell would only leave
 # more empty directories behind on the server.
+#
+# What is measured is the scenario's mode, not always overlay, and a
+# prepopulated scenario gets an unmeasured full deploy plus a small local change
+# in between (issue #184, phase 3). Both come from scenario_shape.
 measure_cell() {
   local label=$1 binary=$2 ref=$3 scenario=$4 conns=$5 conc=$6 request=$7 repeat=$8
   local remote="$REMOTE_BASE/matrix/$label/$scenario"
@@ -152,12 +175,21 @@ measure_cell() {
   slug=$(link_profile_slug "$link_profile")
   local stem="$LOG_DIR/$slug-$label-$scenario-c$conns-w$conc-r${request:-default}-$repeat"
   local code=0
+  local mode prepopulate
+  read -r mode prepopulate _ <<<"$(scenario_shape "$scenario")"
 
   local advanced="connections: $conns
 concurrency: $conc"
   if [[ -n "$request" ]]; then
     advanced="$advanced
 request_concurrency: $request"
+  fi
+  # Kept off the pre-clean: skip_unchanged applies to overlay only, and a clean
+  # deployment carrying it just logs a warning about being ignored.
+  local deploy_advanced=$advanced
+  if ((prepopulate)) && [[ "$mode" == overlay ]]; then
+    deploy_advanced="$advanced
+skip_unchanged: true"
   fi
 
   if ! METRICS_FILE='' run_easysftp "$binary" "$DATASET_DIR/empty" "$remote" clean \
@@ -166,8 +198,20 @@ request_concurrency: $request"
     cat "$stem.clean.log"
   fi
 
+  # The deploy the measured run redeploys over. Unmeasured, with the cell's own
+  # settings: what is under test is the second run, and a base laid down at
+  # other settings would put a different remote tree under each cell.
+  if ((prepopulate)); then
+    if ! METRICS_FILE='' run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" "$mode" \
+      "$stem.base.log" "$stem.base.out" "$deploy_advanced"; then
+      echo "::warning::base deploy of $label/$scenario c$conns/w$conc repeat $repeat failed"
+      cat "$stem.base.log"
+    fi
+    scenario_mutate "$DATASET_DIR/$scenario" "$SCENARIO_CHANGED_FILES"
+  fi
+
   METRICS_FILE="$stem.metrics.json" \
-    run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" overlay "$stem.log" "$stem.out" "$advanced" || code=$?
+    run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" "$mode" "$stem.log" "$stem.out" "$deploy_advanced" || code=$?
   if ((code != 0)); then
     # Into the job log, which masks secrets. Never into the artifact.
     echo "::warning::$label/$scenario c$conns/w$conc repeat $repeat exited $code"
@@ -368,7 +412,7 @@ jq -s "
   | sort_by([.link_profile, .scenario, .label, .connections, .concurrency, .request_concurrency])
 " "$runs_file" >"$cells_file"
 
-settings="matrix sweep; every other advanced.* setting stays at easySFTP's defaults (retries 2, timeout 30s, mode overlay)"
+settings="matrix sweep; every other advanced.* setting stays at easySFTP's defaults (retries 2, timeout 30s). The mode belongs to the scenario, see scenarios below: a redeploy scenario is deployed once unmeasured and then measured over itself with $SCENARIO_CHANGED_FILES file(s) changed"
 if [[ -n "$MATRIX_LINK_PROFILES" ]]; then
   settings="$settings; swept over the link profiles ${link_profiles[*]}"
 fi
@@ -500,6 +544,19 @@ jq -r '
   echo "| request_concurrency | ${MATRIX_REQUEST_CONCURRENCY:-easySFTP default} |"
   echo "| Link profiles | ${MATRIX_LINK_PROFILES:-the real line} |"
   echo "| Scenarios | ${scenarios[*]} |"
+  echo
+  # What each scenario is, next to the numbers: "sync" and "redeploy" are a
+  # deploy shape and not only a payload, and a MiB/s of theirs is over the few
+  # changed files rather than over the tree.
+  echo "| Scenario | Mode | Payload |"
+  echo "|---|---|---|"
+  for scenario in "${scenarios[@]}"; do
+    read -r mode prepopulate _ <<<"$(scenario_shape "$scenario")"
+    if ((prepopulate)); then
+      mode="$mode, redeployed"
+    fi
+    echo "| \`$scenario\` | $mode | $(scenario_description "$scenario") |"
+  done
   echo
   link_markdown "$OUT_DIR/matrix.json"
   echo "Each grid below is median wall-clock milliseconds: rows are \`advanced.connections\`, columns are \`advanced.concurrency\`. Lower is better. \`connections > concurrency\` is measured, not skipped; easySFTP caps the pool at the concurrency (a connection no worker picks is a handshake for nothing), so those cells are expected to flatten out rather than improve."

--- a/scripts/test-benchmark.sh
+++ b/scripts/test-benchmark.sh
@@ -56,15 +56,26 @@ cat >"$stub" <<'STUB'
 set -euo pipefail
 
 source_dir=${EASYSFTP_SOURCE:-}
+mode=${EASYSFTP_MODE:-}
 connections=1
 concurrency=4
+skip_unchanged=false
 if [[ -n "${EASYSFTP_CONFIG:-}" ]]; then
   source_dir=$(awk -F'"' '/source:/ { print $2; exit }' "$EASYSFTP_CONFIG")
+  mode=$(awk '/^    mode:/ { print $2; exit }' "$EASYSFTP_CONFIG")
   connections=$(awk '/^  connections:/ { print $2; exit }' "$EASYSFTP_CONFIG")
   concurrency=$(awk '/^  concurrency:/ { print $2; exit }' "$EASYSFTP_CONFIG")
   connections=${connections:-1}
   concurrency=${concurrency:-4}
+  if grep -q '^  skip_unchanged: true' "$EASYSFTP_CONFIG"; then
+    skip_unchanged=true
+  fi
 fi
+
+# Into the run log, which is what the checks on the deploy shapes read: the mode
+# and skip_unchanged are chosen per scenario, and nothing else in the output
+# would show which ones a cell actually ran with.
+echo "stub: mode=${mode:-none} skip_unchanged=$skip_unchanged source=$source_dir"
 
 files=0
 bytes=0
@@ -431,6 +442,84 @@ expect_equal 'the matrix CSV carries net_write_bytes' 1 \
   "$(head -1 "$OUT_DIR/matrix.csv" | grep -c 'net_write_bytes')"
 expect_equal 'the matrix renders one grid per build and profile' 4 \
   "$(grep -c '^#### ' "$OUT_DIR/matrix.md")"
+
+echo
+echo "== scenario shapes (issue #184, phase 3) =="
+# The payload side, checked directly against the library: the deep layout, the
+# calibration grammar and the mutation are all logic a stub run would only
+# exercise by accident.
+# shellcheck source=scripts/benchmark-lib.sh disable=SC1091
+source "$repo_root/scripts/benchmark-lib.sh"
+
+expect_equal 'the calibration grammar parses a KiB size' '10:64' "$(scenario_spec calib-10x64k)"
+expect_equal 'the calibration grammar parses a MiB size' '1000:16384' "$(scenario_spec calib-1000x16m)"
+if scenario_spec calib-nonsense >/dev/null 2>&1; then
+  fail "a malformed calibration scenario is accepted"
+else
+  pass "a malformed calibration scenario is rejected"
+fi
+expect_equal 'a redeploy scenario declares its shape' 'overlay 1 flat' "$(scenario_shape redeploy)"
+expect_equal 'the sync scenario is measured in mode sync' 'sync 1 flat' "$(scenario_shape sync)"
+expect_equal 'the scenarios that predate this keep the old shape' 'overlay 0 flat' "$(scenario_shape small)"
+
+shapes="$work/shapes"
+(DATASET_DIR="$shapes" && generate_dataset deep calib-10x64k >/dev/null)
+expect_equal 'the deep payload has the file count of its spec' 400 \
+  "$(find "$shapes/deep" -type f | wc -l | tr -d ' ')"
+# 7 levels of two directories each: many directories holding a handful of files,
+# which is what separates create_dirs cost from transfer cost.
+expect_equal 'the deep payload nests 7 levels' 128 \
+  "$(find "$shapes/deep" -mindepth 7 -maxdepth 7 -type d | wc -l | tr -d ' ')"
+expect_equal 'nothing sits deeper than that' 0 \
+  "$(find "$shapes/deep" -mindepth 8 -type d | wc -l | tr -d ' ')"
+expect_equal 'a calibration payload is uniform' '10 65536' \
+  "$(find "$shapes/calib-10x64k" -type f -exec wc -c {} + | awk '$2 != "total" { n += 1; s[$1] = 1 } END { for (k in s) u = k; print n, u }')"
+
+scenario_mutate "$shapes/calib-10x64k" "$SCENARIO_CHANGED_FILES"
+expect_equal 'the mutation changes exactly the files it says' 3 \
+  "$(find "$shapes/calib-10x64k" -type f -exec wc -c {} + | awk '$2 != "total" && $1 == 66048 { n += 1 } END { print n + 0 }')"
+
+echo
+echo "== scripts/benchmark-matrix.sh over the deploy shapes =="
+# One cell, one build, three scenarios: what is under test is that a scenario
+# carries a mode and a base deploy, not the grid.
+export OUT_DIR="$work/shape-out" LOG_DIR="$work/shape-logs" REPEATS=1
+export MATRIX_CONNECTIONS="1" MATRIX_CONCURRENCY="2"
+export MATRIX_SCENARIOS="redeploy sync calib-10x64k"
+unset MATRIX_LINK_PROFILES LINKPROBE_BIN BASELINE_BIN BASELINE_REF
+bash "$repo_root/scripts/benchmark-matrix.sh" >"$work/matrix-shapes.stdout" 2>&1 ||
+  fail "benchmark-matrix.sh over the deploy shapes exited non-zero (see $work/matrix-shapes.stdout)"
+
+shape_matrix="$OUT_DIR/matrix.json"
+if [[ ! -f $shape_matrix ]]; then
+  echo "FAIL: the deploy shape run produced no matrix.json" >&2
+  cat "$work/matrix-shapes.stdout" >&2
+  exit 1
+fi
+
+expect_equal 'every deploy shape produced a cell' 'calib-10x64k redeploy sync' \
+  "$(jq -r '[.cells[].scenario] | unique | join(" ")' "$shape_matrix")"
+expect_equal 'the sync scenario was measured in mode sync' 1 \
+  "$(grep -lc 'stub: mode=sync' "$LOG_DIR"/baseline-candidate-sync-*[0-9].log | wc -l | tr -d ' ')"
+expect_equal 'the redeploy scenario was measured with skip_unchanged' 1 \
+  "$(grep -lc 'stub: mode=overlay skip_unchanged=true' "$LOG_DIR"/baseline-candidate-redeploy-*[0-9].log | wc -l | tr -d ' ')"
+# The unmeasured deploy the measured run redeploys over. Its metrics must not
+# exist: a base deploy counted as a measurement would report the fresh upload
+# this scenario exists to *not* measure.
+expect_equal 'a redeploy cell laid down an unmeasured base deploy first' 2 \
+  "$(find "$LOG_DIR" -name '*.base.log' | wc -l | tr -d ' ')"
+expect_equal 'a scenario without a base deploy runs one deploy only' 0 \
+  "$(find "$LOG_DIR" -name '*calib-10x64k*.base.log' | wc -l | tr -d ' ')"
+expect_equal 'the calibration scenario is documented by its spec' \
+  '10 files x 64 KiB, uniform (calibration)' \
+  "$(jq -r '.scenarios["calib-10x64k"]' "$shape_matrix")"
+# The backticks around the scenario name are matched as "." so this pattern
+# stays a single-quoted string shellcheck does not read as an expansion.
+if grep -qE '^\| .sync. \| sync, redeployed \|' "$OUT_DIR/matrix.md"; then
+  pass "matrix.md says which mode a scenario was measured in"
+else
+  fail "matrix.md does not say which mode a scenario was measured in"
+fi
 
 if ((failures > 0)); then
   echo "$failures check(s) failed" >&2


### PR DESCRIPTION
Phase 3 of #184.

Every stored result so far is a full upload into an empty target in `mode: overlay`, which is the rarest real deploy. That is why `remote_scan`, `hash`, `manifest_read`, `manifest_write`, the skip path and `prune_dirs` are empty or trivial in all of them, and it is the half of the data phase 5 would have to calibrate against.

A scenario now carries a **shape** as well as a payload (`scenario_shape` in `scripts/benchmark-lib.sh`: mode, whether the measured run redeploys over an unmeasured one, flat or deep layout). Everything not listed keeps the shape it was always measured with, so `small`, `mixed`, `large` and `single` are byte for byte the runs they were.

| Scenario | What it is | Why |
|---|---|---|
| `redeploy` | 500 x 4 KiB deployed twice, 3 files changed, `overlay` plus `advanced.skip_unchanged` | the common CI case, and the only shape that measures a scan against a populated target |
| `sync` | the same, in `mode: sync` | the phases that are empty everywhere else, and the only CPU-bound path in the product |
| `deep` | 400 x 4 KiB over 128 directories 7 levels down | separates `create_dirs` / `sftp_mkdirall` cost from transfer cost |
| `bulk` | 2000 x 4 KiB | per-run fixed costs fall away against per-file cost |
| `calib-<count>x<size>` | uniform, e.g. `calib-100x64k`, `calib-10x16m` | `t_file = r · RTT + size / B` can be fitted against it; `mixed` mixes three sizes and structurally cannot |

Two details worth knowing:

- The change between the two deploys **appends** instead of rewriting in place. It has to be visible to both detectors: `mode: sync` compares content hashes, but `advanced.skip_unchanged` compares the remote file's *size* only (`uploadFiles`, `internal/uploader/transfer.go`), so a same-size rewrite would be skipped as unchanged.
- A `redeploy` or `sync` cell costs roughly twice its measured time, and its MiB/s is over the changed files, not over the tree. Both are said in the run log before the sweep starts and in the scenario table `matrix.md` now prints.

All of it is **matrix-only and off by default**: `MATRIX_SCENARIOS` still defaults to `small large single`, and `benchmark.sh`'s set stays fixed, because adding to it would make every stored release result incomparable. The calibration family takes its count and size from whoever types it, so `generate_dataset` prints the planned size before it writes and warns past 2 GiB (`calib-1000x16m` is 16 GiB of runner disk).

Deletions are phase 4 and deliberately not in here.

Checked: `scripts/test-benchmark.sh` (90 checks, including a new section on the shapes and a matrix run over `redeploy sync calib-10x64k`), `scripts/test-benchmark-store.sh`, `shellcheck scripts/*.sh`. No Go code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
