### PR TITLE
feat(benchmark): sweep the axes that move, and score what auto picks (#184)

### DIFF
--- a/.github/workflows/benchmark-matrix.yml
+++ b/.github/workflows/benchmark-matrix.yml
@@ -14,10 +14,18 @@ name: SFTP benchmark matrix
 # "sftp-benchmark" concurrency group with benchmark.yml, since both measure the
 # same host and two of them at once would measure each other.
 #
-# Cost: the default grid is 4 connection values x 5 concurrency values x 3
-# scenarios x the number of builds. That is over a hundred measured runs; the
-# job's timeout is generous for that reason, and the inputs exist so a quick
-# look can be a quick look.
+# Cost: the grid is per scenario, not global. An axis value above a scenario's
+# file count is the same configuration under another name, and
+# request_concurrency is a per-file setting a payload of 4 KiB files cannot use,
+# so both axes are capped against the payload (issue #184, phase 5). That is
+# what pays for the longer concurrency axis, whose old maximum of 16 could only
+# ever report an optimum on its own edge. It is still tens of measured runs per
+# scenario; the job's timeout is generous for that reason, and the inputs exist
+# so a quick look can be a quick look.
+#
+# Each sweep also measures the settings easySFTP picks for itself, once per
+# scenario and profile, and reports the gap to the best cell as the policy's
+# regret. That number is what the auto-config work of #156 has to beat.
 #
 # Secrets, runner and approval: identical to benchmark.yml; see its header for
 # the reasoning, including why this must stay off "on: release" and why the
@@ -44,14 +52,14 @@ on:
         default: "1 2 4 8"
         type: string
       concurrency:
-        description: "advanced.concurrency values to sweep, space separated."
+        description: "advanced.concurrency values to sweep, space separated. Each scenario is swept over the values its file count can use, so a large value costs nothing on a small payload."
         required: false
-        default: "1 2 4 8 16"
+        default: "1 2 4 8 16 32 64"
         type: string
       request-concurrency:
-        description: "Optional third axis (advanced.request_concurrency), space separated. Empty keeps easySFTP's default and the grid two-dimensional."
+        description: "Third axis (advanced.request_concurrency), space separated. Applied only to scenarios whose files are at least 1 MiB, since the setting is per file. The token 'default' is a pass that sets nothing, so 'default' alone gives a two-dimensional grid."
         required: false
-        default: ""
+        default: "1 16 64"
         type: string
       scenarios:
         description: "Scenarios to sweep: small, mixed, large, single, plus the deploy shapes redeploy, sync, deep, bulk and the calibration family calib-<count>x<size> (for example calib-100x64k). redeploy and sync deploy their tree twice per cell, only the second one measured."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,22 @@ jobs:
           BENCH_KNOWN_HOSTS=$(ssh-keyscan -p 2222 localhost 2>/dev/null)
           export BENCH_KNOWN_HOSTS
           bash scripts/benchmark-matrix.sh
-          jq -e '.cells | length == 8 and all(.median_ms > 0 and .failed_runs == 0)' "$OUT_DIR/matrix.json"
+          # 7, not 2x2x2: the grid is per scenario (issue #184, phase 5). "small"
+          # takes the whole 2x2, "single" is one file and therefore one
+          # connections/concurrency cell, swept over the three
+          # request_concurrency values it is the only scenario here to qualify for.
+          jq -e '.cells | length == 7 and all(.median_ms > 0 and .failed_runs == 0)' "$OUT_DIR/matrix.json"
+          # The request axis really reaches the run, and every cell records the
+          # value it ran with. Against a real server because the counter behind
+          # it is the only source of that; the stub can only echo it back.
+          jq -e '.cells | all(.request_concurrency_used > 0
+                   and (.request_concurrency == null
+                        or .request_concurrency == .request_concurrency_used))' "$OUT_DIR/matrix.json"
+          # And "auto" resolved to something real, per scenario, which is what
+          # the policy regret of issue #184 phase 5 is computed from.
+          jq -e '.auto | length == 2 and all(.median_ms > 0 and .failed_runs == 0
+                   and .chosen.connections > 0 and .chosen.concurrency > 0
+                   and .chosen.request_concurrency > 0 and .regret_percent != null)' "$OUT_DIR/matrix.json"
           # connections > concurrency must be measured, not rejected, and the
           # pool must really cap at the concurrency there (see the pool note in
           # internal/uploader/session.go).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,27 @@ applied only behind the EXIT/INT/TERM trap in `benchmark-link.sh`, because a
 runner left shaped makes every later measurement on it quietly wrong. Shaping
 that is unavailable is recorded, never fatal.
 
