### PR TITLE
feat(benchmark): keep the delete sweep that already runs (#184)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,14 @@ applied only behind the EXIT/INT/TERM trap in `benchmark-link.sh`, because a
 runner left shaped makes every later measurement on it quietly wrong. Shaping
 that is unavailable is recorded, never fatal.
 
+The `clean` deployment of an empty directory that runs before every measured run
+is instrumented too, into its own metrics file and its own `deletes[]` block
+(issue #184, phase 4): it is a pure delete sweep and the only measurement of
+deletions there is. Do not "simplify" it back to `METRICS_FILE=''`, and keep its
+numbers out of `results[]` / `cells[]`: an upload aggregate that grew a
+`delete_sweep` phase is a bug, and `scripts/test-benchmark.sh` asserts it did
+not.
+
 Instrumentation lives in `internal/metrics` and is off unless
 `EASYSFTP_METRICS_FILE` names a path. It is deliberately **not** an
 `action.yml` input, so none of the drift-check lists apply to it. When metrics

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,6 +87,7 @@ Markdown:
 | `results[].operations[]` | per round-trip: count, cumulative total, average, p50/p90/p99, max, errors |
 | `results[].counters` | connections opened/used/refused, reconnects, retries, stalls, errors |
 | `comparison[]` | each build against the reference build: `delta_ms`, `delta_percent`, and `within_noise` (is the delta smaller than the reference's MAD?) |
+| `deletes[]` | the delete sweeps, one row per (build, scenario, link profile); see "The delete sweeps" below |
 | `runs[]` | every individual repeat, verbatim, including its own metrics document |
 
 **Phases are wall clock. Operations are not.** A phase adds up to roughly the
@@ -112,6 +113,7 @@ same thing in version 2.
 | `scaling[]` | the same cells pre-grouped per link profile, scenario and build, ordered along the axes, plus the `best` cell |
 | `comparison[]` | candidate against baseline at identical coordinates, **including the same link profile** |
 | `canary[]` | the fixed cell, measured at the `start`, the `mid` and the `end` of each profile's grid |
+| `deletes[]` | the delete sweeps, one row per cell coordinate; see "The delete sweeps" below |
 
 A matrix run has no `runs[]`: a cell is its finest grain, which is why the cell
 itself carries the phase and round-trip detail rather than only the
@@ -138,6 +140,40 @@ purpose, so canaries are comparable both within one run and across runs.
 
 The middle canary needs a middle to sit in; a grid of a single measured run per
 profile only gets a start and an end.
+
+### The delete sweeps
+
+Both scripts have always run a `clean` deployment of an empty directory before
+every measured run, so that each run starts from the same empty remote
+directory. That pre-clean *is* a pure delete sweep, and until issue #184 phase 4
+its numbers were thrown away. They are now kept, in a `deletes[]` block of their
+own: no additional run, no additional minute, and the only place deletions are
+measured at all.
+
+| Field | What it is |
+|---|---|
+| the coordinates | build, scenario and link profile; a matrix row adds `connections`, `concurrency` and `request_concurrency`, the same coordinates its cell has |
+| `sweeps`, `failed_sweeps` | how many sweeps the row aggregates, and how many of them exited non-zero |
+| `files_deleted` | how many entries the sweep found to delete |
+| `median_ms`, `min_ms`, `max_ms`, `mad_ms`, `durations_ms`, `deletes_per_s` | the same statistics an upload row carries |
+| `phases[]` | wall clock, `remote_scan` and `delete_sweep` |
+| `operations[]` | per round-trip, `sftp_remove` and `sftp_rmdir` with count, cumulative total, p50/p90/p99 and max |
+
+Read the round-trips against issue #157: a deletion is one round-trip per entry
+and nothing spreads them over the connection pool, so a matrix row's
+`sftp_remove` count and percentiles at different `connections` are what turns
+that from a plausible claim into a measured one.
+
+Two things kept deliberately separate:
+
+- **A sweep that found nothing is not counted.** The first pre-clean of a build
+  and scenario runs against an empty remote directory and measures the scan
+  alone; a median over that and a real sweep describes neither. A coordinate
+  left with no sweep at all has no row.
+- **Delete numbers never touch upload numbers.** They are aggregated from their
+  own metrics files into their own block; no `results[]` or `cells[]` row
+  contains a `delete_sweep` phase or an `sftp_remove` round-trip. The CSVs stay
+  upload-only too: `deletes[]` lives in the JSON.
 
 ### The deploy shapes
 

--- a/scripts/benchmark-lib.sh
+++ b/scripts/benchmark-lib.sh
@@ -321,6 +321,26 @@ count_matches() {
   fi
 }
 
+# delete_json <stem> [exit-code]: the pre-clean of "<stem>.clean.*" as JSON.
+#
+# That pre-clean is a pure delete sweep: it wipes the populated tree the last
+# run left behind, and both scripts already run one before every measured run.
+# Its numbers used to be discarded (issue #184, phase 4); this reads them back
+# out, and the callers keep them in their own block so they can never reach an
+# upload aggregate.
+#
+# The caller adds the coordinates, e.g.
+#   jq -c --arg label "$l" '. + $ARGS.named' <<<"$(delete_json "$stem" "$code")"
+delete_json() {
+  local stem=$1
+  jq -nc \
+    --argjson exit_code "${2:-0}" \
+    --argjson duration_ms "$(step_number "$stem.clean.out" duration-ms)" \
+    --argjson files_deleted "$(step_number "$stem.clean.out" files-deleted)" \
+    --argjson metrics "$(metrics_json "$stem.clean.metrics.json")" \
+    '$ARGS.named'
+}
+
 # metrics_json <file>: the run's metrics document, or "null" when the run died
 # before writing one (or wrote something unreadable). Always prints valid JSON
 # so callers can pass it to "jq --argjson" unconditionally.
@@ -362,6 +382,54 @@ JQ_STATS='
   def round1: (. * 10 | round) / 10;
   def round2: (. * 100 | round) / 100;
   def pct(a; b): if (b // 0) == 0 then null else (((a - b) / b) * 100 | round2) end;
+'
+
+# JQ_DELETE aggregates one group of delete_json rows into the block both scripts
+# store under "deletes" (issue #184, phase 4). Prepend JQ_STATS with it.
+#
+# Sweeps that deleted nothing are dropped rather than averaged in: the first
+# pre-clean of a (build, scenario) runs against an empty remote directory and
+# measures the scan alone, and a median over that and a real sweep describes
+# neither. A group left with no sweep at all is dropped by the callers.
+#
+# Phases (remote_scan, delete_sweep) are wall clock; sftp_remove and sftp_rmdir
+# are per round-trip, which is the pair issue #157 is about.
+# SC2034: used by the scripts that source this file. SC2016: the "$s"/"$m" in
+# here are jq variables, so single quotes are exactly right.
+# shellcheck disable=SC2034,SC2016
+JQ_DELETE='
+  def delete_agg: map(select(.files_deleted > 0)) as $s
+    | ($s | map(select(.metrics != null) | .metrics)) as $m
+    | {
+        sweeps: ($s | length),
+        failed_sweeps: ($s | map(select(.exit_code != 0)) | length),
+        files_deleted: ($s | map(.files_deleted) | max // 0),
+        durations_ms: ($s | map(.duration_ms)),
+        median_ms: ($s | map(.duration_ms) | median),
+        min_ms: ($s | map(.duration_ms) | min // 0),
+        max_ms: ($s | map(.duration_ms) | max // 0),
+        mad_ms: ($s | map(.duration_ms) | mad),
+        phases: ($m | map(.phases // []) | add // []
+          | group_by(.name)
+          | map({name: .[0].name, median_ms: (map(.wall_ms) | median)})
+          | sort_by(-.median_ms)),
+        operations: ($m | map(.operations // []) | add // []
+          | group_by(.name)
+          | map({
+              name: .[0].name,
+              count: (map(.count) | median),
+              median_total_ms: (map(.total_ms) | median),
+              avg_ms: (map(.avg_ms) | median),
+              p50_ms: (map(.p50_ms) | median),
+              p90_ms: (map(.p90_ms) | median),
+              p99_ms: (map(.p99_ms) | median),
+              max_ms: (map(.max_ms) | median),
+              errors: (map(.errors) | add)
+            })
+          | sort_by(-.median_total_ms))
+      }
+    | . + {deletes_per_s:
+        (if .median_ms > 0 then (.files_deleted / (.median_ms / 1000) | round2) else 0 end)};
 '
 
 # bench_environment: the machine and toolchain a result was measured on, as

--- a/scripts/benchmark-matrix.sh
+++ b/scripts/benchmark-matrix.sh
@@ -113,9 +113,11 @@ check_log_dir
 runs_file="$LOG_DIR/matrix-runs.jsonl"
 probes_file="$LOG_DIR/link-probes.jsonl"
 canary_file="$LOG_DIR/canary.jsonl"
+deletes_file="$LOG_DIR/deletes.jsonl"
 : >"$runs_file"
 : >"$probes_file"
 : >"$canary_file"
+: >"$deletes_file"
 
 # The profile every cell below is measured on; set by the profile loop.
 link_profile=baseline
@@ -192,11 +194,28 @@ request_concurrency: $request"
 skip_unchanged: true"
   fi
 
-  if ! METRICS_FILE='' run_easysftp "$binary" "$DATASET_DIR/empty" "$remote" clean \
-    "$stem.clean.log" "$stem.clean.out" "$advanced"; then
-    echo "::warning::pre-clean of $label/$scenario c$conns/w$conc repeat $repeat failed"
+  # The pre-clean wipes what the previous cell of this (build, scenario) left
+  # behind, which makes it a pure delete sweep at this cell's own settings. It is
+  # instrumented into its own file and aggregated into "deletes" (issue #184,
+  # phase 4), never into the cell: no extra run, no extra minute, and the only
+  # measurement of deletions there is.
+  local clean_code=0
+  METRICS_FILE="$stem.clean.metrics.json" \
+    run_easysftp "$binary" "$DATASET_DIR/empty" "$remote" clean \
+    "$stem.clean.log" "$stem.clean.out" "$advanced" || clean_code=$?
+  if ((clean_code != 0)); then
+    echo "::warning::pre-clean of $label/$scenario c$conns/w$conc repeat $repeat exited $clean_code"
     cat "$stem.clean.log"
   fi
+  jq -c \
+    --arg label "$label" \
+    --arg scenario "$scenario" \
+    --arg link_profile "$link_profile" \
+    --argjson connections "$conns" \
+    --argjson concurrency "$conc" \
+    --argjson request_concurrency "${request:-null}" \
+    --argjson repeat "$repeat" \
+    '. + $ARGS.named' <<<"$(delete_json "$stem" "$clean_code")" >>"$deletes_file"
 
   # The deploy the measured run redeploys over. Unmeasured, with the cell's own
   # settings: what is under test is the second run, and a base laid down at
@@ -412,6 +431,24 @@ jq -s "
   | sort_by([.link_profile, .scenario, .label, .connections, .concurrency, .request_concurrency])
 " "$runs_file" >"$cells_file"
 
+# The delete sweeps, one row per cell coordinate, sweeps that found an empty
+# directory dropped (the first cell of a build and scenario is one) and a
+# coordinate left with none dropped with them. Kept apart from cells[]: a delete
+# sweep and an upload at the same coordinates are two different measurements.
+deletes_agg_file="$LOG_DIR/deletes.json"
+jq -s "
+  $JQ_STATS
+  $JQ_DELETE
+  group_by([.link_profile, .label, .scenario, .connections, .concurrency, .request_concurrency])
+  | map({
+      scenario: .[0].scenario, label: .[0].label, link_profile: .[0].link_profile,
+      connections: .[0].connections, concurrency: .[0].concurrency,
+      request_concurrency: .[0].request_concurrency
+    } + delete_agg)
+  | map(select(.sweeps > 0))
+  | sort_by([.link_profile, .scenario, .label, .connections, .concurrency, .request_concurrency])
+" "$deletes_file" >"$deletes_agg_file"
+
 settings="matrix sweep; every other advanced.* setting stays at easySFTP's defaults (retries 2, timeout 30s). The mode belongs to the scenario, see scenarios below: a redeploy scenario is deployed once unmeasured and then measured over itself with $SCENARIO_CHANGED_FILES file(s) changed"
 if [[ -n "$MATRIX_LINK_PROFILES" ]]; then
   settings="$settings; swept over the link profiles ${link_profiles[*]}"
@@ -426,8 +463,9 @@ done | jq -s 'from_entries')
 # combination, "scaling" is the same data pre-grouped into the curve a reader
 # usually wants (per scenario and build, ordered by connections then
 # concurrency), "comparison" pairs each candidate cell with the reference
-# build's cell at the same coordinates, and "canary" holds the fixed cell's
-# three measurements per profile.
+# build's cell at the same coordinates, "canary" holds the fixed cell's three
+# measurements per profile, and "deletes" holds the pre-clean sweeps at the same
+# coordinates as the cells.
 #
 # A matrix run has no "runs[]" the way a standard result does, so a cell is the
 # finest grain there is. That is why it carries its own phases[] and
@@ -443,6 +481,7 @@ jq -n \
   --argjson environment "$(bench_environment)" \
   --argjson link "$(link_json "$probes_file")" \
   --argjson canary "$(jq -s '.' "$canary_file")" \
+  --slurpfile deletes "$deletes_agg_file" \
   --arg settings "$settings" \
   --argjson scenarios "$scenario_docs" \
   --argjson link_axis "$(printf '%s\n' "${link_profiles[@]}" | jq -Rs 'split("\n") | map(select(. != ""))')" \
@@ -473,6 +512,7 @@ jq -n \
        request_concurrency: \$request_axis
      },
      cells: \$c,
+     deletes: \$deletes[0],
      scaling: (\$c | group_by([.link_profile, .scenario, .label])
        | map({
            scenario: .[0].scenario,
@@ -638,13 +678,35 @@ jq -r '
       + "| \(if ($d | min) > 0 then ((($d | max) - ($d | min)) / ($d | min) * 100 | round | tostring) + "%" else "-" end) |"
   ' "$OUT_DIR/matrix.json"
 
+  echo
+  echo "### Delete sweeps"
+  echo
+  echo "Every cell's pre-clean wipes the tree the cell before it left behind, at that cell's own \`connections\`/\`concurrency\`. It has always run and cost nothing extra; what is new is that it is measured (issue #184, phase 4). Cells whose pre-clean found an empty directory are not listed. Read the two columns on the right against #157: deletions are one round-trip per entry and the pool has nowhere to spread them."
+  echo
+  echo "<details><summary>Per-cell delete sweeps</summary>"
+  echo
+  echo "| Scenario | Build | Profile | conn | conc | Files deleted | Median | files/s | remote_scan | delete_sweep | sftp_remove p50 | sftp_rmdir p50 |"
+  echo "|---|---|---|---|---|---|---|---|---|---|---|---|"
+  jq -r '
+    def phase($n): [.phases[] | select(.name == $n) | .median_ms] | first;
+    def op($n): [.operations[] | select(.name == $n) | .p50_ms] | first;
+    def ms: if . == null then "-" else "\(.) ms" end;
+    .deletes[]
+    | "| \(.scenario) | \(.label) | \(.link_profile) | \(.connections) | \(.concurrency) "
+      + "| \(.files_deleted) | \(.median_ms) ms | \(.deletes_per_s) "
+      + "| \(phase("remote_scan") | ms) | \(phase("delete_sweep") | ms) "
+      + "| \(op("sftp_remove") | ms) | \(op("sftp_rmdir") | ms) |"
+  ' "$OUT_DIR/matrix.json"
+  echo
+  echo "</details>"
+
   refused=$(jq '[.cells[].connections_refused] | add // 0' "$OUT_DIR/matrix.json")
   if [[ "$refused" != 0 ]]; then
     echo
     echo "**$refused connection(s) were refused by the server** across the sweep and fell back to the run's first connection. Those cells had fewer connections than configured, which is the server's limit showing up in the data, not easySFTP's."
   fi
   echo
-  echo "Raw data: \`matrix.json\` (every cell with its own phases and round-trip percentiles, plus the pre-grouped \`scaling\` view and the \`canary\` runs), \`matrix.csv\` (one flat row per cell). Data only: nothing here fails a build."
+  echo "Raw data: \`matrix.json\` (every cell with its own phases and round-trip percentiles, plus the pre-grouped \`scaling\` view, the \`canary\` runs and the \`deletes\` sweeps), \`matrix.csv\` (one flat row per cell). Data only: nothing here fails a build."
 } >"$OUT_DIR/matrix.md"
 
 cat "$OUT_DIR/matrix.md"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -86,8 +86,10 @@ check_log_dir
 runs_file="$LOG_DIR/runs.jsonl"
 aggregate_file="$LOG_DIR/aggregate.json"
 probes_file="$LOG_DIR/link-probes.jsonl"
+deletes_file="$LOG_DIR/deletes.jsonl"
 : >"$runs_file"
 : >"$probes_file"
+: >"$deletes_file"
 
 # The profile every run below is measured on. Set by the profile loop; a run
 # always carries it, so "baseline" in a stored result means "the real line" and
@@ -103,15 +105,27 @@ measure() {
   local stem="$LOG_DIR/$slug-$label-$scenario-$repeat"
   local code=0
 
-  # Unmeasured: every repeat starts from the same empty remote directory, so
-  # repeat 1 (uploading into nothing) measures the same thing as the repeats
-  # after it (which would otherwise overwrite existing files). METRICS_FILE is
-  # cleared for it, so the pre-clean's own numbers can never be mistaken for
-  # the measurement's.
-  if ! METRICS_FILE='' run_easysftp "$binary" "$DATASET_DIR/empty" "$remote" clean "$stem.clean.log" "$stem.clean.out"; then
-    echo "::warning::pre-clean of $label/$scenario repeat $repeat failed"
+  # Unmeasured *as an upload*: every repeat starts from the same empty remote
+  # directory, so repeat 1 (uploading into nothing) measures the same thing as
+  # the repeats after it (which would otherwise overwrite existing files).
+  #
+  # It is instrumented all the same, into its own metrics file and its own
+  # aggregate (issue #184, phase 4): a clean deployment of an empty directory is
+  # a pure delete sweep, and it is the only place deletions are measured at all.
+  # Nothing of it ever reaches the upload numbers; the two files never meet.
+  local clean_code=0
+  METRICS_FILE="$stem.clean.metrics.json" \
+    run_easysftp "$binary" "$DATASET_DIR/empty" "$remote" clean "$stem.clean.log" "$stem.clean.out" || clean_code=$?
+  if ((clean_code != 0)); then
+    echo "::warning::pre-clean of $label/$scenario repeat $repeat exited $clean_code"
     cat "$stem.clean.log"
   fi
+  jq -c \
+    --arg label "$label" \
+    --arg scenario "$scenario" \
+    --arg link_profile "$link_profile" \
+    --argjson repeat "$repeat" \
+    '. + $ARGS.named' <<<"$(delete_json "$stem" "$clean_code")" >>"$deletes_file"
 
   METRICS_FILE="$stem.metrics.json" \
     run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" overlay "$stem.log" "$stem.out" "$advanced" || code=$?
@@ -287,6 +301,18 @@ jq -s "
     })
 " "$runs_file" >"$aggregate_file"
 
+# The delete sweeps, aggregated the same way and kept strictly apart: one row per
+# (link profile, build, scenario), sweeps that deleted nothing dropped, and a
+# group left with none dropped entirely rather than stored as a row of zeroes.
+delete_file="$LOG_DIR/delete.json"
+jq -s "
+  $JQ_STATS
+  $JQ_DELETE
+  group_by([.link_profile, .label, .scenario])
+  | map({label: .[0].label, scenario: .[0].scenario, link_profile: .[0].link_profile} + delete_agg)
+  | map(select(.sweeps > 0))
+" "$deletes_file" >"$delete_file"
+
 # The reference build every delta is measured against: the baseline when one
 # was measured, otherwise the candidate, so a pool run without a baseline is
 # still compared against something.
@@ -311,6 +337,7 @@ done | jq -s 'from_entries')
 #   metadata (candidate_ref, baseline_ref, repeats, runner, settings, env)
 #   results   aggregated per build and scenario, incl. process/phases/operations
 #   comparison  candidate (and pool) against the reference build
+#   deletes   the pre-clean sweeps, aggregated apart from everything above
 #   runs      every individual repeat, verbatim, metrics included
 # v1's top-level keys all still exist and mean the same thing.
 # Through a file, not a process substitution: jq's --slurpfile wants a real
@@ -321,6 +348,7 @@ jq -s '.' "$runs_file" >"$runs_array"
 jq -n \
   --slurpfile results "$aggregate_file" \
   --slurpfile runs "$runs_array" \
+  --slurpfile deletes "$delete_file" \
   --arg candidate_ref "$CANDIDATE_REF" \
   --arg baseline_ref "$BASELINE_REF" \
   --arg reference_label "$reference_label" \
@@ -347,6 +375,7 @@ jq -n \
      scenarios: \$scenarios,
      note: \"phases are wall clock and add up to the duration; operations are cumulative across parallel workers and do not\",
      results: \$r,
+     deletes: \$deletes[0],
      comparison: [
        \$r[] | select(.label != \$reference_label) as \$c
        | (\$r[] | select(.label == \$reference_label and .scenario == \$c.scenario
@@ -482,6 +511,29 @@ jq -r '
     echo "</details>"
     echo
   done
+
+  echo "### Delete sweeps"
+  echo
+  echo "The pre-clean before every measured run wipes the tree the previous repeat left behind, which makes it a pure delete sweep. It costs no extra time (it has always run) and its numbers never enter the upload tables above. Sweeps that found an empty directory are not counted."
+  echo
+  echo "| Scenario | Build | Profile | Sweeps | Files deleted | Median | files/s | remote_scan | delete_sweep |"
+  echo "|---|---|---|---|---|---|---|---|---|"
+  jq -r '
+    def phase($n): [.phases[] | select(.name == $n) | .median_ms] | first;
+    def ms: if . == null then "-" else "\(.) ms" end;
+    .deletes[]
+    | "| \(.scenario) | \(.label) | \(.link_profile) | \(.sweeps) | \(.files_deleted) | \(.median_ms) ms "
+      + "| \(.deletes_per_s) | \(phase("remote_scan") | ms) | \(phase("delete_sweep") | ms) |"
+  ' "$OUT_DIR/results.json"
+  echo
+  echo "| Scenario | Build | Profile | Operation | Count | Cumulative | p50 | p90 | p99 | Max |"
+  echo "|---|---|---|---|---|---|---|---|---|---|"
+  # sftp_remove and sftp_rmdir are the numbers issue #157 is about: one
+  # round-trip per entry, strictly sequential, no concurrency anywhere near them.
+  jq -r '.deletes[] as $d | $d.operations[] | select(.count > 0)
+    | "| \($d.scenario) | \($d.label) | \($d.link_profile) | \(.name) | \(.count) | \(.median_total_ms) ms "
+      + "| \(.p50_ms) ms | \(.p90_ms) ms | \(.p99_ms) ms | \(.max_ms) ms |"' "$OUT_DIR/results.json"
+  echo
 
   # Without this line a pool run whose extra connections the server refused
   # reads as "the pool did nothing", which is the wrong conclusion entirely.

--- a/scripts/test-benchmark.sh
+++ b/scripts/test-benchmark.sh
@@ -56,12 +56,14 @@ cat >"$stub" <<'STUB'
 set -euo pipefail
 
 source_dir=${EASYSFTP_SOURCE:-}
+target=${EASYSFTP_TARGET:-}
 mode=${EASYSFTP_MODE:-}
 connections=1
 concurrency=4
 skip_unchanged=false
 if [[ -n "${EASYSFTP_CONFIG:-}" ]]; then
   source_dir=$(awk -F'"' '/source:/ { print $2; exit }' "$EASYSFTP_CONFIG")
+  target=$(awk -F'"' '/target:/ { print $2; exit }' "$EASYSFTP_CONFIG")
   mode=$(awk '/^    mode:/ { print $2; exit }' "$EASYSFTP_CONFIG")
   connections=$(awk '/^  connections:/ { print $2; exit }' "$EASYSFTP_CONFIG")
   concurrency=$(awk '/^  concurrency:/ { print $2; exit }' "$EASYSFTP_CONFIG")
@@ -86,18 +88,56 @@ if [[ -d "$source_dir" ]]; then
   bytes=$(find "$source_dir" -type f -exec wc -c {} + | awk '$2 != "total" { s += $1 } END { print s + 0 }')
 fi
 
+# Just enough remote state to make a "clean" run delete what an earlier run put
+# there: one file per remote target holding its file count. Without it every
+# pre-clean would report zero deletions, and the delete aggregation (issue #184,
+# phase 4) would have nothing to aggregate.
+deleted=0
+if [[ -n "${EASYSFTP_STUB_STATE:-}" && -n "$target" ]]; then
+  mkdir -p "$EASYSFTP_STUB_STATE"
+  state="$EASYSFTP_STUB_STATE/${target//\//_}"
+  if [[ "$mode" == clean ]]; then
+    deleted=$(cat "$state" 2>/dev/null || echo 0)
+    rm -f "$state"
+  else
+    echo "$files" >"$state"
+  fi
+fi
+
 # More connections and more workers finish sooner, with a floor: exactly the
 # shape a scaling curve should have, so the matrix output can be checked
 # against a known answer.
 parallel=$((connections < concurrency ? connections : concurrency))
-duration=$((200 + files * 4 / parallel + RANDOM % 7))
+duration=$((200 + (files + deleted) * 4 / parallel + RANDOM % 7))
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
     echo "files-uploaded<<EOF"; echo "$files"; echo "EOF"
     echo "bytes-uploaded<<EOF"; echo "$bytes"; echo "EOF"
+    echo "files-deleted<<EOF"; echo "$deleted"; echo "EOF"
     echo "duration-ms<<EOF"; echo "$duration"; echo "EOF"
   } >>"$GITHUB_OUTPUT"
+fi
+
+# A clean deployment runs different phases and different round-trips than an
+# upload, and the delete aggregation reads exactly those.
+if [[ "$mode" == clean ]]; then
+  phases='[{"name": "remote_scan", "wall_ms": '$((duration / 3))', "count": 1},
+    {"name": "delete_sweep", "wall_ms": '$((duration * 2 / 3))', "count": 1},
+    {"name": "connect", "wall_ms": 40, "count": 1}]'
+  operations='[{"name": "sftp_remove", "count": '"$deleted"', "errors": 0, "total_ms": '$((duration / 2))',
+     "avg_ms": 2.1, "min_ms": 1, "p50_ms": 2, "p90_ms": 4, "p99_ms": 7, "max_ms": 8},
+    {"name": "sftp_rmdir", "count": 8, "errors": 0, "total_ms": 24,
+     "avg_ms": 3, "min_ms": 2, "p50_ms": 3, "p90_ms": 4, "p99_ms": 5, "max_ms": 5}]'
+else
+  phases='[{"name": "upload", "wall_ms": '$((duration - 60))', "count": 1},
+    {"name": "connect", "wall_ms": 40, "count": 1},
+    {"name": "local_scan", "wall_ms": 15, "count": 1},
+    {"name": "create_dirs", "wall_ms": 5, "count": 1}]'
+  operations='[{"name": "file_upload", "count": '"$files"', "errors": 0, "total_ms": '$((duration * 2))',
+     "avg_ms": 3.5, "min_ms": 1, "p50_ms": 3, "p90_ms": 6, "p99_ms": 9, "max_ms": 11},
+    {"name": "sftp_open", "count": '"$files"', "errors": 0, "total_ms": '"$duration"',
+     "avg_ms": 1.7, "min_ms": 1, "p50_ms": 1.5, "p90_ms": 3, "p99_ms": 5, "max_ms": 6}]'
 fi
 
 if [[ -n "${EASYSFTP_METRICS_FILE:-}" ]]; then
@@ -113,23 +153,13 @@ if [[ -n "${EASYSFTP_METRICS_FILE:-}" ]]; then
     "disk_read_bytes": $bytes, "disk_write_bytes": 0,
     "net_read_bytes": 4096, "net_write_bytes": $bytes
   },
-  "phases": [
-    {"name": "upload", "wall_ms": $((duration - 60)), "count": 1},
-    {"name": "connect", "wall_ms": 40, "count": 1},
-    {"name": "local_scan", "wall_ms": 15, "count": 1},
-    {"name": "create_dirs", "wall_ms": 5, "count": 1}
-  ],
-  "operations": [
-    {"name": "file_upload", "count": $files, "errors": 0, "total_ms": $((duration * 2)),
-     "avg_ms": 3.5, "min_ms": 1, "p50_ms": 3, "p90_ms": 6, "p99_ms": 9, "max_ms": 11},
-    {"name": "sftp_open", "count": $files, "errors": 0, "total_ms": $duration,
-     "avg_ms": 1.7, "min_ms": 1, "p50_ms": 1.5, "p90_ms": 3, "p99_ms": 5, "max_ms": 6}
-  ],
+  "phases": $phases,
+  "operations": $operations,
   "counters": {
     "connections_opened": $connections, "connections_used": $connections,
     "connections_refused": 0, "reconnects": 0, "retries": 0, "stalls": 0, "errors": 0,
     "config_connections": $connections, "config_concurrency": $concurrency,
-    "files_uploaded": $files, "bytes_uploaded": $bytes
+    "files_uploaded": $files, "bytes_uploaded": $bytes, "files_deleted": $deleted
   }
 }
 JSON
@@ -173,6 +203,9 @@ export REMOTE_BASE=/easysftp-benchmark-test
 export BENCH_HOST=example.invalid BENCH_PORT=22 BENCH_USERNAME=tester
 export BENCH_PASSWORD=secret BENCH_KNOWN_HOSTS="example.invalid ssh-ed25519 AAAA"
 export DATASET_DIR="$work/data"
+# The stub's stand-in for the remote server, so a pre-clean has something to
+# delete; see the stub above.
+export EASYSFTP_STUB_STATE="$work/remote-state"
 
 # Shaping must never actually happen here. This check may run as root on a
 # maintainer's box or on a self-hosted runner, and a netem qdisc left on a real
@@ -228,22 +261,44 @@ fi
 expect_equal 'the MAD of the repeats is reported' 3 \
   "$(jq '[.results[] | select(.label == "candidate") | .mad_ms | select(. != null)] | length' "$results")"
 
+# The pre-clean is a delete sweep and is now stored as one (issue #184, phase 4).
+# Three repeats mean two sweeps that found something: the first pre-clean of a
+# build and scenario runs against an empty directory and is dropped.
+expect_equal 'every build and scenario has a delete row' 9 "$(jq '.deletes | length' "$results")"
+expect_equal 'empty sweeps are not counted' 2 \
+  "$(jq -r '[.deletes[] | select(.label == "candidate" and .scenario == "small") | .sweeps] | first' "$results")"
+expect_equal 'a delete row says how much it deleted' 300 \
+  "$(jq -r '[.deletes[] | select(.label == "candidate" and .scenario == "small") | .files_deleted] | first' "$results")"
+expect_equal 'the delete sweep keeps its own phases' 'connect delete_sweep remote_scan' \
+  "$(jq -r '[.deletes[0].phases[].name] | sort | join(" ")' "$results")"
+expect_equal 'the delete sweep keeps the round-trips issue #157 is about' 'sftp_remove sftp_rmdir' \
+  "$(jq -r '[.deletes[0].operations[].name] | sort | join(" ")' "$results")"
+expect_nonempty 'sftp_remove carries percentiles' \
+  "$(jq -r '[.deletes[0].operations[] | select(.name == "sftp_remove") | .p90_ms] | first' "$results")"
+# The whole point of a separate block: an upload aggregate must not have grown a
+# delete phase, and the delete numbers must not have moved an upload median.
+expect_equal 'no upload result picked up a delete phase' 0 \
+  "$(jq '[.results[].phases[] | select(.name == "delete_sweep")] | length' "$results")"
+expect_equal 'no upload result picked up a delete round-trip' 0 \
+  "$(jq '[.results[].operations[] | select(.name == "sftp_remove")] | length' "$results")"
+
 expect_equal 'the CSV has a header plus one row per build and scenario' 10 \
   "$(line_count "$OUT_DIR/results.csv")"
 expect_equal 'the CSV names its columns' '"scenario","build"' \
   "$(head -1 "$OUT_DIR/results.csv" | cut -d, -f1,2)"
 
-for needle in '## easySFTP benchmark' '### Throughput' '### Resources' '### Where the time goes'; do
+for needle in '## easySFTP benchmark' '### Throughput' '### Resources' '### Where the time goes' '### Delete sweeps'; do
   if grep -qF "$needle" "$OUT_DIR/summary.md"; then
     pass "summary.md has '$needle'"
   else
     fail "summary.md is missing '$needle'"
   fi
 done
-# The file count in the fourth column is what distinguishes a throughput row
-# from the resources table's row for the same scenario, build and link profile.
+# The file count and the payload size in columns four and five are what
+# distinguish a throughput row from the resources and delete-sweep tables, which
+# start with the same scenario, build and link profile.
 expect_equal 'summary.md has a throughput row for every build and scenario' 9 \
-  "$(grep -cE '^\| (small|mixed|large) \| (candidate|baseline|pool2) \| baseline \| [0-9]+ \|' "$OUT_DIR/summary.md")"
+  "$(grep -cE '^\| (small|mixed|large) \| (candidate|baseline|pool2) \| baseline \| [0-9]+ \| [0-9.]+ MiB \|' "$OUT_DIR/summary.md")"
 expect_equal 'summary.md has a resources row for every build and scenario' 9 \
   "$(grep -cE '^\| (small|mixed|large) \| (candidate|baseline|pool2) \| baseline \| [0-9.]+ ms \|' "$OUT_DIR/summary.md")"
 
@@ -371,6 +426,23 @@ expect_equal 'the canary says when each run happened' 'start mid end' \
   "$(jq -r '[.canary[].at] | join(" ")' "$matrix")"
 expect_equal 'the canary is one fixed cell' 'small/1/4' \
   "$(jq -r '[.canary[] | "\(.scenario)/\(.connections)/\(.concurrency)"] | unique | join(" ")' "$matrix")"
+# One delete row per cell, minus the first cell of each (build, scenario): its
+# pre-clean has an empty directory in front of it (issue #184, phase 4).
+expect_equal 'every cell but the first of its build and scenario has a delete row' 12 \
+  "$(jq '.deletes | length' "$matrix")"
+expect_equal 'a delete row carries the cell coordinates it was measured at' true \
+  "$(jq '.deletes[0] | has("connections") and has("concurrency") and has("request_concurrency")' "$matrix")"
+expect_equal 'a matrix delete row keeps its sweep phase' 12 \
+  "$(jq '[.deletes[] | select([.phases[] | select(.name == "delete_sweep")] | length == 1)] | length' "$matrix")"
+expect_nonempty 'a matrix delete row keeps the sftp_remove percentiles' \
+  "$(jq -r '[.deletes[0].operations[] | select(.name == "sftp_remove") | .p50_ms] | first' "$matrix")"
+expect_equal 'no cell picked up a delete phase' 0 \
+  "$(jq '[.cells[].phases[] | select(.name == "delete_sweep")] | length' "$matrix")"
+if grep -qF '### Delete sweeps' "$OUT_DIR/matrix.md"; then
+  pass "matrix.md reports the delete sweeps"
+else
+  fail "matrix.md is missing its delete sweep section"
+fi
 if grep -qF '### Canary' "$OUT_DIR/matrix.md"; then
   pass "matrix.md reports the canary"
 else


### PR DESCRIPTION
## What & why

Issue #184, phase 4. Both benchmark scripts run a `clean` deployment of an
empty directory before every measured run, so that each run starts from the
same empty remote directory. That pre-clean *is* a pure delete sweep, and its
numbers were thrown away (`METRICS_FILE=''`). Deletions were therefore the one
part of the product that hours of benchmarking never measured, although the
measurement was already happening.

It is now instrumented into its own metrics file and aggregated into a
`deletes[]` block. No additional run, no additional minute of runtime.

- **Standard run**: one row per (build, scenario, link profile), in
  `results.json` and a `### Delete sweeps` section in `summary.md`.
- **Matrix run**: one row per *cell coordinate*. The pre-clean already runs at
  the cell's own `connections`/`concurrency`, so this comes for free and is
  what makes #157 ("deletions and remote scans are strictly sequential
  round-trips") decidable rather than plausible: each row keeps the
  `remote_scan` and `delete_sweep` phases plus the `sftp_remove` and
  `sftp_rmdir` percentiles.

Two separations the aggregation keeps, both asserted by the self-check:

- A sweep that found an empty directory is dropped rather than averaged in.
  The first pre-clean of a build and scenario is one of those, and a median
  over an empty scan and a real sweep describes neither.
- Nothing of a sweep reaches an upload aggregate: no `results[]` or `cells[]`
  row contains a `delete_sweep` phase or an `sftp_remove` round-trip.

Closes nothing on its own; #184 stays open for phase 5.

## Checklist

- [x] `go test ./...`, `go vet ./...` and `gofmt -l .` are clean
- [x] Behavior changes have a test (bug fixes: one that fails without the fix)
- [x] Docs updated where affected: `README.md`, `docs/`, `action.yml` input
      descriptions, `schema/easysftp.schema.json`
- [x] New external dependency in CI is pinned by full commit SHA / `@sha256:` digest
- [x] `CHANGELOG.md` **not** hand-edited (release-please generates it)

No Go code changed, so the Go checks are green by not being touched; `-race`
was not run for the same reason. `shellcheck scripts/*.sh` is clean.
`scripts/test-benchmark.sh` (105 checks) and `scripts/test-benchmark-store.sh`
pass locally. Docs touched: `benchmarks/README.md` (the `deletes[]` rows in
both key tables plus a "The delete sweeps" section) and `CLAUDE.md`.

## Notes for the reviewer

- The self-check's stub now models just enough remote state (one file per
  remote target holding its file count) for a `clean` run to have something to
  delete, and writes delete phases and round-trips instead of upload ones. Without
  that, every stub sweep would report zero deletions and the new aggregation
  would have nothing to aggregate.
- One pre-existing check was under-specified: its regex for a throughput row in
  `summary.md` also matched the new delete table. It now pins the payload-size
  column as well, which is what actually distinguishes those rows.
- Deliberately left out: delete columns in `results.csv` / `matrix.csv` (those
  are the upload grid a heatmap reads; a delete sweep is a different
  measurement at the same coordinates, and flattening both into one row would
  invite reading them as one), and instrumenting the canary's own pre-clean
  (the canary measures server steadiness, not deletions).
- `CLAUDE.md` gained a short warning against "simplifying" the pre-clean back
  to `METRICS_FILE=''`, since that is exactly what this PR undoes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