+The matrix grid is **per scenario** (issue #184, phase 5). `axis_for_scenario`
+caps and deduplicates both axes at the scenario's file count, and
+`scenario_sweeps_requests` only lets the `request_concurrency` axis through for
+payloads with files of at least 1 MiB, because that setting is
+`MaxConcurrentRequestsPerFile`. Both rules are properties of the payload, not
+opinions about the code: a value above the file count measures the same
+configuration twice (the stored `single` sweeps are 30 cells of one number).
+`axes` keeps what was requested and `axes.per_scenario` what was measured; do
+not collapse the two. That reduction is what pays for the `concurrency` axis
+running to 64, and the point of running it that far is that
+`scaling[].best_at_axis_max` should come out empty: a best cell on the largest
+swept value is a cut-off, not an optimum.
+
+Every sweep also measures `auto` (the settings easySFTP picks for itself) once
+per scenario and profile, and reports the regret against the best cell. It is
+deliberately not a build label in the grid: `auto` chooses a coordinate rather
+than sitting at one, so it stays out of `cells[]`, `scaling[]`, `comparison[]`
+and the CSV, and its chosen settings are read back from the run's own
+`config_*` counters rather than assumed. Changing the policy itself is #156 and
+belongs in its own PR; this only measures it.
+
 The `clean` deployment of an empty directory that runs before every measured run
 is instrumented too, into its own metrics file and its own `deletes[]` block
 (issue #184, phase 4): it is a pure delete sweep and the only measurement of

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -105,12 +105,16 @@ same thing in version 2.
 
 | Key | What it is |
 |---|---|
-| `axes` | the grid, declared: `link_profiles`, `connections`, `concurrency`, `request_concurrency` |
+| `axes` | the grid as requested: `link_profiles`, `connections`, `concurrency`, `request_concurrency` |
+| `axes.per_scenario` | the grid as measured, per scenario, plus the `files` count it was capped against; see "The per-scenario grid" below |
 | `link` | the same object a standard run carries, one probe pair per swept profile |
 | `cells[]` | one row per (link profile, scenario, build, connections, concurrency, request_concurrency) with duration, throughput, files/s, network bytes, CPU, peak RSS, connections opened/used/refused, reconnects, retries, errors |
+| `cells[].request_concurrency_used` | the value the run actually ran with, read from its counters; `request_concurrency` is null on the pass that sets nothing, and that null alone does not say which value it was |
 | `cells[].phases[]` | wall clock per phase, the same list a standard run's `results[].phases[]` carries |
 | `cells[].operations[]` | per round-trip: count, cumulative total, average, p50/p90/p99, max, errors |
 | `scaling[]` | the same cells pre-grouped per link profile, scenario and build, ordered along the axes, plus the `best` cell |
+| `scaling[].best_at_axis_max` | the axes whose largest swept value *is* the best cell, i.e. where the optimum was cut off rather than measured |
+| `auto[]` | the settings easySFTP picked for itself, and the regret against the best cell; see "What `auto` costs" below |
 | `comparison[]` | candidate against baseline at identical coordinates, **including the same link profile** |
 | `canary[]` | the fixed cell, measured at the `start`, the `mid` and the `end` of each profile's grid |
 | `deletes[]` | the delete sweeps, one row per cell coordinate; see "The delete sweeps" below |
@@ -123,6 +127,73 @@ that change have `upload_phase_ms` alone.
 The CSV next to it is the same `cells[]` flattened, one row per cell, which is
 what a heatmap or a scaling plot reads. The nested `phases[]` and
 `operations[]` stay out of it and live in the JSON only.
+
+### The per-scenario grid
+
+Up to issue #184 phase 5 every scenario was swept over the same axes, and the
+stored results show what that bought: `single` (one 32 MiB file) has 30 cells
+holding the same 0.38 MiB/s, because one file cannot be spread over connections
+or over workers. Meanwhile the optimum of every small-file scenario sat at
+`concurrency: 32`, the largest value swept, so the grid could report a boundary
+and never an optimum.
+
+The axes are therefore capped against the payload, per scenario, by
+`axis_for_scenario` in
+[`scripts/benchmark-lib.sh`](../scripts/benchmark-lib.sh):
+
+- **A value above the file count is dropped** (capped and deduplicated). Only
+  the per-file upload path spreads over connections and workers, so at most
+  *file count* files are ever in flight; measuring `concurrency: 16` on a
+  one-file payload measures `concurrency: 1` under another name.
+- **`request_concurrency` is only swept where a file is at least 1 MiB.** It is
+  `sftp.MaxConcurrentRequestsPerFile`, how many write requests of *one* file may
+  be in flight. pkg/sftp writes 32 KiB packets, so a 4 KiB file is a single
+  packet and a value above the default of 16 needs at least 32 packets before it
+  has anything left to pipeline.
+
+What that pays for is the two things phase 5 asks for: a `concurrency` axis that
+runs to 64 so the optimum can be interior, and a `request_concurrency` axis that
+is swept for real instead of being declared and left empty. `axes` keeps what
+was requested, `axes.per_scenario` records what each scenario was actually
+measured over, and `matrix.md` prints both next to the scenario table. A cell
+missing from the declared grid was not skipped; it would have been a duplicate.
+
+`scaling[].best_at_axis_max` is the honesty check on top: it names the axes
+whose largest swept value is the best cell. Where it is non-empty the optimum is
+at or beyond the edge of the sweep, and anything fitted to those numbers
+extrapolates.
+
+### What `auto` costs
+
+Every sweep also measures one run per scenario and link profile with
+`connections`, `concurrency` and `request_concurrency` all set to `auto`, on the
+candidate build, and scores it against the grid:
+
+| Field | What it is |
+|---|---|
+| `chosen` | the `connections`, `concurrency` and `request_concurrency` the run used, read from its own counters rather than assumed |
+| `median_ms`, `min_ms`, `max_ms`, `mad_ms`, `durations_ms`, `mib_per_s`, `files_per_s` | the same statistics a cell carries |
+| `best` | the fastest candidate cell of that scenario and profile |
+| `regret_ms`, `regret_percent` | the gap: how much slower the policy is than the settings a sweep would have picked |
+| `chosen_in_grid`, `chosen_cell_median_ms` | the same coordinates measured as an ordinary cell, when the grid contains them |
+
+Three things about it:
+
+- **It is not a cell.** `auto` does not sit at a coordinate, it chooses one, so
+  it stays out of `cells[]`, `scaling[]`, `comparison[]` and the CSV. A build
+  label in the grid would have measured the same policy at every coordinate.
+- **`chosen_cell_median_ms` is a control, not a result.** It is the same
+  settings measured a second time, as a cell. A large gap between it and the
+  `auto` run means the two saw different conditions, and the regret next to it
+  is then drift rather than policy.
+- **The regret is per link profile on purpose.** `RTT`, the per-connection
+  operation ceiling and the per-connection bandwidth are properties of one line
+  (see "The link profile"), and a policy that is only good on the benchmark
+  host's line is the failure class of #62 all over again. A policy within ~15%
+  of optimum on every profile is defensible; one that only wins here is not.
+  This is the number the auto-config work of #156 has to beat, and today it
+  scores a hardcoded default, which is exactly what #156 says `auto` currently
+  is.
 
 ### The canary
 
@@ -411,16 +482,21 @@ stays one.
 
 The **`SFTP benchmark matrix`** workflow
 ([`.github/workflows/benchmark-matrix.yml`](../.github/workflows/benchmark-matrix.yml))
-runs the sweep. Its `connections` and `concurrency` inputs are the axes,
-`request-concurrency` adds an optional third one and `link-profiles` a fourth.
-Its `scenarios` input is where the deploy shapes above are requested; the
-default stays `small large single`, since each added scenario multiplies the
-grid the same way a link profile does.
+runs the sweep. Its `connections`, `concurrency` and `request-concurrency`
+inputs are the axes and `link-profiles` adds a fourth. Its `scenarios` input is
+where the deploy shapes above are requested; the default stays
+`small large single`, since each added scenario multiplies the grid the same way
+a link profile does.
 Candidate and baseline are measured cell by cell, back to back, for the same
-reason the standard benchmark interleaves its repeats. The default grid is over a
-hundred measured runs and takes hours, and each extra link profile multiplies
-that; shrink the axes for a quick look. The script prints its run count before it
-starts, canary runs included.
+reason the standard benchmark interleaves its repeats. The grid is tens of
+measured runs per scenario and takes hours, and each extra link profile
+multiplies that; shrink the axes for a quick look. The script prints its run
+count before it starts, per scenario and with the canary and `auto` runs
+included, and it prints the axes each scenario was reduced to (see "The
+per-scenario grid").
+
+Setting `request-concurrency` to the single token `default` turns that axis off
+again, which is the grid every result before issue #184 phase 5 was measured on.
 
 ### About `connections` above `concurrency`
 
@@ -432,3 +508,9 @@ over the pool, and at most `concurrency` files are ever in flight, so a
 connection past that number buys a handshake and no parallelism. Those cells are
 in the grid so the data shows that flattening rather than leaving a gap where a
 reader has to take the cap on trust.
+
+The per-scenario cap above does not remove them: it caps both axes at the same
+number, so a scenario with at least two files still has its `connections >
+concurrency` cells. A one-file scenario has exactly one configuration and
+therefore one cell, which is the same statement made in one row instead of
+thirty.

--- a/scripts/benchmark-lib.sh
+++ b/scripts/benchmark-lib.sh
@@ -111,6 +111,82 @@ scenario_shape() {
   esac
 }
 
+# scenario_files <name>: how many files the payload has, summed over its groups.
+scenario_files() {
+  local group total=0
+  local -a groups
+  read -r -a groups <<<"$(scenario_spec "$1")"
+  for group in "${groups[@]}"; do
+    total=$((total + ${group%%:*}))
+  done
+  echo "$total"
+}
+
+# scenario_max_kib <name>: the largest single file in the payload, in KiB.
+scenario_max_kib() {
+  local group size max=0
+  local -a groups
+  read -r -a groups <<<"$(scenario_spec "$1")"
+  for group in "${groups[@]}"; do
+    size=${group##*:}
+    if ((size > max)); then
+      max=$size
+    fi
+  done
+  echo "$max"
+}
+
+# REQUEST_AXIS_MIN_KIB: the file size from which advanced.request_concurrency
+# can do anything at all.
+#
+# That setting is sftp.MaxConcurrentRequestsPerFile (see
+# internal/uploader/connection.go): how many write requests of *one* file may be
+# in flight. pkg/sftp writes in 32 KiB packets, so a 4 KiB file is a single
+# packet and cannot use a second request no matter what the value is, and a file
+# needs 32 packets (1 MiB) before a value above easySFTP's default of 16 has
+# anything left to pipeline. Below this threshold the axis measures the same
+# number repeatedly, which is what keeps it from tripling a grid it cannot move.
+REQUEST_AXIS_MIN_KIB=1024
+
+# scenario_sweeps_requests <name>: 1 when the request_concurrency axis applies
+# to this scenario, 0 when it is measured at easySFTP's own default only.
+scenario_sweeps_requests() {
+  local max
+  max=$(scenario_max_kib "$1")
+  if ((max >= REQUEST_AXIS_MIN_KIB)); then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
+# axis_for_scenario <scenario> <value>...: the requested axis values that can
+# actually differ for this payload, one per line, order preserved.
+#
+# Only the per-file upload path spreads over connections and workers, so at most
+# <file count> files are ever in flight: an axis value above that is the same
+# configuration measured a second time under a different name. The stored
+# "single" grid is the demonstration, 30 cells of 0.38 MiB/s for one 32 MiB file
+# (issue #184, phase 5). Values are therefore capped at the file count and
+# deduplicated, which is what buys the room for a longer concurrency axis where
+# it can move and for the request axis where it can.
+axis_for_scenario() {
+  local scenario=$1 value files seen=" "
+  local -a out=()
+  files=$(scenario_files "$scenario")
+  shift
+  for value in "$@"; do
+    if ((value > files)); then
+      value=$files
+    fi
+    if [[ "$seen" != *" $value "* ]]; then
+      seen="$seen$value "
+      out+=("$value")
+    fi
+  done
+  printf '%s\n' "${out[@]}"
+}
+
 # SCENARIO_CHANGED_FILES: how many files scenario_mutate changes between the
 # unmeasured deploy and the measured one. Small on purpose: "500 files, 3
 # changed" is the CI case, and a larger number would measure the upload again

--- a/scripts/benchmark-matrix.sh
+++ b/scripts/benchmark-matrix.sh
@@ -16,10 +16,19 @@
 #
 # Environment (everything scripts/benchmark.sh reads, plus):
 #   MATRIX_CONNECTIONS          advanced.connections values (default "1 2 4 8")
-#   MATRIX_CONCURRENCY          advanced.concurrency values (default "1 2 4 8 16")
-#   MATRIX_REQUEST_CONCURRENCY  optional third axis; empty (default) leaves
-#                               advanced.request_concurrency at easySFTP's own
-#                               default and keeps the grid two-dimensional
+#   MATRIX_CONCURRENCY          advanced.concurrency values (default
+#                               "1 2 4 8 16 32 64"; the stored sweeps put the
+#                               optimum of every small-file scenario at 32, the
+#                               edge of the old grid, so the old default could
+#                               only ever report a boundary, issue #184 phase 5)
+#   MATRIX_REQUEST_CONCURRENCY  advanced.request_concurrency values (default
+#                               "1 16 64"; 16 is easySFTP's own value). The
+#                               literal token "default" is a pass that sets
+#                               nothing, so "default" alone is the old
+#                               two-dimensional grid. Applied only to scenarios
+#                               whose files are large enough for the setting to
+#                               do anything, see scenario_sweeps_requests in
+#                               scripts/benchmark-lib.sh
 #   MATRIX_SCENARIOS            default "small large single". Beyond those:
 #                               "mixed", plus the deploy shapes of issue #184
 #                               phase 3, "redeploy", "sync", "deep", "bulk" and
@@ -37,16 +46,27 @@
 #   LINK_IFACE, LINK_SUDO       see scripts/benchmark-link.sh
 #   REPEATS                     repeats per cell (default 1)
 #
-# Cost warning: the grid is measured in full. The default 4x5 grid over three
-# scenarios and two builds is 120 measured runs plus 120 unmeasured pre-cleans.
-# The script prints its own run count before it starts; shrink the axes rather
-# than letting a job time out halfway.
+# Cost warning: the grid is measured in full, but it is measured *per scenario*.
+# An axis value above a scenario's file count is the same configuration under
+# another name (only the per-file upload path spreads over connections and
+# workers), so axis_for_scenario caps and deduplicates both axes against the
+# payload: "single" is one cell, not the 30 identical ones the stored sweeps
+# hold. The script prints its own run count before it starts; shrink the axes
+# rather than letting a job time out halfway.
 #
 # On top of the grid, three canary runs per link profile (issue #184, phase 2):
 # one fixed cell measured at the start, the middle and the end of that profile's
 # grid. A sweep takes hours against a server that is fixed but not constant, and
 # three values that disagree are the only signal that the whole run is not a
 # comparison basis.
+#
+# And one "auto" run per scenario, profile and repeat (issue #184, phase 5): the
+# candidate build with every knob left at "auto", i.e. whatever easySFTP picks
+# for itself. It is not a cell, because auto does not sit at a coordinate, it
+# chooses one; what it is measured for is the *regret* of that choice, the gap
+# between it and the best cell of the same scenario and profile. That number is
+# what keeps #156 honest, and it is the reason the auto runs are kept out of
+# cells[], scaling[] and comparison[].
 
 set -euo pipefail
 
@@ -65,8 +85,8 @@ BENCH_PORT=${BENCH_PORT:-22}
 BASELINE_BIN=${BASELINE_BIN:-}
 BASELINE_REF=${BASELINE_REF:-}
 MATRIX_CONNECTIONS=${MATRIX_CONNECTIONS:-"1 2 4 8"}
-MATRIX_CONCURRENCY=${MATRIX_CONCURRENCY:-"1 2 4 8 16"}
-MATRIX_REQUEST_CONCURRENCY=${MATRIX_REQUEST_CONCURRENCY:-}
+MATRIX_CONCURRENCY=${MATRIX_CONCURRENCY:-"1 2 4 8 16 32 64"}
+MATRIX_REQUEST_CONCURRENCY=${MATRIX_REQUEST_CONCURRENCY:-"1 16 64"}
 MATRIX_SCENARIOS=${MATRIX_SCENARIOS:-"small large single"}
 MATRIX_LINK_PROFILES=${MATRIX_LINK_PROFILES:-}
 
@@ -81,24 +101,49 @@ read -r -a connections_axis <<<"$MATRIX_CONNECTIONS"
 read -r -a concurrency_axis <<<"$MATRIX_CONCURRENCY"
 read -r -a request_axis <<<"$MATRIX_REQUEST_CONCURRENCY"
 read -r -a scenarios <<<"$MATRIX_SCENARIOS"
-# An empty third axis means "one pass at easySFTP's own default", which is what
-# the empty string stands for in the loop below.
+# The third axis carries the token "default" for "set nothing and let easySFTP
+# pick", so a two-dimensional grid stays expressible now that the axis has a
+# real default. It travels as that token rather than as an empty string because
+# it has to survive being stored in the per-scenario axis strings below.
 if ((${#request_axis[@]} == 0)); then
-  request_axis=("")
+  request_axis=(default)
 fi
 
 if [[ ! "$REPEATS" =~ ^[1-9][0-9]*$ ]]; then
   echo "::error::REPEATS must be a positive integer, got '$REPEATS'" >&2
   exit 1
 fi
-for value in "${connections_axis[@]}" "${concurrency_axis[@]}" "${request_axis[@]}"; do
-  if [[ -n "$value" && ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+for value in "${connections_axis[@]}" "${concurrency_axis[@]}"; do
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
     echo "::error::matrix axis values must be positive integers, got '$value'" >&2
+    exit 1
+  fi
+done
+for value in "${request_axis[@]}"; do
+  if [[ "$value" != default && ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error::request_concurrency axis values must be positive integers or the token 'default', got '$value'" >&2
     exit 1
   fi
 done
 for scenario in "${scenarios[@]}"; do
   scenario_spec "$scenario" >/dev/null
+done
+
+# The grid is per scenario, not global (issue #184, phase 5). Two payload facts
+# decide it, and both are properties of the payload rather than of the code:
+# a value above the file count cannot be used by anything (axis_for_scenario),
+# and request_concurrency is per file, so a payload of 4 KiB files cannot show
+# it at all (scenario_sweeps_requests). Computed once, up front, because the run
+# count printed below has to be the count that is actually measured.
+declare -A scenario_conn_axis scenario_conc_axis scenario_req_axis
+for scenario in "${scenarios[@]}"; do
+  scenario_conn_axis[$scenario]=$(axis_for_scenario "$scenario" "${connections_axis[@]}" | tr '\n' ' ')
+  scenario_conc_axis[$scenario]=$(axis_for_scenario "$scenario" "${concurrency_axis[@]}" | tr '\n' ' ')
+  if (($(scenario_sweeps_requests "$scenario"))); then
+    scenario_req_axis[$scenario]=${request_axis[*]}
+  else
+    scenario_req_axis[$scenario]=default
+  fi
 done
 # Through a command substitution and not a process substitution, so a rejected
 # profile stops the sweep under "set -e" instead of hours later.
@@ -114,10 +159,12 @@ runs_file="$LOG_DIR/matrix-runs.jsonl"
 probes_file="$LOG_DIR/link-probes.jsonl"
 canary_file="$LOG_DIR/canary.jsonl"
 deletes_file="$LOG_DIR/deletes.jsonl"
+auto_file="$LOG_DIR/auto.jsonl"
 : >"$runs_file"
 : >"$probes_file"
 : >"$canary_file"
 : >"$deletes_file"
+: >"$auto_file"
 
 # The profile every cell below is measured on; set by the profile loop.
 link_profile=baseline
@@ -136,10 +183,20 @@ if [[ -n "$BASELINE_BIN" ]]; then
 fi
 
 # Cells of one profile's grid, which is also what the middle canary counts to.
-cells_per_profile=$((${#scenarios[@]} * ${#connections_axis[@]} * ${#concurrency_axis[@]} * ${#request_axis[@]} * ${#labels[@]} * REPEATS))
+# Summed per scenario, since each one has its own axes.
+cells_per_profile=0
+for scenario in "${scenarios[@]}"; do
+  read -r -a axis_conn <<<"${scenario_conn_axis[$scenario]}"
+  read -r -a axis_conc <<<"${scenario_conc_axis[$scenario]}"
+  read -r -a axis_req <<<"${scenario_req_axis[$scenario]}"
+  cells_per_profile=$((cells_per_profile +
+    ${#axis_conn[@]} * ${#axis_conc[@]} * ${#axis_req[@]} * ${#labels[@]} * REPEATS))
+  echo "matrix: $scenario ($(scenario_files "$scenario") file(s)) sweeps connections ${axis_conn[*]}, concurrency ${axis_conc[*]}, request_concurrency ${axis_req[*]}"
+done
 total=$((cells_per_profile * ${#link_profiles[@]}))
 canary_total=$((3 * ${#link_profiles[@]}))
-echo "matrix: ${#scenarios[@]} scenario(s) x ${#connections_axis[@]} connection value(s) x ${#concurrency_axis[@]} concurrency value(s) x ${#request_axis[@]} request-concurrency value(s) x ${#link_profiles[@]} link profile(s) x ${#labels[@]} build(s) x $REPEATS repeat(s) = $total measured run(s), plus up to $canary_total canary run(s)"
+auto_total=$((${#scenarios[@]} * REPEATS * ${#link_profiles[@]}))
+echo "matrix: ${#scenarios[@]} scenario(s) x ${#link_profiles[@]} link profile(s) x ${#labels[@]} build(s) x $REPEATS repeat(s) = $total measured run(s), plus up to $canary_total canary run(s) and $auto_total auto run(s)"
 
 # A prepopulated scenario deploys its tree twice per cell, and only the second
 # one is measured. Worth saying before the hours start rather than after.
@@ -161,31 +218,22 @@ if [[ " ${scenarios[*]} " != *" $CANARY_SCENARIO "* ]]; then
 fi
 generate_dataset "${dataset_scenarios[@]}"
 
-# measure_cell <label> <binary> <ref> <scenario> <connections> <concurrency> <request> <repeat>
+# measure_deploy <binary> <scenario> <remote> <stem> <advanced> <instrument-clean> <what>
 #
-# The remote path is per (build, scenario) rather than per cell: every run is
-# preceded by an unmeasured clean anyway, so a path per cell would only leave
-# more empty directories behind on the server.
+# One deployment of a scenario, run exactly the way its shape says: a pre-clean,
+# the unmeasured base deploy plus mutation a redeploy scenario needs, then the
+# measured run. Shared by the cells and the auto runs, which differ only in the
+# advanced block they pass and in what they do with the result.
 #
-# What is measured is the scenario's mode, not always overlay, and a
-# prepopulated scenario gets an unmeasured full deploy plus a small local change
-# in between (issue #184, phase 3). Both come from scenario_shape.
-measure_cell() {
-  local label=$1 binary=$2 ref=$3 scenario=$4 conns=$5 conc=$6 request=$7 repeat=$8
-  local remote="$REMOTE_BASE/matrix/$label/$scenario"
-  local slug
-  slug=$(link_profile_slug "$link_profile")
-  local stem="$LOG_DIR/$slug-$label-$scenario-c$conns-w$conc-r${request:-default}-$repeat"
-  local code=0
+# Sets MEASURE_CODE and MEASURE_CLEAN_CODE for the caller. The pre-clean is only
+# instrumented where its numbers are wanted, which is the cells: an auto run's
+# coordinates are not a coordinate of the grid, so a delete row of it would sit
+# in deletes[] under settings nobody asked for.
+measure_deploy() {
+  local binary=$1 scenario=$2 remote=$3 stem=$4 advanced=$5 instrument_clean=$6 what=$7
   local mode prepopulate
   read -r mode prepopulate _ <<<"$(scenario_shape "$scenario")"
 
-  local advanced="connections: $conns
-concurrency: $conc"
-  if [[ -n "$request" ]]; then
-    advanced="$advanced
-request_concurrency: $request"
-  fi
   # Kept off the pre-clean: skip_unchanged applies to overlay only, and a clean
   # deployment carrying it just logs a warning about being ignored.
   local deploy_advanced=$advanced
@@ -194,48 +242,88 @@ request_concurrency: $request"
 skip_unchanged: true"
   fi
 
-  # The pre-clean wipes what the previous cell of this (build, scenario) left
-  # behind, which makes it a pure delete sweep at this cell's own settings. It is
-  # instrumented into its own file and aggregated into "deletes" (issue #184,
+  # The pre-clean wipes what the previous run of this (build, scenario) left
+  # behind, which makes it a pure delete sweep at this run's own settings. Where
+  # it is instrumented it goes into its own file and into "deletes" (issue #184,
   # phase 4), never into the cell: no extra run, no extra minute, and the only
   # measurement of deletions there is.
-  local clean_code=0
-  METRICS_FILE="$stem.clean.metrics.json" \
+  MEASURE_CLEAN_CODE=0
+  local clean_metrics=''
+  if ((instrument_clean)); then
+    clean_metrics="$stem.clean.metrics.json"
+  fi
+  METRICS_FILE="$clean_metrics" \
     run_easysftp "$binary" "$DATASET_DIR/empty" "$remote" clean \
-    "$stem.clean.log" "$stem.clean.out" "$advanced" || clean_code=$?
-  if ((clean_code != 0)); then
-    echo "::warning::pre-clean of $label/$scenario c$conns/w$conc repeat $repeat exited $clean_code"
+    "$stem.clean.log" "$stem.clean.out" "$advanced" || MEASURE_CLEAN_CODE=$?
+  if ((MEASURE_CLEAN_CODE != 0)); then
+    echo "::warning::pre-clean of $what exited $MEASURE_CLEAN_CODE"
     cat "$stem.clean.log"
   fi
+
+  # The deploy the measured run redeploys over. Unmeasured, with the same
+  # settings: what is under test is the second run, and a base laid down at
+  # other settings would put a different remote tree under each cell.
+  if ((prepopulate)); then
+    if ! METRICS_FILE='' run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" "$mode" \
+      "$stem.base.log" "$stem.base.out" "$deploy_advanced"; then
+      echo "::warning::base deploy of $what failed"
+      cat "$stem.base.log"
+    fi
+    scenario_mutate "$DATASET_DIR/$scenario" "$SCENARIO_CHANGED_FILES"
+  fi
+
+  MEASURE_CODE=0
+  METRICS_FILE="$stem.metrics.json" \
+    run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" "$mode" "$stem.log" "$stem.out" "$deploy_advanced" || MEASURE_CODE=$?
+  if ((MEASURE_CODE != 0)); then
+    # Into the job log, which masks secrets. Never into the artifact.
+    echo "::warning::$what exited $MEASURE_CODE"
+    cat "$stem.log"
+  fi
+}
+
+# measure_cell <label> <binary> <ref> <scenario> <connections> <concurrency> <request> <repeat>
+#
+# The remote path is per (build, scenario) rather than per cell: every run is
+# preceded by an unmeasured clean anyway, so a path per cell would only leave
+# more empty directories behind on the server.
+#
+# What is measured is the scenario's mode, not always overlay, and a
+# prepopulated scenario gets an unmeasured full deploy plus a small local change
+# in between (issue #184, phase 3). Both come from scenario_shape, via
+# measure_deploy.
+measure_cell() {
+  local label=$1 binary=$2 ref=$3 scenario=$4 conns=$5 conc=$6 request=$7 repeat=$8
+  local remote="$REMOTE_BASE/matrix/$label/$scenario"
+  local slug
+  slug=$(link_profile_slug "$link_profile")
+  local stem="$LOG_DIR/$slug-$label-$scenario-c$conns-w$conc-r$request-$repeat"
+  local what="$label/$scenario c$conns/w$conc/r$request repeat $repeat"
+  local code=0
+
+  local advanced="connections: $conns
+concurrency: $conc"
+  # The token "default" is the pass that sets nothing and leaves easySFTP its
+  # own value; it is stored as a null coordinate.
+  local request_json=null
+  if [[ "$request" != default ]]; then
+    advanced="$advanced
+request_concurrency: $request"
+    request_json=$request
+  fi
+
+  measure_deploy "$binary" "$scenario" "$remote" "$stem" "$advanced" 1 "$what"
+  code=$MEASURE_CODE
+
   jq -c \
     --arg label "$label" \
     --arg scenario "$scenario" \
     --arg link_profile "$link_profile" \
     --argjson connections "$conns" \
     --argjson concurrency "$conc" \
-    --argjson request_concurrency "${request:-null}" \
+    --argjson request_concurrency "$request_json" \
     --argjson repeat "$repeat" \
-    '. + $ARGS.named' <<<"$(delete_json "$stem" "$clean_code")" >>"$deletes_file"
-
-  # The deploy the measured run redeploys over. Unmeasured, with the cell's own
-  # settings: what is under test is the second run, and a base laid down at
-  # other settings would put a different remote tree under each cell.
-  if ((prepopulate)); then
-    if ! METRICS_FILE='' run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" "$mode" \
-      "$stem.base.log" "$stem.base.out" "$deploy_advanced"; then
-      echo "::warning::base deploy of $label/$scenario c$conns/w$conc repeat $repeat failed"
-      cat "$stem.base.log"
-    fi
-    scenario_mutate "$DATASET_DIR/$scenario" "$SCENARIO_CHANGED_FILES"
-  fi
-
-  METRICS_FILE="$stem.metrics.json" \
-    run_easysftp "$binary" "$DATASET_DIR/$scenario" "$remote" "$mode" "$stem.log" "$stem.out" "$deploy_advanced" || code=$?
-  if ((code != 0)); then
-    # Into the job log, which masks secrets. Never into the artifact.
-    echo "::warning::$label/$scenario c$conns/w$conc repeat $repeat exited $code"
-    cat "$stem.log"
-  fi
+    '. + $ARGS.named' <<<"$(delete_json "$stem" "$MEASURE_CLEAN_CODE")" >>"$deletes_file"
 
   jq -nc \
     --arg label "$label" \
@@ -244,7 +332,7 @@ skip_unchanged: true"
     --arg link_profile "$link_profile" \
     --argjson connections "$conns" \
     --argjson concurrency "$conc" \
-    --argjson request_concurrency "${request:-null}" \
+    --argjson request_concurrency "$request_json" \
     --argjson repeat "$repeat" \
     --argjson exit_code "$code" \
     --argjson duration_ms "$(step_number "$stem.out" duration-ms)" \
@@ -255,7 +343,48 @@ skip_unchanged: true"
     --argjson metrics "$(metrics_json "$stem.metrics.json")" \
     '$ARGS.named' >>"$runs_file"
 
-  echo "$link_profile $label/$scenario connections=$conns concurrency=$conc request=${request:-default} repeat $repeat: $(step_number "$stem.out" duration-ms) ms, exit $code"
+  echo "$link_profile $label/$scenario connections=$conns concurrency=$conc request=$request repeat $repeat: $(step_number "$stem.out" duration-ms) ms, exit $code"
+}
+
+# measure_auto <scenario> <repeat>: the candidate build with connections,
+# concurrency and request_concurrency all left at "auto" (issue #184, phase 5).
+#
+# This is the policy under test, not a coordinate: auto picks its own settings,
+# so what the run is measured for is the gap to the best cell of the same
+# scenario and profile. Which settings it picked is read back out of the run's
+# own counters (config_connections and friends, see internal/uploader) rather
+# than assumed here, because the point of the measurement is what easySFTP did,
+# not what this script believes it does.
+#
+# It runs inside the repeat loop, next to the cells it is compared against, and
+# on the candidate build only: a regret against a baseline build's grid would
+# compare two different products.
+measure_auto() {
+  local scenario=$1 repeat=$2 slug
+  slug=$(link_profile_slug "$link_profile")
+  local stem="$LOG_DIR/auto-$slug-$scenario-$repeat"
+  local remote="$REMOTE_BASE/matrix/auto/$scenario"
+  local what="auto/$scenario repeat $repeat"
+  local advanced="connections: auto
+concurrency: auto
+request_concurrency: auto"
+
+  measure_deploy "$CANDIDATE_BIN" "$scenario" "$remote" "$stem" "$advanced" 0 "$what"
+
+  jq -nc \
+    --arg label auto \
+    --arg ref "$CANDIDATE_REF" \
+    --arg scenario "$scenario" \
+    --arg link_profile "$link_profile" \
+    --argjson repeat "$repeat" \
+    --argjson exit_code "$MEASURE_CODE" \
+    --argjson duration_ms "$(step_number "$stem.out" duration-ms)" \
+    --argjson files "$(step_number "$stem.out" files-uploaded)" \
+    --argjson bytes "$(step_number "$stem.out" bytes-uploaded)" \
+    --argjson metrics "$(metrics_json "$stem.metrics.json")" \
+    '$ARGS.named' >>"$auto_file"
+
+  echo "$link_profile auto/$scenario repeat $repeat: $(step_number "$stem.out" duration-ms) ms, exit $MEASURE_CODE"
 }
 
 # measure_canary <at>: the fixed cell, always the candidate build, run three
@@ -319,10 +448,16 @@ for link_profile in "${link_profiles[@]}"; do
   # has no middle, and then there are two canaries instead of three.
   runs_done=0
   for scenario in "${scenarios[@]}"; do
+    read -r -a axis_conn <<<"${scenario_conn_axis[$scenario]}"
+    read -r -a axis_conc <<<"${scenario_conc_axis[$scenario]}"
+    read -r -a axis_req <<<"${scenario_req_axis[$scenario]}"
     for ((repeat = 1; repeat <= REPEATS; repeat++)); do
-      for conns in "${connections_axis[@]}"; do
-        for conc in "${concurrency_axis[@]}"; do
-          for request in "${request_axis[@]}"; do
+      # Before this repeat's cells, so the policy run and the grid it is scored
+      # against sit inside the same stretch of the sweep.
+      measure_auto "$scenario" "$repeat"
+      for conns in "${axis_conn[@]}"; do
+        for conc in "${axis_conc[@]}"; do
+          for request in "${axis_req[@]}"; do
             # Innermost, so candidate and baseline of one cell are measured
             # within seconds of each other.
             for i in "${!labels[@]}"; do
@@ -355,6 +490,10 @@ for scenario in "${scenarios[@]}"; do
       "$REMOTE_BASE/matrix/${labels[$i]}/$scenario" clean "$stem.log" "$stem.out" "" ||
       echo "::warning::cleanup of ${labels[$i]}/$scenario failed"
   done
+  stem="$LOG_DIR/cleanup-auto-$scenario"
+  METRICS_FILE='' run_easysftp "$CANDIDATE_BIN" "$DATASET_DIR/empty" \
+    "$REMOTE_BASE/matrix/auto/$scenario" clean "$stem.log" "$stem.out" "" ||
+    echo "::warning::cleanup of auto/$scenario failed"
 done
 METRICS_FILE='' run_easysftp "$CANDIDATE_BIN" "$DATASET_DIR/empty" \
   "$REMOTE_BASE/matrix/canary" clean "$LOG_DIR/cleanup-canary.log" "$LOG_DIR/cleanup-canary.out" "" ||
@@ -401,6 +540,10 @@ jq -s "
         net_write_bytes: (\$m | map(.process.net_write_bytes) | median),
         connections_opened: (\$m | map(.counters.connections_opened // 0) | median),
         connections_used: (\$m | map(.counters.connections_used // 0) | median),
+        # What the run actually ran with, not what the axis asked for: the
+        # request axis has a pass that sets nothing, and a null coordinate on
+        # its own does not say which value that was (issue #184, phase 5).
+        request_concurrency_used: (\$m | map(.counters.config_request_concurrency) | median),
         connections_refused: (\$m | map(.counters.connections_refused // 0) | add),
         reconnects: (\$m | map(.counters.reconnects // 0) | add),
         upload_phase_ms: (\$m | map(.phases // []) | add // []
@@ -449,7 +592,59 @@ jq -s "
   | sort_by([.link_profile, .scenario, .label, .connections, .concurrency, .request_concurrency])
 " "$deletes_file" >"$deletes_agg_file"
 
-settings="matrix sweep; every other advanced.* setting stays at easySFTP's defaults (retries 2, timeout 30s). The mode belongs to the scenario, see scenarios below: a redeploy scenario is deployed once unmeasured and then measured over itself with $SCENARIO_CHANGED_FILES file(s) changed"
+# The auto runs, one row per (profile, scenario). "chosen" is read out of the
+# run's own counters, so it says what easySFTP did rather than what this script
+# expects it to do; the regret against the grid is added further down, where the
+# cells are in scope.
+auto_agg_file="$LOG_DIR/auto.json"
+jq -s "
+  $JQ_STATS
+  group_by([.link_profile, .scenario])
+  | map(
+      (map(select(.metrics != null)) | map(.metrics)) as \$m
+      | {
+        scenario: .[0].scenario,
+        label: \"auto\",
+        ref: .[0].ref,
+        link_profile: .[0].link_profile,
+        repeats: length,
+        failed_runs: (map(select(.exit_code != 0)) | length),
+        files: (map(.files) | max),
+        bytes: (map(.bytes) | max),
+        durations_ms: map(.duration_ms),
+        median_ms: (map(.duration_ms) | median),
+        min_ms: (map(.duration_ms) | min),
+        max_ms: (map(.duration_ms) | max),
+        mad_ms: (map(.duration_ms) | mad),
+        chosen: {
+          connections: (\$m | map(.counters.config_connections) | median),
+          concurrency: (\$m | map(.counters.config_concurrency) | median),
+          request_concurrency: (\$m | map(.counters.config_request_concurrency) | median)
+        }
+      })
+  | map(. + {
+      mib_per_s: (if .median_ms > 0 then ((.bytes / 1048576) / (.median_ms / 1000) | round2) else 0 end),
+      files_per_s: (if .median_ms > 0 then (.files / (.median_ms / 1000) | round2) else 0 end)
+    })
+  | sort_by([.link_profile, .scenario])
+" "$auto_file" >"$auto_agg_file"
+
+# The axes each scenario was actually swept over, as JSON. The declared axes are
+# what was asked for; these are what the payload allows, and a reader plotting a
+# heatmap needs the second kind (issue #184, phase 5).
+per_scenario_axes=$(for scenario in "${scenarios[@]}"; do
+  read -r -a axis_conn <<<"${scenario_conn_axis[$scenario]}"
+  read -r -a axis_conc <<<"${scenario_conc_axis[$scenario]}"
+  read -r -a axis_req <<<"${scenario_req_axis[$scenario]}"
+  jq -nc --arg k "$scenario" \
+    --argjson files "$(scenario_files "$scenario")" \
+    --argjson conn "$(printf '%s\n' "${axis_conn[@]}" | jq -s '.')" \
+    --argjson conc "$(printf '%s\n' "${axis_conc[@]}" | jq -s '.')" \
+    --argjson req "$(printf '%s\n' "${axis_req[@]}" | jq -Rs 'split("\n") | map(select(. != "") | if . == "default" then null else tonumber end)')" \
+    '{key: $k, value: {files: $files, connections: $conn, concurrency: $conc, request_concurrency: $req}}'
+done | jq -s 'from_entries')
+
+settings="matrix sweep; every other advanced.* setting stays at easySFTP's defaults (retries 2, timeout 30s). The mode belongs to the scenario, see scenarios below: a redeploy scenario is deployed once unmeasured and then measured over itself with $SCENARIO_CHANGED_FILES file(s) changed. Each scenario is swept over the axis values its payload can use, see axes.per_scenario"
 if [[ -n "$MATRIX_LINK_PROFILES" ]]; then
   settings="$settings; swept over the link profiles ${link_profiles[*]}"
 fi
@@ -471,8 +666,17 @@ done | jq -s 'from_entries')
 # finest grain there is. That is why it carries its own phases[] and
 # operations[] and not just upload_phase_ms: those are hours of measurement that
 # used to be aggregated and then dropped (issue #184, phase 2).
+#
+# "auto" is the policy measurement of phase 5: what easySFTP picked when asked
+# to pick, what the grid says was best, and the gap. "scaling[].best_at_axis_max"
+# is the other half of that: an optimum sitting on the largest value of an axis
+# was not measured, it was cut off, and a policy fitted to such a grid
+# extrapolates. Both are reported per scenario and profile, never averaged: the
+# whole point is that they differ per link.
 jq -n \
   --slurpfile cells "$cells_file" \
+  --slurpfile auto "$auto_agg_file" \
+  --argjson per_scenario_axes "$per_scenario_axes" \
   --arg candidate_ref "$CANDIDATE_REF" \
   --arg baseline_ref "$BASELINE_REF" \
   --arg reference_label "$reference_label" \
@@ -487,7 +691,7 @@ jq -n \
   --argjson link_axis "$(printf '%s\n' "${link_profiles[@]}" | jq -Rs 'split("\n") | map(select(. != ""))')" \
   --argjson connections_axis "$(printf '%s\n' "${connections_axis[@]}" | jq -s '.')" \
   --argjson concurrency_axis "$(printf '%s\n' "${concurrency_axis[@]}" | jq -s '.')" \
-  --argjson request_axis "$(printf '%s\n' "${request_axis[@]}" | jq -Rs 'split("\n") | map(select(. != "") | tonumber)')" \
+  --argjson request_axis "$(printf '%s\n' "${request_axis[@]}" | jq -Rs 'split("\n") | map(select(. != "") | if . == "default" then null else tonumber end)')" \
   "
   $JQ_STATS
   (\$cells[0]) as \$c
@@ -504,25 +708,57 @@ jq -n \
      canary: \$canary,
      settings: \$settings,
      scenarios: \$scenarios,
-     note: \"one cell per (link_profile, scenario, build, connections, concurrency, request_concurrency); median_ms is wall clock over the cell's repeats\",
+     note: \"one cell per (link_profile, scenario, build, connections, concurrency, request_concurrency); median_ms is wall clock over the cell's repeats. Each scenario is swept over the axis values its payload can use (axes.per_scenario), so a cell absent from the declared axes was not skipped, it was the same configuration twice. auto[] is off the grid: it is the settings easySFTP picked for itself, scored against the best cell\",
      axes: {
        link_profiles: \$link_axis,
        connections: \$connections_axis,
        concurrency: \$concurrency_axis,
-       request_concurrency: \$request_axis
+       request_concurrency: \$request_axis,
+       per_scenario: \$per_scenario_axes
      },
      cells: \$c,
      deletes: \$deletes[0],
      scaling: (\$c | group_by([.link_profile, .scenario, .label])
-       | map({
+       | map(. as \$g
+         | (\$g | sort_by(.median_ms) | .[0]) as \$best
+         | {
            scenario: .[0].scenario,
            label: .[0].label,
            link_profile: .[0].link_profile,
            points: (sort_by([.connections, .concurrency])
-             | map({connections, concurrency, request_concurrency, median_ms, mib_per_s, files_per_s,
+             | map({connections, concurrency, request_concurrency, request_concurrency_used,
+                    median_ms, mib_per_s, files_per_s,
                     connections_used, connections_refused, max_rss_bytes, user_cpu_ms})),
-           best: (sort_by(.median_ms) | .[0]
-             | {connections, concurrency, request_concurrency, median_ms, mib_per_s, files_per_s})
+           best: (\$best | {connections, concurrency, request_concurrency, median_ms, mib_per_s, files_per_s}),
+           best_at_axis_max: ([
+             (if ((\$g | map(.connections) | unique | length) > 1)
+                 and \$best.connections == (\$g | map(.connections) | max)
+               then \"connections\" else empty end),
+             (if ((\$g | map(.concurrency) | unique | length) > 1)
+                 and \$best.concurrency == (\$g | map(.concurrency) | max)
+               then \"concurrency\" else empty end),
+             (if ((\$g | map(.request_concurrency) | unique | length) > 1)
+                 and \$best.request_concurrency != null
+                 and \$best.request_concurrency == (\$g | map(.request_concurrency) | max)
+               then \"request_concurrency\" else empty end)
+           ])
+         })),
+     auto: (\$auto[0] | map(. as \$a
+       | ([\$c[] | select(.label == \"candidate\" and .scenario == \$a.scenario
+            and .link_profile == \$a.link_profile)] | sort_by(.median_ms) | first) as \$best
+       | ([\$c[] | select(.label == \"candidate\" and .scenario == \$a.scenario
+            and .link_profile == \$a.link_profile
+            and .connections == \$a.chosen.connections
+            and .concurrency == \$a.chosen.concurrency
+            and .request_concurrency_used == \$a.chosen.request_concurrency)] | first) as \$at
+       | \$a + {
+           best: (if \$best == null then null
+             else (\$best | {connections, concurrency, request_concurrency, median_ms, mib_per_s, files_per_s})
+             end),
+           chosen_in_grid: (\$at != null),
+           chosen_cell_median_ms: (if \$at == null then null else \$at.median_ms end),
+           regret_ms: (if \$best == null then null else \$a.median_ms - \$best.median_ms end),
+           regret_percent: (if \$best == null then null else pct(\$a.median_ms; \$best.median_ms) end)
          })),
      comparison: [
        \$c[] | select(.label != \$reference_label) as \$x
@@ -550,7 +786,7 @@ jq -n \
 jq -r '
   (.link.probes // []) as $probes
   | ["scenario","build","ref","link_profile","rtt_p50_ms","control_single_mib_per_s",
-     "connections","concurrency","request_concurrency","repeats",
+     "connections","concurrency","request_concurrency","request_concurrency_used","repeats",
      "files","bytes","median_ms","min_ms","max_ms","mad_ms","mib_per_s","files_per_s",
      "upload_phase_ms","net_write_bytes","user_cpu_ms","sys_cpu_ms","cpu_percent","max_rss_bytes","go_gc_count",
      "go_peak_goroutines","connections_opened","connections_used","connections_refused",
@@ -561,7 +797,7 @@ jq -r '
    | [
     .scenario, .label, .ref, .link_profile,
     ($p.rtt_ms.p50 // null), ($p.control.single_stream_mib_per_s // null),
-    .connections, .concurrency, .request_concurrency, .repeats,
+    .connections, .concurrency, .request_concurrency, .request_concurrency_used, .repeats,
     .files, .bytes, .median_ms, .min_ms, .max_ms, .mad_ms, .mib_per_s, .files_per_s,
     .upload_phase_ms, .net_write_bytes, .user_cpu_ms, .sys_cpu_ms, .cpu_percent, .max_rss_bytes, .go_gc_count,
     .go_peak_goroutines, .connections_opened, .connections_used, .connections_refused,
@@ -588,42 +824,49 @@ jq -r '
   # What each scenario is, next to the numbers: "sync" and "redeploy" are a
   # deploy shape and not only a payload, and a MiB/s of theirs is over the few
   # changed files rather than over the tree.
-  echo "| Scenario | Mode | Payload |"
-  echo "|---|---|---|"
+  echo "| Scenario | Mode | Payload | connections | concurrency | request_concurrency |"
+  echo "|---|---|---|---|---|---|"
   for scenario in "${scenarios[@]}"; do
     read -r mode prepopulate _ <<<"$(scenario_shape "$scenario")"
     if ((prepopulate)); then
       mode="$mode, redeployed"
     fi
-    echo "| \`$scenario\` | $mode | $(scenario_description "$scenario") |"
+    echo "| \`$scenario\` | $mode | $(scenario_description "$scenario") | ${scenario_conn_axis[$scenario]} | ${scenario_conc_axis[$scenario]} | ${scenario_req_axis[$scenario]} |"
   done
+  echo
+  echo "The last three columns are the axis values this scenario was swept over, which are not always the ones requested above. A value larger than the payload's file count is the same configuration under another name (only the per-file upload path spreads over connections and workers), and \`request_concurrency\` is a per-file setting that a payload of small files cannot use at all, so both are capped against the payload rather than measured twice."
   echo
   link_markdown "$OUT_DIR/matrix.json"
   echo "Each grid below is median wall-clock milliseconds: rows are \`advanced.connections\`, columns are \`advanced.concurrency\`. Lower is better. \`connections > concurrency\` is measured, not skipped; easySFTP caps the pool at the concurrency (a connection no worker picks is a handshake for nothing), so those cells are expected to flatten out rather than improve."
   echo
 
   for scenario in "${scenarios[@]}"; do
+    read -r -a axis_conn <<<"${scenario_conn_axis[$scenario]}"
+    read -r -a axis_conc <<<"${scenario_conc_axis[$scenario]}"
+    read -r -a axis_req <<<"${scenario_req_axis[$scenario]}"
     for label in "${labels[@]}"; do
       for profile in "${link_profiles[@]}"; do
-        for request in "${request_axis[@]}"; do
+        for request in "${axis_req[@]}"; do
           title="\`$scenario\` / $label / $profile"
-          if [[ -n "$request" ]]; then
+          if [[ "$request" != default ]]; then
             title="$title / request_concurrency $request"
           fi
           echo "#### $title"
           echo
           printf '| connections \\ concurrency |'
-          for conc in "${concurrency_axis[@]}"; do printf ' %s |' "$conc"; done
+          for conc in "${axis_conc[@]}"; do printf ' %s |' "$conc"; done
           printf '\n|---|'
           # "%s": bash's printf reads a leading "-" in the format as an option.
-          for _ in "${concurrency_axis[@]}"; do printf '%s' '---|'; done
+          for _ in "${axis_conc[@]}"; do printf '%s' '---|'; done
           printf '\n'
-          for conns in "${connections_axis[@]}"; do
+          for conns in "${axis_conn[@]}"; do
             printf '| %s |' "$conns"
-            for conc in "${concurrency_axis[@]}"; do
+            for conc in "${axis_conc[@]}"; do
+              req_json=null
+              if [[ "$request" != default ]]; then req_json=$request; fi
               cell=$(jq -r --arg s "$scenario" --arg l "$label" --arg p "$profile" \
                 --argjson conns "$conns" --argjson conc "$conc" \
-                --argjson req "${request:-null}" '
+                --argjson req "$req_json" '
               [.cells[] | select(.scenario == $s and .label == $l and .link_profile == $p
                  and .connections == $conns
                  and .concurrency == $conc and .request_concurrency == $req)] | first
@@ -643,10 +886,23 @@ jq -r '
 
   echo "### Best cell per scenario, build and link profile"
   echo
-  echo "| Scenario | Build | Profile | connections | concurrency | request_concurrency | Median | MiB/s | files/s |"
-  echo "|---|---|---|---|---|---|---|---|---|"
-  jq -r '.scaling[] | "| \(.scenario) | \(.label) | \(.link_profile) | \(.best.connections) | \(.best.concurrency) | \(.best.request_concurrency // "default") | \(.best.median_ms) ms | \(.best.mib_per_s) | \(.best.files_per_s) |"' \
+  echo "| Scenario | Build | Profile | connections | concurrency | request_concurrency | Median | MiB/s | files/s | On an axis edge |"
+  echo "|---|---|---|---|---|---|---|---|---|---|"
+  jq -r '.scaling[] | "| \(.scenario) | \(.label) | \(.link_profile) | \(.best.connections) | \(.best.concurrency) | \(.best.request_concurrency // "default") | \(.best.median_ms) ms | \(.best.mib_per_s) | \(.best.files_per_s) | \(if (.best_at_axis_max | length) == 0 then "no" else (.best_at_axis_max | join(", ")) end) |"' \
     "$OUT_DIR/matrix.json"
+  echo
+  # The check the auto-config work of issue #184 phase 5 rests on: a best cell
+  # sitting on the largest value of an axis is a cut-off, not an optimum, and
+  # anything fitted to it extrapolates. Only the upper edge is reported; the
+  # lower one is 1 and there is nothing below it to sweep.
+  boundary=$(jq -r '[.scaling[] | select((.best_at_axis_max | length) > 0)
+    | "\(.scenario)/\(.label)/\(.link_profile): \(.best_at_axis_max | join(", "))"] | join("; ")' \
+    "$OUT_DIR/matrix.json")
+  if [[ -n "$boundary" ]]; then
+    echo "**The optimum sits on the edge of the grid** for $boundary. The best value measured is the largest one swept, so the real optimum is at or beyond it and this sweep does not contain it. Extend that axis before fitting anything to these numbers."
+  else
+    echo "Every best cell is interior to its axes, so each optimum was measured rather than cut off."
+  fi
 
   if [[ -n "$BASELINE_BIN" ]]; then
     echo
@@ -661,6 +917,24 @@ jq -r '
       | .[] | "| \(.scenario) | \(.link_profile) | \(.connections) | \(.concurrency) | \(.median_ms) ms | \(.reference_median_ms) ms | \(if .delta_percent == null then "-" else (if .delta_percent > 0 then "+" else "" end) + (.delta_percent | tostring) + "%" end) |"' \
       "$OUT_DIR/matrix.json"
   fi
+
+  echo
+  echo "### What \`auto\` costs (policy regret)"
+  echo
+  echo "One run per scenario and profile with \`connections\`, \`concurrency\` and \`request_concurrency\` all set to \`auto\`, on the candidate build, measured next to the cells it is scored against. \`Picked\` is read out of the run's own counters, so it is what easySFTP did and not what this script assumes; \`Best\` is the fastest cell of the same scenario and profile. \`Regret\` is the gap between them: how much slower the policy is than the settings a sweep would have chosen. A policy within ~15% on every profile is defensible, one that only wins on the house line is not (issue #184, phase 5; the policy itself is #156)."
+  echo
+  echo "| Scenario | Profile | Picked (conn/conc/req) | auto | Best cell | Best | Regret | Same cell in grid |"
+  echo "|---|---|---|---|---|---|---|---|"
+  jq -r '
+    def cell($x): if $x == null then "-" else "\($x.connections)/\($x.concurrency)/\($x.request_concurrency // "default")" end;
+    .auto[]
+    | "| \(.scenario) | \(.link_profile) | \(.chosen.connections)/\(.chosen.concurrency)/\(.chosen.request_concurrency) "
+      + "| \(.median_ms) ms | \(cell(.best)) | \(if .best == null then "-" else "\(.best.median_ms) ms" end) "
+      + "| \(if .regret_percent == null then "-" else (if .regret_percent > 0 then "+" else "" end) + (.regret_percent | tostring) + "%" end) "
+      + "| \(if .chosen_in_grid then "\(.chosen_cell_median_ms) ms" else "not swept" end) |"
+  ' "$OUT_DIR/matrix.json"
+  echo
+  echo "The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the \`auto\` column means the two runs saw different conditions, and then the regret next to it is drift rather than policy. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all."
 
   echo
   echo "### Canary"
@@ -706,7 +980,7 @@ jq -r '
     echo "**$refused connection(s) were refused by the server** across the sweep and fell back to the run's first connection. Those cells had fewer connections than configured, which is the server's limit showing up in the data, not easySFTP's."
   fi
   echo
-  echo "Raw data: \`matrix.json\` (every cell with its own phases and round-trip percentiles, plus the pre-grouped \`scaling\` view, the \`canary\` runs and the \`deletes\` sweeps), \`matrix.csv\` (one flat row per cell). Data only: nothing here fails a build."
+  echo "Raw data: \`matrix.json\` (every cell with its own phases and round-trip percentiles, plus the pre-grouped \`scaling\` view, the \`auto\` policy runs, the \`canary\` runs and the \`deletes\` sweeps), \`matrix.csv\` (one flat row per cell). Data only: nothing here fails a build."
 } >"$OUT_DIR/matrix.md"
 
 cat "$OUT_DIR/matrix.md"

--- a/scripts/test-benchmark.sh
+++ b/scripts/test-benchmark.sh
@@ -479,7 +479,7 @@ if grep -qF '**The optimum sits on the edge of the grid**' "$OUT_DIR/matrix.md";
 else
   fail "matrix.md hides that the optimum sits on an axis edge"
 fi
-if grep -qF '### What `auto` costs (policy regret)' "$OUT_DIR/matrix.md"; then
+if grep -qF 'costs (policy regret)' "$OUT_DIR/matrix.md"; then
   pass "matrix.md reports the policy regret"
 else
   fail "matrix.md is missing its policy regret section"
@@ -705,9 +705,9 @@ expect_equal 'and the declared axis says so too' 'null' \
   "$(jq -r '.axes.request_concurrency | map(tostring) | join(" ")' "$req_matrix")"
 expect_equal 'the run still records what easySFTP used' 16 \
   "$(jq -r '.cells[0].request_concurrency_used' "$req_matrix")"
-if bash -c "MATRIX_REQUEST_CONCURRENCY='fast' \
-  OUT_DIR='$work/req-out' LOG_DIR='$work/req-logs' DATASET_DIR='$DATASET_DIR' \
-  bash '$repo_root/scripts/benchmark-matrix.sh'" >/dev/null 2>&1; then
+# Everything the script reads is exported already, so the bad value is the only
+# thing that changes here; it is rejected during validation, before any run.
+if MATRIX_REQUEST_CONCURRENCY=fast bash "$repo_root/scripts/benchmark-matrix.sh" >/dev/null 2>&1; then
   fail "a nonsense request_concurrency axis value is accepted"
 else
   pass "a nonsense request_concurrency axis value is rejected"

--- a/scripts/test-benchmark.sh
+++ b/scripts/test-benchmark.sh
@@ -60,6 +60,7 @@ target=${EASYSFTP_TARGET:-}
 mode=${EASYSFTP_MODE:-}
 connections=1
 concurrency=4
+request_concurrency=16
 skip_unchanged=false
 if [[ -n "${EASYSFTP_CONFIG:-}" ]]; then
   source_dir=$(awk -F'"' '/source:/ { print $2; exit }' "$EASYSFTP_CONFIG")
@@ -67,8 +68,16 @@ if [[ -n "${EASYSFTP_CONFIG:-}" ]]; then
   mode=$(awk '/^    mode:/ { print $2; exit }' "$EASYSFTP_CONFIG")
   connections=$(awk '/^  connections:/ { print $2; exit }' "$EASYSFTP_CONFIG")
   concurrency=$(awk '/^  concurrency:/ { print $2; exit }' "$EASYSFTP_CONFIG")
+  request_concurrency=$(awk '/^  request_concurrency:/ { print $2; exit }' "$EASYSFTP_CONFIG")
+  # "auto" resolves to easySFTP's own defaults here, exactly as autoInt.or does
+  # in internal/config/configfile.go: an auto run has to come out somewhere on
+  # the grid, otherwise the regret arithmetic has nothing to compare.
   connections=${connections:-1}
   concurrency=${concurrency:-4}
+  request_concurrency=${request_concurrency:-16}
+  case $connections in auto) connections=1 ;; esac
+  case $concurrency in auto) concurrency=4 ;; esac
+  case $request_concurrency in auto) request_concurrency=16 ;; esac
   if grep -q '^  skip_unchanged: true' "$EASYSFTP_CONFIG"; then
     skip_unchanged=true
   fi
@@ -159,6 +168,7 @@ if [[ -n "${EASYSFTP_METRICS_FILE:-}" ]]; then
     "connections_opened": $connections, "connections_used": $connections,
     "connections_refused": 0, "reconnects": 0, "retries": 0, "stalls": 0, "errors": 0,
     "config_connections": $connections, "config_concurrency": $concurrency,
+    "config_request_concurrency": $request_concurrency,
     "files_uploaded": $files, "bytes_uploaded": $bytes, "files_deleted": $deleted
   }
 }
@@ -390,33 +400,90 @@ fi
 
 expect_equal 'matrix.json is schema_version 2' 2 "$(jq -r .schema_version "$matrix")"
 expect_equal 'matrix.json says what kind it is' matrix "$(jq -r .benchmark_kind "$matrix")"
-# 2 connections x 2 concurrency x 2 scenarios x 2 builds.
-expect_equal 'every cell of the grid was measured' 16 "$(jq '.cells | length' "$matrix")"
+# The grid is per scenario (issue #184, phase 5): "small" (300 files) is swept
+# over 2 connections x 2 concurrency at easySFTP's own request_concurrency, and
+# "single" (one 32 MiB file) collapses to a single connections/concurrency cell
+# but is the one scenario the request axis applies to. 2 builds each: 8 + 6.
+expect_equal 'every cell of the grid was measured' 14 "$(jq '.cells | length' "$matrix")"
+expect_equal 'a one-file scenario is not measured at four identical coordinates' 3 \
+  "$(jq '[.cells[] | select(.scenario == "single" and .label == "candidate")] | length' "$matrix")"
+expect_equal 'the request axis is swept where a file is large enough for it' '1 16 64' \
+  "$(jq -r '[.cells[] | select(.scenario == "single") | .request_concurrency] | unique | sort | join(" ")' "$matrix")"
+expect_equal 'and left at easySFTP its own value where it cannot matter' 'null' \
+  "$(jq -r '[.cells[] | select(.scenario == "small") | .request_concurrency] | unique | map(tostring) | join(" ")' "$matrix")"
+expect_equal 'a cell records the request_concurrency it actually ran with' 16 \
+  "$(jq -r '[.cells[] | select(.scenario == "small") | .request_concurrency_used] | first' "$matrix")"
+expect_equal 'the per-scenario axes are declared next to the requested ones' '1 2/1 4/null' \
+  "$(jq -r '.axes.per_scenario.small | "\(.connections | join(" "))/\(.concurrency | join(" "))/\(.request_concurrency | map(tostring) | join(" "))"' "$matrix")"
+expect_equal 'a scenario declares the file count its axes were capped against' 1 \
+  "$(jq -r '.axes.per_scenario.single.files' "$matrix")"
 expect_equal 'connections > concurrency is measured, not rejected' 1 \
   "$(jq '[.cells[] | select(.connections == 2 and .concurrency == 1 and .label == "candidate" and .scenario == "small")] | length' "$matrix")"
 expect_nonempty 'cells carry the used connection count' \
   "$(jq -r '[.cells[] | .connections_used] | first' "$matrix")"
-expect_equal 'cells carry throughput and file rate' 16 \
+expect_equal 'cells carry throughput and file rate' 14 \
   "$(jq '[.cells[] | select(.mib_per_s != null and .files_per_s != null)] | length' "$matrix")"
-expect_equal 'cells carry CPU and RSS' 16 \
+expect_equal 'cells carry CPU and RSS' 14 \
   "$(jq '[.cells[] | select(.max_rss_bytes != null and .user_cpu_ms != null)] | length' "$matrix")"
 expect_equal 'the scaling view is grouped per scenario and build' 4 \
   "$(jq '.scaling | length' "$matrix")"
 
 # A matrix run has no runs[], so a cell is the finest grain there is: the phase
 # and round-trip detail has to survive into it (issue #184, phase 2).
-expect_equal 'every cell keeps its phases' 16 \
+expect_equal 'every cell keeps its phases' 14 \
   "$(jq '[.cells[] | select((.phases | length) > 0)] | length' "$matrix")"
 expect_equal 'a cell keeps the phases that are not the upload' 'connect create_dirs local_scan upload' \
   "$(jq -r '[.cells[0].phases[].name] | sort | join(" ")' "$matrix")"
-expect_equal 'every cell keeps its round-trip percentiles' 16 \
+expect_equal 'every cell keeps its round-trip percentiles' 14 \
   "$(jq '[.cells[] | select(([.operations[] | select(.name == "sftp_open") | .p90_ms] | first) != null)] | length' "$matrix")"
 expect_nonempty 'upload_phase_ms is still there for anything reading it' \
   "$(jq -r '.cells[0].upload_phase_ms' "$matrix")"
 
 # A single repeat has no measured spread; 0 there would read as precision.
-expect_equal 'a one-repeat cell reports no MAD' 16 \
+expect_equal 'a one-repeat cell reports no MAD' 14 \
   "$(jq '[.cells[] | select(.mad_ms == null)] | length' "$matrix")"
+
+# The policy measurement of issue #184 phase 5. The stub resolves "auto" to
+# easySFTP's own defaults (1/4/16), and gets faster with more parallelism, so
+# the best cell of "small" is 2/4 and auto must come out behind it.
+expect_equal 'auto is measured once per scenario and profile' 2 \
+  "$(jq '.auto | length' "$matrix")"
+expect_equal 'auto is not a cell' 0 \
+  "$(jq '[.cells[] | select(.label == "auto")] | length' "$matrix")"
+expect_equal 'auto stays out of the scaling view and the comparison' 0 \
+  "$(jq '[(.scaling[], .comparison[]) | select(.label == "auto")] | length' "$matrix")"
+expect_equal 'auto reports the settings it picked, read from its own counters' '1/4/16' \
+  "$(jq -r '[.auto[] | select(.scenario == "small") | "\(.chosen.connections)/\(.chosen.concurrency)/\(.chosen.request_concurrency)"] | first' "$matrix")"
+expect_equal 'auto is scored against the best cell of its scenario' '2/4' \
+  "$(jq -r '[.auto[] | select(.scenario == "small") | "\(.best.connections)/\(.best.concurrency)"] | first' "$matrix")"
+regret=$(jq -r '[.auto[] | select(.scenario == "small") | .regret_percent] | first' "$matrix")
+if [[ -n $regret ]] && awk -v r="$regret" 'BEGIN { exit !(r > 0) }'; then
+  pass "a policy that picks a slower cell reports a positive regret ($regret%)"
+else
+  fail "auto picked the slower cell, so the regret should be positive, got $regret%"
+fi
+# The control column: the same coordinates measured as an ordinary cell. For
+# "single" the picked concurrency is not on the grid at all, and that has to be
+# said rather than silently paired with something else.
+expect_equal 'the picked cell is cross-checked against the grid' true \
+  "$(jq -r '[.auto[] | select(.scenario == "small") | .chosen_in_grid] | first' "$matrix")"
+expect_equal 'a pick outside the grid is reported as such' 'false null' \
+  "$(jq -r '[.auto[] | select(.scenario == "single") | "\(.chosen_in_grid) \(.chosen_cell_median_ms)"] | first' "$matrix")"
+
+# An optimum on the largest swept value of an axis was cut off, not measured.
+# "small" is fastest at 2/4 here, the largest value of both of its axes.
+expect_equal 'a best cell on the edge of an axis is flagged' 'connections concurrency' \
+  "$(jq -r '[.scaling[] | select(.scenario == "small" and .label == "candidate") | .best_at_axis_max[]] | join(" ")' "$matrix")"
+if grep -qF '**The optimum sits on the edge of the grid**' "$OUT_DIR/matrix.md"; then
+  pass "matrix.md says when the optimum was cut off"
+else
+  fail "matrix.md hides that the optimum sits on an axis edge"
+fi
+if grep -qF '### What `auto` costs (policy regret)' "$OUT_DIR/matrix.md"; then
+  pass "matrix.md reports the policy regret"
+else
+  fail "matrix.md is missing its policy regret section"
+fi
 
 # Start, middle and end of the grid: 2 connections x 2 concurrency x 2 scenarios
 # x 2 builds is 16 cells, so the middle canary has a middle to sit in.
@@ -428,11 +495,16 @@ expect_equal 'the canary is one fixed cell' 'small/1/4' \
   "$(jq -r '[.canary[] | "\(.scenario)/\(.connections)/\(.concurrency)"] | unique | join(" ")' "$matrix")"
 # One delete row per cell, minus the first cell of each (build, scenario): its
 # pre-clean has an empty directory in front of it (issue #184, phase 4).
-expect_equal 'every cell but the first of its build and scenario has a delete row' 12 \
+expect_equal 'every cell but the first of its build and scenario has a delete row' 10 \
   "$(jq '.deletes | length' "$matrix")"
+# The auto runs deploy into their own remote directory and their pre-clean is
+# left uninstrumented: their coordinates are not a coordinate of the grid, so a
+# delete row of them would sit under settings nobody swept.
+expect_equal 'the auto runs contribute no delete rows' 0 \
+  "$(jq '[.deletes[] | select(.label == "auto")] | length' "$matrix")"
 expect_equal 'a delete row carries the cell coordinates it was measured at' true \
   "$(jq '.deletes[0] | has("connections") and has("concurrency") and has("request_concurrency")' "$matrix")"
-expect_equal 'a matrix delete row keeps its sweep phase' 12 \
+expect_equal 'a matrix delete row keeps its sweep phase' 10 \
   "$(jq '[.deletes[] | select([.phases[] | select(.name == "delete_sweep")] | length == 1)] | length' "$matrix")"
 expect_nonempty 'a matrix delete row keeps the sftp_remove percentiles' \
   "$(jq -r '[.deletes[0].operations[] | select(.name == "sftp_remove") | .p50_ms] | first' "$matrix")"
@@ -454,7 +526,7 @@ fi
 expect_equal 'the axes are declared' '1 2' "$(jq -r '.axes.connections | join(" ")' "$matrix")"
 expect_equal 'the concurrency axis is declared' '1 4' "$(jq -r '.axes.concurrency | join(" ")' "$matrix")"
 
-expect_equal 'the matrix CSV has a header plus one row per cell' 17 \
+expect_equal 'the matrix CSV has a header plus one row per cell' 15 \
   "$(line_count "$OUT_DIR/matrix.csv")"
 if grep -qF '## easySFTP connections/concurrency matrix' "$OUT_DIR/matrix.md"; then
   pass "matrix.md has its heading"
@@ -530,6 +602,20 @@ if scenario_spec calib-nonsense >/dev/null 2>&1; then
 else
   pass "a malformed calibration scenario is rejected"
 fi
+# The per-scenario grid of issue #184 phase 5. Both rules are properties of the
+# payload: an axis value above the file count is the same configuration twice,
+# and request_concurrency is per file, so small files cannot use it at all.
+expect_equal 'the file count is summed over the payload groups' 56 "$(scenario_files mixed)"
+expect_equal 'the largest file of a payload decides the request axis' 2048 "$(scenario_max_kib mixed)"
+expect_equal 'the request axis applies where a file is large enough' 1 "$(scenario_sweeps_requests single)"
+expect_equal 'and not to a payload of 4 KiB files' 0 "$(scenario_sweeps_requests small)"
+expect_equal 'an axis is capped at the file count and deduplicated' '1' \
+  "$(axis_for_scenario single 1 2 4 8 | tr '\n' ' ' | sed 's/ $//')"
+expect_equal 'a payload that can use the whole axis keeps it' '1 2 4 8' \
+  "$(axis_for_scenario small 1 2 4 8 | tr '\n' ' ' | sed 's/ $//')"
+expect_equal 'a partial cap keeps the values below it' '1 2' \
+  "$(axis_for_scenario large 1 2 4 8 | tr '\n' ' ' | sed 's/ $//')"
+
 expect_equal 'a redeploy scenario declares its shape' 'overlay 1 flat' "$(scenario_shape redeploy)"
 expect_equal 'the sync scenario is measured in mode sync' 'sync 1 flat' "$(scenario_shape sync)"
 expect_equal 'the scenarios that predate this keep the old shape' 'overlay 0 flat' "$(scenario_shape small)"
@@ -578,7 +664,9 @@ expect_equal 'the redeploy scenario was measured with skip_unchanged' 1 \
 # The unmeasured deploy the measured run redeploys over. Its metrics must not
 # exist: a base deploy counted as a measurement would report the fresh upload
 # this scenario exists to *not* measure.
-expect_equal 'a redeploy cell laid down an unmeasured base deploy first' 2 \
+# Two cells plus the two auto runs of the same scenarios: the policy run is a
+# deployment of that scenario like any other, so it gets the base deploy too.
+expect_equal 'a redeploy cell laid down an unmeasured base deploy first' 4 \
   "$(find "$LOG_DIR" -name '*.base.log' | wc -l | tr -d ' ')"
 expect_equal 'a scenario without a base deploy runs one deploy only' 0 \
   "$(find "$LOG_DIR" -name '*calib-10x64k*.base.log' | wc -l | tr -d ' ')"
@@ -591,6 +679,38 @@ if grep -qE '^\| .sync. \| sync, redeployed \|' "$OUT_DIR/matrix.md"; then
   pass "matrix.md says which mode a scenario was measured in"
 else
   fail "matrix.md does not say which mode a scenario was measured in"
+fi
+
+echo
+echo "== the request_concurrency axis turned off (issue #184, phase 5) =="
+# The axis has a real default now, so the two-dimensional grid needs a way to be
+# asked for. The token "default" is it: one pass that sets nothing.
+export OUT_DIR="$work/req-out" LOG_DIR="$work/req-logs" REPEATS=1
+export MATRIX_CONNECTIONS="1" MATRIX_CONCURRENCY="1" MATRIX_SCENARIOS="single"
+export MATRIX_REQUEST_CONCURRENCY="default"
+bash "$repo_root/scripts/benchmark-matrix.sh" >"$work/matrix-req.stdout" 2>&1 ||
+  fail "benchmark-matrix.sh with the request axis off exited non-zero (see $work/matrix-req.stdout)"
+
+req_matrix="$OUT_DIR/matrix.json"
+if [[ ! -f $req_matrix ]]; then
+  echo "FAIL: the request-axis run produced no matrix.json" >&2
+  cat "$work/matrix-req.stdout" >&2
+  exit 1
+fi
+expect_equal 'the default token keeps the grid two-dimensional' 1 \
+  "$(jq '.cells | length' "$req_matrix")"
+expect_equal 'a pass that sets nothing is stored as a null coordinate' 'null' \
+  "$(jq -r '.cells[0].request_concurrency | tostring' "$req_matrix")"
+expect_equal 'and the declared axis says so too' 'null' \
+  "$(jq -r '.axes.request_concurrency | map(tostring) | join(" ")' "$req_matrix")"
+expect_equal 'the run still records what easySFTP used' 16 \
+  "$(jq -r '.cells[0].request_concurrency_used' "$req_matrix")"
+if bash -c "MATRIX_REQUEST_CONCURRENCY='fast' \
+  OUT_DIR='$work/req-out' LOG_DIR='$work/req-logs' DATASET_DIR='$DATASET_DIR' \
+  bash '$repo_root/scripts/benchmark-matrix.sh'" >/dev/null 2>&1; then
+  fail "a nonsense request_concurrency axis value is accepted"
+else
+  pass "a nonsense request_concurrency axis value is rejected"
 fi
 
 if ((failures > 0)); then


### PR DESCRIPTION
## What & why

Closes #184. This is phase 5, the measurement half: three gaps the stored
sweeps could not answer, plus one reduction that pays for the other two.
The auto-config work itself is #156 and is deliberately not here, as the
issue's own ordering section asks ("its auto-config half should be its own
PR with its own issue reference, since it changes product behaviour rather
than measurement").

**The grid is now per scenario.** An axis value above a scenario's file
count is the same configuration under another name, because only the
per-file upload path spreads over connections and workers. The stored data
is the proof: `single` (one 32 MiB file) has 30 cells holding the same
0.38 MiB/s. `axis_for_scenario` caps and deduplicates both axes against the
payload, `axes` keeps what was requested and `axes.per_scenario` records
what was measured. The default sweep gets *cheaper* while covering more.

That budget buys the two axes that do move:

- **`concurrency` runs to 64.** With a maximum of 16 (32 in the stored
  runs) the optimum of every small-file scenario sat on the edge of the
  grid, so the sweep could only ever report a boundary. To keep that
  falsifiable rather than a thing a reader has to notice,
  `scaling[].best_at_axis_max` names the axes whose largest swept value
  *is* the best cell, and `matrix.md` states it in plain text.
- **`request_concurrency` is swept for real** (default `1 16 64`) instead
  of being a declared axis nobody ever filled. It is applied only where it
  can do anything: the setting is `sftp.MaxConcurrentRequestsPerFile`, so a
  4 KiB file is one 32 KiB packet and cannot use a second in-flight
  request. The token `default` keeps the old two-dimensional grid
  expressible, and cells carry `request_concurrency_used` so a null
  coordinate no longer hides which value was in effect.

**And the policy measurement.** One `auto` run per scenario and link
profile (candidate build, every knob at `auto`), scored against the best
cell as `regret_percent`. It is not a build label in the grid: `auto`
chooses a coordinate rather than sitting at one, so it stays out of
`cells[]`, `scaling[]`, `comparison[]` and the CSV. What it picked is read
back from the run's own `config_*` counters rather than assumed, and
`chosen_cell_median_ms` re-measures those same coordinates as an ordinary
cell so drift can be told apart from policy. Today it scores a hardcoded
default, which is precisely what #156 says `auto` currently is; that is the
number #156 has to beat.

## Checklist

- [ ] `go test ./...`, `go vet ./...` and `gofmt -l .` are clean (not run locally: no Go code is touched by this PR, see the notes below)
- [x] Behavior changes have a test
- [x] Docs updated where affected: `benchmarks/README.md`, `CLAUDE.md`,
      the workflow input descriptions
- [x] New external dependency in CI is pinned — none added
- [x] `CHANGELOG.md` **not** hand-edited

## Notes for the reviewer

- **No Go code changed.** `go test`/`go vet`/`gofmt` are therefore
  unaffected and were not re-run locally; CI covers them.
  `scripts/test-benchmark.sh` is the check that matters here and it passes
  end to end against the stub (all sections, exit 0), including the new
  per-scenario caps, both request-axis paths, the boundary flag and the
  regret arithmetic.
- **The stub now resolves `auto`** to easySFTP's own defaults (1/4/16),
  the same thing `autoInt.or` does in `internal/config/configfile.go`, and
  emits `config_request_concurrency`. Without that an auto run has no
  coordinates to be scored at.
- **Stored results stay readable.** Nothing was removed from the JSON;
  `axes`, `cells[]`, `scaling[]`, `comparison[]`, `canary[]` and
  `deletes[]` all keep their shape and meaning. `index.json` reads
  `scaling[].best`, which is untouched, and `auto[]` being separate is what
  keeps it from ever being picked as a "best cell".
- **Cost.** The default grid over `small large single` comes out smaller
  than before despite the longer axes, because `single` collapses from 30
  cells to 3 and `large` from 30 to 12. The script prints the per-scenario
  axes and the full run count (canary and auto runs included) before it
  starts.
- **Left out deliberately:** the `#156` policy change, and any coefficient
  fitted on this host. The benchmark supplies the shape of the function,
  never its constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

