### PR TITLE
feat(benchmark): aggregate in Go, with the jq implementation as the oracle (#190)

### DIFF
--- a/.github/workflows/benchmark-matrix.yml
+++ b/.github/workflows/benchmark-matrix.yml
@@ -186,6 +186,10 @@ jobs:
           # not from the candidate: it measures the path, and the path must be
           # measured the same way no matter which ref is under test.
           go build -trimpath -ldflags="-s -w" -o "$RUNNER_TEMP/bin/linkprobe" ./cmd/linkprobe
+          # The aggregation (issue #190). Built from the workflow's own checkout
+          # for the same reason: it decides what the stored result looks like,
+          # and that must not depend on which ref is under test.
+          go build -trimpath -ldflags="-s -w" -o "$RUNNER_TEMP/bin/easysftp-bench" ./cmd/easysftp-bench
           {
             echo "candidate-ref=$CANDIDATE_REF_INPUT ($(git -C builds/candidate rev-parse --short HEAD))"
             echo "candidate-sha=$(git -C builds/candidate rev-parse HEAD)"
@@ -212,6 +216,7 @@ jobs:
           MATRIX_SCENARIOS: ${{ inputs.scenarios }}
           MATRIX_LINK_PROFILES: ${{ inputs.link-profiles }}
           LINKPROBE_BIN: ${{ runner.temp }}/bin/linkprobe
+          BENCH_TOOL: ${{ runner.temp }}/bin/easysftp-bench
           LINK_IFACE: ${{ inputs.link-iface }}
           # OUT_DIR is uploaded as an artifact; LOG_DIR (which holds logs that
           # name the host and user) deliberately is not.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -238,6 +238,10 @@ jobs:
           # not from the candidate: it measures the path, and the path must be
           # measured the same way no matter which ref is under test.
           go build -trimpath -ldflags="-s -w" -o "$RUNNER_TEMP/bin/linkprobe" ./cmd/linkprobe
+          # The aggregation (issue #190). Built from the workflow's own checkout
+          # for the same reason: it decides what the stored result looks like,
+          # and that must not depend on which ref is under test.
+          go build -trimpath -ldflags="-s -w" -o "$RUNNER_TEMP/bin/easysftp-bench" ./cmd/easysftp-bench
           candidate_sha=$(git -C builds/candidate rev-parse HEAD)
           {
             echo "candidate-ref=$CANDIDATE_REF_INPUT ($(git -C builds/candidate rev-parse --short HEAD))"
@@ -262,6 +266,7 @@ jobs:
           BENCH_CONNECTIONS: ${{ inputs.connections }}
           BENCH_LINK_PROFILES: ${{ inputs.link-profiles }}
           LINKPROBE_BIN: ${{ runner.temp }}/bin/linkprobe
+          BENCH_TOOL: ${{ runner.temp }}/bin/easysftp-bench
           LINK_IFACE: ${{ inputs.link-iface }}
           # OUT_DIR is uploaded as an artifact; LOG_DIR (which holds logs that
           # name the host and user) deliberately is not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,11 +171,33 @@ granularity is a separate, later decision; don't build it speculatively.
 
 ## Benchmarks
 
-`scripts/benchmark.sh` measures throughput at the default settings,
-`scripts/benchmark-matrix.sh` sweeps `advanced.connections` against
-`advanced.concurrency`, both on top of the shared `scripts/benchmark-lib.sh`
-(payload generation, running a build, reading its outputs, the jq statistics)
-and `scripts/benchmark-link.sh` (the probed link profile and `tc` shaping).
+The harness is split in two, and the split is the thing to keep straight
+(issue #190). **Shell measures, Go aggregates.** `scripts/benchmark.sh`
+measures throughput at the default settings, `scripts/benchmark-matrix.sh`
+sweeps `advanced.connections` against `advanced.concurrency`, both on top of the
+shared `scripts/benchmark-lib.sh` (payload generation, running a build, reading
+its outputs) and `scripts/benchmark-link.sh` (the probed link profile and `tc`
+shaping). Each appends one JSON document per run to its JSONL files, writes a
+`manifest.json` describing the run, and then calls `cmd/easysftp-bench`, which
+reads both and writes `results.json`/`matrix.json` plus their CSV and Markdown.
+
+That means a change to *what is measured* is a shell change and a change to
+*what is reported* is a Go change, and the manifest is the seam. The manifest
+carries the display strings the summaries print (axis lists, the runner line,
+the settings sentence) verbatim rather than rebuilding them in Go: a summary
+table that reformats itself is a change to a stored document made by accident.
+
+Inside `internal/benchmark`: `schema` is what is on disk and must keep reading
+every result already committed (its fixture test decodes every file under
+`benchmarks/` strictly, so a type that does not cover a stored field fails);
+`stats` is the old `JQ_STATS` block, and its edge cases are load-bearing (lower
+middle median, `mad` null below two samples, null sorting below every number and
+being the identity of addition); `report` renders the CSV and the Markdown.
+
+`scripts/benchmark-aggregate-jq.sh` is the jq implementation the Go one
+replaced, kept only as the parity oracle `scripts/test-benchmark.sh` diffs
+against. It is scaffolding, not a second implementation: do not tidy it, and do
+not add to it. Step 6 of #190 deletes it.
 A scenario there carries a *shape* as well as a payload (`scenario_shape`: mode,
 whether the measured run redeploys over an unmeasured one, flat or deep
 layout). The deploy-shape scenarios (`redeploy`, `sync`, `deep`, `bulk`,

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,8 +3,16 @@
 Upload performance of easySFTP against a real SFTP server, measured by
 [`scripts/benchmark.sh`](../scripts/benchmark.sh) (throughput at the default
 settings) and [`scripts/benchmark-matrix.sh`](../scripts/benchmark-matrix.sh)
-(a connections/concurrency sweep), and filed here by
+(a connections/concurrency sweep), aggregated into the documents below by
+[`cmd/easysftp-bench`](../cmd/easysftp-bench), and filed here by
 [`scripts/benchmark-store.sh`](../scripts/benchmark-store.sh).
+
+The split is deliberate (issue #190): the scripts measure, because that needs a
+host, a payload and privileges; everything downstream of the measurement is Go,
+because it is where the schemas, the statistics and the reports live. The
+documents themselves did not change with that move, which is what
+`scripts/test-benchmark.sh` checks by aggregating the same measurement twice and
+diffing the two.
 
 These numbers set no threshold and fail no build. They exist to see where the
 time goes (issues #158 and #169), so read them as one host's behaviour on

--- a/cmd/easysftp-bench/main.go
+++ b/cmd/easysftp-bench/main.go
@@ -1,0 +1,233 @@
+// Command easysftp-bench aggregates a benchmark run into the documents it
+// stores.
+//
+// It is the Go half of the split issue #190 describes. The measuring scripts
+// keep generating payloads, running easySFTP and shaping the link; they hand
+// this command one manifest describing the run plus the JSONL they appended to,
+// and it writes results.json/results.csv/summary.md or
+// matrix.json/matrix.csv/matrix.md.
+//
+// It performs no measurement, opens no connection and reads no environment
+// variable. Given the same inputs it writes the same bytes, which is what makes
+// it comparable against the jq implementation it replaces.
+//
+// Usage:
+//
+//	easysftp-bench aggregate --manifest <path> --out <dir>
+//	easysftp-bench validate <stored-result.json>...
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/eiserv/easySFTP/internal/benchmark"
+	"github.com/eiserv/easySFTP/internal/benchmark/report"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	var err error
+	switch os.Args[1] {
+	case "aggregate":
+		err = aggregate(os.Args[2:])
+	case "validate":
+		err = validate(os.Args[2:])
+	case "-h", "--help", "help":
+		usage()
+		return
+	default:
+		usage()
+		os.Exit(2)
+	}
+	if err != nil {
+		// The GitHub Actions annotation format, like every other error the
+		// benchmark scripts produce.
+		fmt.Fprintf(os.Stderr, "::error::%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `easysftp-bench aggregates a benchmark run into its stored documents.
+
+  aggregate --manifest <path> --out <dir>   write the result, the CSV and the summary
+  validate <file>...                        check stored results against the schema
+`)
+}
+
+func aggregate(args []string) error {
+	flags := flag.NewFlagSet("aggregate", flag.ExitOnError)
+	manifestPath := flags.String("manifest", "", "the run manifest the measuring script wrote")
+	outDir := flags.String("out", "", "directory the result, CSV and summary are written to")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *manifestPath == "" || *outDir == "" {
+		return fmt.Errorf("aggregate needs both --manifest and --out")
+	}
+
+	manifest, err := benchmark.LoadManifest(*manifestPath)
+	if err != nil {
+		return err
+	}
+	inputs, err := benchmark.Load(manifest)
+	if err != nil {
+		return err
+	}
+
+	switch manifest.Kind {
+	case schema.BenchmarkMatrix:
+		return writeMatrix(manifest, inputs, *outDir)
+	default:
+		return writeStandard(manifest, inputs, *outDir)
+	}
+}
+
+func writeStandard(m *benchmark.Manifest, in *benchmark.Inputs, outDir string) error {
+	result := benchmark.BuildStandard(m, in)
+	summary := report.Standard{
+		Result:        result,
+		CandidateRef:  m.CandidateRef,
+		BaselineRef:   m.BaselineRef,
+		Repeats:       m.Repeats,
+		RunnerDisplay: m.RunnerDisplay,
+		LinkRequested: m.Link.Requested,
+		Settings:      m.Settings,
+		Labels:        m.Labels,
+		Scenarios:     scenarioNames(m),
+		LinkProfiles:  m.Link.Profiles,
+	}
+	if err := writeJSON(filepath.Join(outDir, "results.json"), result); err != nil {
+		return err
+	}
+	if err := writeFile(filepath.Join(outDir, "results.csv"), summary.CSV()); err != nil {
+		return err
+	}
+	return writeFile(filepath.Join(outDir, "summary.md"), summary.Markdown())
+}
+
+func writeMatrix(m *benchmark.Manifest, in *benchmark.Inputs, outDir string) error {
+	result := benchmark.BuildMatrix(m, in)
+	summary := report.Matrix{
+		Result:             result,
+		CandidateRef:       m.CandidateRef,
+		BaselineRef:        m.BaselineRef,
+		Repeats:            m.Repeats,
+		RunnerDisplay:      m.RunnerDisplay,
+		LinkRequested:      m.Link.Requested,
+		ConnectionsDisplay: m.Grid.ConnectionsDisplay,
+		ConcurrencyDisplay: m.Grid.ConcurrencyDisplay,
+		RequestDisplay:     m.Grid.RequestDisplay,
+		Labels:             m.Labels,
+		LinkProfiles:       m.Link.Profiles,
+		Scenarios:          matrixScenarios(m),
+		Canary: schema.Canary{
+			Scenario:    m.Grid.Canary.Scenario,
+			Connections: m.Grid.Canary.Connections,
+			Concurrency: m.Grid.Canary.Concurrency,
+		},
+		HasBaseline: m.BaselineRef != "",
+	}
+	if err := writeJSON(filepath.Join(outDir, "matrix.json"), result); err != nil {
+		return err
+	}
+	if err := writeFile(filepath.Join(outDir, "matrix.csv"), summary.CSV()); err != nil {
+		return err
+	}
+	return writeFile(filepath.Join(outDir, "matrix.md"), summary.Markdown())
+}
+
+func scenarioNames(m *benchmark.Manifest) []string {
+	names := make([]string, 0, len(m.Scenarios))
+	for _, s := range m.Scenarios {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func matrixScenarios(m *benchmark.Manifest) []report.MatrixScenario {
+	out := make([]report.MatrixScenario, 0, len(m.Scenarios))
+	for _, s := range m.Scenarios {
+		out = append(out, report.MatrixScenario{
+			Name:               s.Name,
+			Description:        s.Description,
+			Mode:               s.Mode,
+			ConnectionsDisplay: s.ConnectionsDisplay,
+			ConcurrencyDisplay: s.ConcurrencyDisplay,
+			RequestDisplay:     s.RequestDisplay,
+			Connections:        s.Connections,
+			Concurrency:        s.Concurrency,
+			RequestConcurrency: s.RequestConcurrency,
+		})
+	}
+	return out
+}
+
+// validate checks stored results against the schema. It is what keeps "current
+// stored results remain readable" from being a claim nobody runs.
+func validate(paths []string) error {
+	if len(paths) == 0 {
+		return fmt.Errorf("validate needs at least one file")
+	}
+	failures := 0
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+			failures++
+			continue
+		}
+		env, err := schema.DecodeStrict[schema.Envelope](data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+			failures++
+			continue
+		}
+		if err := env.Validate(); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+			failures++
+			continue
+		}
+		fmt.Printf("%s: ok\n", path)
+	}
+	if failures > 0 {
+		return fmt.Errorf("%d of %d stored result(s) did not validate", failures, len(paths))
+	}
+	return nil
+}
+
+// writeJSON writes a document the way jq does: two-space indentation, a
+// trailing newline, and no HTML escaping.
+//
+// That last part is the reason this does not use json.MarshalIndent, which
+// rewrites the three HTML-significant characters as unicode escapes. jq leaves
+// them alone, and a ref or a label carrying one of them would otherwise make a
+// Go-written result differ from the jq-written results already stored, for no
+// reason a reader could make sense of.
+func writeJSON(path string, value any) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(value); err != nil {
+		return err
+	}
+	// Encode already ends the document with a newline.
+	return writeFile(path, buf.String())
+}
+
+func writeFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/internal/benchmark/aggregate.go
+++ b/internal/benchmark/aggregate.go
@@ -1,0 +1,261 @@
+package benchmark
+
+import (
+	"sort"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// The helpers here are the pieces both aggregations share, and each one mirrors
+// one jq expression from scripts/benchmark-lib.sh or the two scripts. Where a
+// comment says "jq does X", that is the reason the Go looks the way it does and
+// not an observation about jq.
+
+// metricsOf is jq's "(map(select(.metrics != null)) | map(.metrics)) as $m":
+// the metrics documents of the runs that wrote one. Runs that died before
+// writing are not represented at all, rather than as an empty document.
+func metricsOf[T any](items []T, metrics func(T) *schema.Metrics) []*schema.Metrics {
+	var out []*schema.Metrics
+	for _, item := range items {
+		if m := metrics(item); m != nil {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// processField reads one process value from every metrics document, keeping the
+// gaps as nulls. A document that never reported the field contributes a null,
+// which can then reach the middle of the sorted list and make the median null.
+func processField(ms []*schema.Metrics, field func(*schema.MetricsProcess) *float64) []*float64 {
+	out := make([]*float64, 0, len(ms))
+	for _, m := range ms {
+		if m == nil || m.Process == nil {
+			out = append(out, nil)
+			continue
+		}
+		out = append(out, field(m.Process))
+	}
+	return out
+}
+
+// counterValues reads one counter from every metrics document, keeping the gaps
+// as nulls. Used where the jq reads ".counters.x" without a "// 0".
+func counterValues(ms []*schema.Metrics, name string) []*float64 {
+	out := make([]*float64, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m.Counter(name))
+	}
+	return out
+}
+
+// counterOr reads one counter from every metrics document with a default, which
+// is what "(.counters.x // 0)" does: a run that never reported the counter
+// contributes the default and not a gap.
+func counterOr(ms []*schema.Metrics, name string, fallback float64) []*float64 {
+	out := make([]*float64, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, stats.Ptr(stats.Or(m.Counter(name), fallback)))
+	}
+	return out
+}
+
+// aggregateProcess is the process block of a standard result: the median of
+// every value across the repeats, except the goroutine peak, which is a peak
+// and is therefore taken as a maximum.
+func aggregateProcess(ms []*schema.Metrics) *schema.Process {
+	field := func(f func(*schema.MetricsProcess) *float64) *float64 {
+		return stats.Median(processField(ms, f))
+	}
+	return &schema.Process{
+		UserCPUMS:         field(func(p *schema.MetricsProcess) *float64 { return p.UserCPUMS }),
+		SysCPUMS:          field(func(p *schema.MetricsProcess) *float64 { return p.SysCPUMS }),
+		CPUPercent:        field(func(p *schema.MetricsProcess) *float64 { return p.CPUPercent }),
+		MaxRSSBytes:       field(func(p *schema.MetricsProcess) *float64 { return p.MaxRSSBytes }),
+		GoTotalAllocBytes: field(func(p *schema.MetricsProcess) *float64 { return p.TotalAllocBytes }),
+		GoMallocs:         field(func(p *schema.MetricsProcess) *float64 { return p.Mallocs }),
+		GoGCCount:         field(func(p *schema.MetricsProcess) *float64 { return p.GCCount }),
+		GoGCPauseTotalMS:  field(func(p *schema.MetricsProcess) *float64 { return p.GCPauseTotalMS }),
+		GoPeakGoroutines:  stats.Max(processField(ms, func(p *schema.MetricsProcess) *float64 { return p.PeakGoroutines })),
+		DiskReadBytes:     field(func(p *schema.MetricsProcess) *float64 { return p.DiskReadBytes }),
+		NetReadBytes:      field(func(p *schema.MetricsProcess) *float64 { return p.NetReadBytes }),
+		NetWriteBytes:     field(func(p *schema.MetricsProcess) *float64 { return p.NetWriteBytes }),
+	}
+}
+
+// aggregateCounters is the counters object: every counter any repeat reported,
+// each one the median of the repeats that reported it.
+//
+// A counter a repeat did not report contributes nothing here rather than a
+// null, because the jq concatenates the counter objects and groups the entries
+// that exist. That is deliberately different from the process block above,
+// where the field is read from every document and a gap stays a gap.
+func aggregateCounters(ms []*schema.Metrics) schema.Counters {
+	values := map[string][]*float64{}
+	for _, m := range ms {
+		for name, value := range m.Counters {
+			values[name] = append(values[name], value)
+		}
+	}
+	if len(values) == 0 {
+		return schema.Counters{}
+	}
+	out := make(schema.Counters, len(values))
+	for name, list := range values {
+		out[name] = stats.Median(list)
+	}
+	return out
+}
+
+// aggregatePhases is the phases block: wall clock per phase, median over the
+// repeats, ordered by cost. Phases add up to roughly the run's duration.
+func aggregatePhases(ms []*schema.Metrics) []schema.Phase {
+	var all []schema.MetricsPhase
+	for _, m := range ms {
+		all = append(all, m.Phases...)
+	}
+	groups := stats.GroupBy(all, func(p schema.MetricsPhase) stats.Key {
+		return stats.Key{p.Name}
+	})
+	out := make([]schema.Phase, 0, len(groups))
+	for _, group := range groups {
+		wall := make([]*float64, 0, len(group))
+		for _, p := range group {
+			wall = append(wall, p.WallMS)
+		}
+		out = append(out, schema.Phase{
+			Name:     group[0].Name,
+			MedianMS: stats.Or(stats.Median(wall), 0),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].MedianMS > out[j].MedianMS })
+	return out
+}
+
+// aggregateOperations is the round-trip block: per operation name, the median
+// of every percentile across the repeats and the sum of the errors.
+//
+// The totals are cumulative across the parallel upload workers and are normally
+// larger than the phase they happened in. They are a share of the work and a
+// per-call cost, never elapsed time.
+func aggregateOperations(ms []*schema.Metrics) []schema.Operation {
+	var all []schema.MetricsOp
+	for _, m := range ms {
+		all = append(all, m.Operations...)
+	}
+	groups := stats.GroupBy(all, func(o schema.MetricsOp) stats.Key {
+		return stats.Key{o.Name}
+	})
+	out := make([]schema.Operation, 0, len(groups))
+	for _, group := range groups {
+		median := func(f func(schema.MetricsOp) *float64) *float64 {
+			values := make([]*float64, 0, len(group))
+			for _, o := range group {
+				values = append(values, f(o))
+			}
+			return stats.Median(values)
+		}
+		errors := make([]*float64, 0, len(group))
+		for _, o := range group {
+			errors = append(errors, o.Errors)
+		}
+		out = append(out, schema.Operation{
+			Name:          group[0].Name,
+			Count:         median(func(o schema.MetricsOp) *float64 { return o.Count }),
+			MedianTotalMS: median(func(o schema.MetricsOp) *float64 { return o.TotalMS }),
+			AvgMS:         median(func(o schema.MetricsOp) *float64 { return o.AvgMS }),
+			P50MS:         median(func(o schema.MetricsOp) *float64 { return o.P50MS }),
+			P90MS:         median(func(o schema.MetricsOp) *float64 { return o.P90MS }),
+			P99MS:         median(func(o schema.MetricsOp) *float64 { return o.P99MS }),
+			MaxMS:         median(func(o schema.MetricsOp) *float64 { return o.MaxMS }),
+			Errors:        stats.Add(errors),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return stats.Or(out[i].MedianTotalMS, 0) > stats.Or(out[j].MedianTotalMS, 0)
+	})
+	return out
+}
+
+// aggregateDeletes is JQ_DELETE: one group of pre-cleans reduced to the row
+// both scripts store under deletes[].
+//
+// Sweeps that deleted nothing are dropped rather than averaged in. The first
+// pre-clean of a build and scenario runs against an empty remote directory and
+// measures the scan alone, and a median over that and a real sweep describes
+// neither.
+func aggregateDeletes(rows []DeleteRecord) schema.DeleteStats {
+	var swept []DeleteRecord
+	for _, row := range rows {
+		if row.FilesDeleted > 0 {
+			swept = append(swept, row)
+		}
+	}
+	ms := metricsOf(swept, func(d DeleteRecord) *schema.Metrics { return d.Metrics })
+
+	durations := make([]float64, 0, len(swept))
+	deleted := make([]*float64, 0, len(swept))
+	failed := 0
+	for _, row := range swept {
+		durations = append(durations, row.DurationMS)
+		deleted = append(deleted, stats.Ptr(row.FilesDeleted))
+		if row.ExitCode != 0 {
+			failed++
+		}
+	}
+
+	out := schema.DeleteStats{
+		Sweeps:       len(swept),
+		FailedSweeps: failed,
+		FilesDeleted: stats.Or(stats.Max(deleted), 0),
+		DurationsMS:  durations,
+		MedianMS:     stats.MedianOf(durations),
+		MinMS:        stats.Or(stats.Min(stats.Nums(durations)), 0),
+		MaxMS:        stats.Or(stats.Max(stats.Nums(durations)), 0),
+		MadMS:        stats.Mad(durations),
+		Phases:       aggregatePhases(ms),
+		Operations:   aggregateOperations(ms),
+	}
+	out.DeletesPerS = stats.Ratio(out.FilesDeleted, out.MedianMS)
+	if out.DurationsMS == nil {
+		out.DurationsMS = []float64{}
+	}
+	return out
+}
+
+// durationsOf and the two helpers below exist so the two aggregations state the
+// same thing the same way.
+func durationsOf(runs []RunRecord) []float64 {
+	out := make([]float64, 0, len(runs))
+	for _, r := range runs {
+		out = append(out, r.DurationMS)
+	}
+	return out
+}
+
+func maxOf(runs []RunRecord, field func(RunRecord) float64) float64 {
+	values := make([]*float64, 0, len(runs))
+	for _, r := range runs {
+		values = append(values, stats.Ptr(field(r)))
+	}
+	return stats.Or(stats.Max(values), 0)
+}
+
+func sumOf(runs []RunRecord, field func(RunRecord) float64) float64 {
+	var total float64
+	for _, r := range runs {
+		total += field(r)
+	}
+	return total
+}
+
+func failedRuns(runs []RunRecord) int {
+	failed := 0
+	for _, r := range runs {
+		if r.ExitCode != 0 {
+			failed++
+		}
+	}
+	return failed
+}

--- a/internal/benchmark/aggregate_test.go
+++ b/internal/benchmark/aggregate_test.go
@@ -1,0 +1,220 @@
+package benchmark
+
+import (
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// The parity check in scripts/test-benchmark.sh shows that this aggregation
+// produces the same documents the jq one did. What it cannot show is *why* any
+// of it is the way it is: it compares two implementations, so a rule both got
+// wrong would pass it. The tests here state the rules themselves.
+
+func metrics(phases map[string]float64, counters map[string]float64) *schema.Metrics {
+	m := &schema.Metrics{Counters: map[string]*float64{}}
+	for name, wall := range phases {
+		m.Phases = append(m.Phases, schema.MetricsPhase{Name: name, WallMS: stats.Ptr(wall)})
+	}
+	for name, value := range counters {
+		m.Counters[name] = stats.Ptr(value)
+	}
+	return m
+}
+
+func run(scenario, label string, repeat int, duration float64, m *schema.Metrics) RunRecord {
+	return RunRecord{
+		Label: label, Ref: label + "-ref", Scenario: scenario, LinkProfile: "baseline",
+		Repeat: repeat, DurationMS: duration, Files: 10, Bytes: 1048576, Metrics: m,
+	}
+}
+
+// TestDeletesNeverReachTheUploadNumbers is the invariant issue #184 phase 4
+// rests on and issue #190 must not lose: the pre-clean is a pure delete sweep,
+// it is aggregated from its own metrics files into its own block, and no upload
+// row may contain a delete_sweep phase or an sftp_remove round-trip.
+func TestDeletesNeverReachTheUploadNumbers(t *testing.T) {
+	in := &Inputs{
+		Runs: []RunRecord{
+			run("small", "candidate", 1, 100, metrics(map[string]float64{"upload": 90}, nil)),
+		},
+		Deletes: []DeleteRecord{{
+			Label: "candidate", Scenario: "small", LinkProfile: "baseline",
+			DurationMS: 50, FilesDeleted: 7,
+			Metrics: metrics(map[string]float64{"delete_sweep": 40, "remote_scan": 10}, nil),
+		}},
+	}
+	result := BuildStandard(&Manifest{Kind: schema.BenchmarkStandard}, in)
+
+	for _, row := range result.Results {
+		for _, phase := range row.Phases {
+			if phase.Name == "delete_sweep" {
+				t.Errorf("an upload row grew a delete_sweep phase")
+			}
+		}
+	}
+	if len(result.Deletes) != 1 {
+		t.Fatalf("got %d delete rows, want 1", len(result.Deletes))
+	}
+	if result.Deletes[0].FilesDeleted != 7 {
+		t.Errorf("files_deleted = %v, want 7", result.Deletes[0].FilesDeleted)
+	}
+}
+
+// TestSweepsThatFoundNothingAreNotCounted pins the other half of that rule. The
+// first pre-clean of a build and scenario runs against an empty remote
+// directory and measures the scan alone; a median over that and a real sweep
+// describes neither, and a coordinate left with no sweep at all has no row.
+func TestSweepsThatFoundNothingAreNotCounted(t *testing.T) {
+	in := &Inputs{
+		Runs: []RunRecord{run("small", "candidate", 1, 100, nil)},
+		Deletes: []DeleteRecord{
+			{Label: "candidate", Scenario: "small", LinkProfile: "baseline", DurationMS: 5, FilesDeleted: 0},
+			{Label: "candidate", Scenario: "small", LinkProfile: "baseline", DurationMS: 50, FilesDeleted: 4},
+			{Label: "candidate", Scenario: "empty-target", LinkProfile: "baseline", DurationMS: 5, FilesDeleted: 0},
+		},
+	}
+	result := BuildStandard(&Manifest{Kind: schema.BenchmarkStandard}, in)
+
+	if len(result.Deletes) != 1 {
+		t.Fatalf("got %d delete rows, want 1", len(result.Deletes))
+	}
+	row := result.Deletes[0]
+	if row.Sweeps != 1 {
+		t.Errorf("sweeps = %d, want 1: the empty sweep must not be counted", row.Sweeps)
+	}
+	if row.MedianMS != 50 {
+		t.Errorf("median_ms = %v, want 50: the empty sweep must not move it", row.MedianMS)
+	}
+}
+
+// TestASingleRepeatReportsNoSpread is issue #184 phase 2 in the aggregation: a
+// 0 there would read as perfect precision, which is the normal case for a
+// matrix run whose REPEATS default is 1.
+func TestASingleRepeatReportsNoSpread(t *testing.T) {
+	in := &Inputs{Runs: []RunRecord{run("small", "candidate", 1, 100, nil)}}
+	result := BuildStandard(&Manifest{Kind: schema.BenchmarkStandard}, in)
+
+	if got := result.Results[0].MadMS; got != nil {
+		t.Errorf("mad_ms = %v, want null", *got)
+	}
+	if got := result.Results[0].DurationMS.Mad; got != nil {
+		t.Errorf("duration_ms.mad = %v, want null", *got)
+	}
+}
+
+// TestWithinNoiseNeedsAMeasuredSpread: a candidate whose delta is smaller than
+// the reference's own MAD has not been shown to be faster or slower, and where
+// there is no spread at all the question has no answer and must not be given
+// one.
+func TestWithinNoiseNeedsAMeasuredSpread(t *testing.T) {
+	in := &Inputs{Runs: []RunRecord{
+		run("small", "baseline", 1, 100, nil),
+		run("small", "baseline", 2, 120, nil),
+		run("small", "baseline", 3, 110, nil),
+		run("small", "candidate", 1, 108, nil),
+		run("small", "candidate", 2, 108, nil),
+		run("small", "candidate", 3, 108, nil),
+	}}
+	result := BuildStandard(&Manifest{Kind: schema.BenchmarkStandard, ReferenceLabel: "baseline"}, in)
+
+	if len(result.Comparison) != 1 {
+		t.Fatalf("got %d comparisons, want 1", len(result.Comparison))
+	}
+	c := result.Comparison[0]
+	if c.WithinNoise == nil {
+		t.Fatal("within_noise is null although the reference has a measured spread")
+	}
+	if !*c.WithinNoise {
+		t.Errorf("a delta of %v against a MAD of %v should be inside the noise",
+			c.DeltaMS, stats.Or(c.ReferenceMadMS, 0))
+	}
+
+	// The same comparison without a spread to compare against.
+	single := &Inputs{Runs: []RunRecord{
+		run("small", "baseline", 1, 100, nil),
+		run("small", "candidate", 1, 150, nil),
+	}}
+	result = BuildStandard(&Manifest{Kind: schema.BenchmarkStandard, ReferenceLabel: "baseline"}, single)
+	if got := result.Comparison[0].WithinNoise; got != nil {
+		t.Errorf("within_noise = %v, want null without a measured spread", *got)
+	}
+}
+
+// TestAutoIsNotACell: auto chooses a coordinate rather than sitting at one, so
+// it must stay out of cells[], scaling[], comparison[] and the CSV, and its
+// chosen settings must be read back from the run's own counters rather than
+// assumed (issue #184, phase 5).
+func TestAutoIsNotACell(t *testing.T) {
+	cell := func(conns, conc int, duration float64) RunRecord {
+		r := run("small", "candidate", 1, duration, metrics(nil, map[string]float64{
+			"config_connections": float64(conns), "config_concurrency": float64(conc),
+			"config_request_concurrency": 16,
+		}))
+		r.Connections, r.Concurrency = &conns, &conc
+		return r
+	}
+	autoRun := run("small", "candidate", 1, 900, metrics(nil, map[string]float64{
+		"config_connections": 1, "config_concurrency": 4, "config_request_concurrency": 16,
+	}))
+
+	in := &Inputs{Runs: []RunRecord{cell(1, 4, 1000), cell(2, 4, 500)}, Auto: []RunRecord{autoRun}}
+	m := &Manifest{Kind: schema.BenchmarkMatrix, ReferenceLabel: "candidate", Grid: &ManifestGrid{}}
+	result := BuildMatrix(m, in)
+
+	for _, c := range result.Cells {
+		if c.Label == "auto" {
+			t.Fatal("an auto run reached cells[]")
+		}
+	}
+	for _, s := range result.Scaling {
+		if s.Label == "auto" {
+			t.Fatal("an auto run reached scaling[]")
+		}
+	}
+	if len(result.Auto) != 1 {
+		t.Fatalf("got %d auto rows, want 1", len(result.Auto))
+	}
+	a := result.Auto[0]
+	if stats.Or(a.Chosen.Connections, 0) != 1 || stats.Or(a.Chosen.Concurrency, 0) != 4 {
+		t.Errorf("chosen = %v/%v, want the values the run's own counters report",
+			stats.Or(a.Chosen.Connections, 0), stats.Or(a.Chosen.Concurrency, 0))
+	}
+	if a.Best == nil || a.Best.MedianMS != 500 {
+		t.Fatalf("best cell = %v, want the fastest candidate cell", a.Best)
+	}
+	if got := stats.Or(a.RegretMS, 0); got != 400 {
+		t.Errorf("regret_ms = %v, want 400", got)
+	}
+	// The chosen coordinates are on this grid, so the control is filled in.
+	if !a.ChosenInGrid || stats.Or(a.ChosenCellMedianMS, 0) != 1000 {
+		t.Errorf("chosen_in_grid = %v, chosen_cell_median_ms = %v; want the 1/4 cell",
+			a.ChosenInGrid, stats.Or(a.ChosenCellMedianMS, 0))
+	}
+}
+
+// TestBestOnTheLargestSweptValueIsReported is the honesty check the auto-config
+// work rests on: an optimum sitting on the edge of an axis was cut off, not
+// measured. An axis with a single swept value has no edge and is not reported.
+func TestBestOnTheLargestSweptValueIsReported(t *testing.T) {
+	cell := func(conns, conc int, duration float64) RunRecord {
+		r := run("small", "candidate", 1, duration, nil)
+		r.Connections, r.Concurrency = &conns, &conc
+		return r
+	}
+	m := &Manifest{Kind: schema.BenchmarkMatrix, ReferenceLabel: "candidate", Grid: &ManifestGrid{}}
+
+	// Fastest at the largest concurrency swept: the sweep stopped before the
+	// optimum. connections was swept at one value only, so it has no edge.
+	edge := BuildMatrix(m, &Inputs{Runs: []RunRecord{cell(1, 1, 900), cell(1, 8, 400)}})
+	if got := edge.Scaling[0].BestAtAxisMax; len(got) != 1 || got[0] != "concurrency" {
+		t.Errorf("best_at_axis_max = %v, want [concurrency]", got)
+	}
+
+	// Fastest in the interior: the optimum was measured.
+	interior := BuildMatrix(m, &Inputs{Runs: []RunRecord{cell(1, 1, 900), cell(1, 4, 400), cell(1, 8, 700)}})
+	if got := interior.Scaling[0].BestAtAxisMax; len(got) != 0 {
+		t.Errorf("best_at_axis_max = %v, want empty", got)
+	}
+}

--- a/internal/benchmark/link.go
+++ b/internal/benchmark/link.go
@@ -1,0 +1,60 @@
+package benchmark
+
+import "github.com/eiserv/easySFTP/internal/benchmark/schema"
+
+// linkNote is stored with every link object. It says the one thing a reader has
+// to know before comparing two results, in the file itself rather than only in
+// benchmarks/README.md.
+const linkNote = "environment describes the runner and is the comparability key; link is measured and varies per run. Under a network ceiling a code delta cannot be interpreted."
+
+// buildLink assembles the link object: the shaping state the script owns, plus
+// the probes it managed to take.
+//
+// An empty probe list is the honest answer when no probe binary was available.
+// An invented entry would not be, which is why nothing here fills a gap.
+func buildLink(m *Manifest, probes []schema.Probe) *schema.Link {
+	shaping := m.Link.Shaping
+	if shaping.Requested == nil {
+		shaping.Requested = []string{}
+	}
+	if shaping.Applied == nil {
+		shaping.Applied = []string{}
+	}
+	if probes == nil {
+		probes = []schema.Probe{}
+	}
+	return &schema.Link{
+		Iface:   m.Link.Iface,
+		Shaping: shaping,
+		Probes:  probes,
+		Note:    linkNote,
+	}
+}
+
+// startProbe is the probe taken right before a profile's own runs, which is the
+// one a row of the CSV quotes: a throughput number cannot be told apart from
+// the line it was measured on without it.
+func startProbe(probes []schema.Probe, profile string) *schema.Probe {
+	for i := range probes {
+		if probes[i].Profile == profile && probes[i].At == "start" {
+			return &probes[i]
+		}
+	}
+	return nil
+}
+
+// rttP50 and controlSingle are the two numbers the CSVs carry, both null when
+// the profile was not probed.
+func rttP50(p *schema.Probe) *float64 {
+	if p == nil || p.RTTMS == nil {
+		return nil
+	}
+	return p.RTTMS.P50
+}
+
+func controlSingle(p *schema.Probe) *float64 {
+	if p == nil || p.Control == nil {
+		return nil
+	}
+	return p.Control.SingleStreamMiBPerS
+}

--- a/internal/benchmark/manifest.go
+++ b/internal/benchmark/manifest.go
@@ -1,0 +1,160 @@
+// Package benchmark turns what a benchmark run measured into the documents it
+// stores.
+//
+// It is the second half of the split issue #190 describes: the shell scripts
+// generate payloads, run easySFTP and shape the link, and everything downstream
+// of the JSONL they append to lives here. The measurement path is deliberately
+// untouched by that move, because a rewrite that also changes what is measured
+// cannot be reviewed.
+//
+// The scripts hand over one manifest describing the run, and the JSONL files
+// they wrote. Nothing here runs a process, opens a connection or reads the
+// environment: given the same inputs it produces the same bytes, which is what
+// makes the parity check against the jq implementation meaningful at all.
+package benchmark
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// Manifest is what a measuring script knows and the aggregation cannot derive:
+// which refs were built, which axes were asked for, which display strings the
+// summary tables print, and where the JSONL it appended to lives.
+//
+// Display strings travel verbatim rather than being rebuilt here. The scripts
+// already have them, and a reformatted axis list in a summary would be a change
+// to a stored document made by accident (issue #190: behavioural rewrite first,
+// improvements separately).
+type Manifest struct {
+	// Kind is "standard" or "matrix" and decides which aggregation runs.
+	Kind string `json:"kind"`
+
+	CandidateRef   string `json:"candidate_ref"`
+	BaselineRef    string `json:"baseline_ref"`
+	ReferenceLabel string `json:"reference_label"`
+	Repeats        int    `json:"repeats"`
+
+	// Runner is the value stored in the result; RunnerDisplay is the shorter
+	// one the summary table prints. The two differ, and reconstructing either
+	// from the other would be guesswork.
+	Runner        string `json:"runner"`
+	RunnerDisplay string `json:"runner_display"`
+
+	Environment *schema.Environment `json:"environment"`
+	Settings    string              `json:"settings"`
+	Note        string              `json:"note"`
+
+	// Labels is the build order the summary tables loop in, and Scenarios the
+	// scenario order. Both are the script's own order, which is not the order
+	// the aggregated rows come out in.
+	Labels    []string           `json:"labels"`
+	Scenarios []ManifestScenario `json:"scenarios"`
+
+	Link  ManifestLink  `json:"link"`
+	Files ManifestFiles `json:"files"`
+	Grid  *ManifestGrid `json:"grid,omitzero"`
+}
+
+// ManifestScenario is one scenario as the run measured it: what it is, how it
+// was deployed, and which axis values its payload could actually use.
+type ManifestScenario struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+
+	// Mode is the display string of the scenario's deploy shape, already
+	// carrying the ", redeployed" a prepopulated scenario adds.
+	Mode string `json:"mode,omitzero"`
+
+	Files int `json:"files,omitzero"`
+
+	// The axes as the summary prints them, and as the result stores them. A
+	// matrix run fills these; a standard run has no grid.
+	ConnectionsDisplay string `json:"connections_display,omitzero"`
+	ConcurrencyDisplay string `json:"concurrency_display,omitzero"`
+	RequestDisplay     string `json:"request_display,omitzero"`
+	Connections        []int  `json:"connections,omitzero"`
+	Concurrency        []int  `json:"concurrency,omitzero"`
+	RequestConcurrency []*int `json:"request_concurrency,omitzero"`
+}
+
+// ManifestLink is the shaping state the script owns. The probes themselves are
+// read from the probe file, so a run without a probe binary simply has none.
+type ManifestLink struct {
+	Iface    *string        `json:"iface"`
+	Shaping  schema.Shaping `json:"shaping"`
+	Profiles []string       `json:"profiles"`
+	// Requested is the raw input string the summary prints, empty when the run
+	// measured the real line only.
+	Requested string `json:"requested,omitzero"`
+}
+
+// ManifestFiles names the JSONL the scripts appended to. Absent paths are an
+// empty measurement rather than an error: a standard run has no canary file and
+// no auto file, and a run without a probe binary has no probes.
+type ManifestFiles struct {
+	Runs    string `json:"runs"`
+	Deletes string `json:"deletes,omitzero"`
+	Probes  string `json:"probes,omitzero"`
+	Canary  string `json:"canary,omitzero"`
+	Auto    string `json:"auto,omitzero"`
+}
+
+// ManifestGrid is the declared grid of a matrix run, i.e. what was asked for
+// before each scenario's payload capped it.
+type ManifestGrid struct {
+	Connections        []int  `json:"connections"`
+	Concurrency        []int  `json:"concurrency"`
+	RequestConcurrency []*int `json:"request_concurrency"`
+
+	// The raw input strings, for the settings table.
+	ConnectionsDisplay string `json:"connections_display"`
+	ConcurrencyDisplay string `json:"concurrency_display"`
+	RequestDisplay     string `json:"request_display"`
+
+	Canary ManifestCanary `json:"canary"`
+}
+
+// ManifestCanary is the fixed cell, which is a constant in the script and has
+// to be printed by the summary that explains it.
+type ManifestCanary struct {
+	Scenario    string `json:"scenario"`
+	Connections int    `json:"connections"`
+	Concurrency int    `json:"concurrency"`
+}
+
+// LoadManifest reads and validates a manifest.
+func LoadManifest(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	switch m.Kind {
+	case schema.BenchmarkStandard, schema.BenchmarkMatrix:
+	default:
+		return nil, fmt.Errorf("%s: unknown benchmark kind %q", path, m.Kind)
+	}
+	if m.Files.Runs == "" {
+		return nil, fmt.Errorf("%s: the manifest names no runs file", path)
+	}
+	if m.Kind == schema.BenchmarkMatrix && m.Grid == nil {
+		return nil, fmt.Errorf("%s: a matrix run must declare its grid", path)
+	}
+	return &m, nil
+}
+
+// ScenarioDocs is the scenarios map a stored result carries.
+func (m *Manifest) ScenarioDocs() map[string]string {
+	docs := make(map[string]string, len(m.Scenarios))
+	for _, s := range m.Scenarios {
+		docs[s.Name] = s.Description
+	}
+	return docs
+}

--- a/internal/benchmark/matrix.go
+++ b/internal/benchmark/matrix.go
@@ -1,0 +1,468 @@
+package benchmark
+
+import (
+	"sort"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// matrixNote is stored with every sweep. It says what a cell is, why a cell can
+// be missing from the declared grid without having been skipped, and why auto
+// is not one.
+const matrixNote = "one cell per (link_profile, scenario, build, connections, concurrency, request_concurrency); median_ms is wall clock over the cell's repeats. Each scenario is swept over the axis values its payload can use (axes.per_scenario), so a cell absent from the declared axes was not skipped, it was the same configuration twice. auto[] is off the grid: it is the settings easySFTP picked for itself, scored against the best cell"
+
+// BuildMatrix aggregates a sweep into matrix.json.
+func BuildMatrix(m *Manifest, in *Inputs) *schema.Matrix {
+	cells := matrixCells(in.Runs)
+	canary := in.Canary
+	if canary == nil {
+		canary = []schema.Canary{}
+	}
+
+	return &schema.Matrix{
+		SchemaVersion:  schema.MatrixSchemaVersion,
+		BenchmarkKind:  schema.BenchmarkMatrix,
+		CandidateRef:   m.CandidateRef,
+		BaselineRef:    m.BaselineRef,
+		ReferenceLabel: m.ReferenceLabel,
+		Repeats:        m.Repeats,
+		Runner:         m.Runner,
+		Environment:    m.Environment,
+		Link:           buildLink(m, in.Probes),
+		Canary:         canary,
+		Settings:       m.Settings,
+		Scenarios:      m.ScenarioDocs(),
+		Note:           matrixNote,
+		Axes:           matrixAxes(m),
+		Cells:          cells,
+		Deletes:        matrixDeletes(in.Deletes),
+		Scaling:        matrixScaling(cells),
+		Auto:           matrixAuto(in.Auto, cells),
+		Comparison:     matrixComparison(cells, m.ReferenceLabel),
+	}
+}
+
+// matrixAxes declares the grid explicitly so a heatmap does not have to infer
+// it from the cells that happen to be present, and records next to it what each
+// scenario was actually measured over (issue #184, phase 5).
+func matrixAxes(m *Manifest) schema.Axes {
+	axes := schema.Axes{
+		LinkProfiles:       m.Link.Profiles,
+		Connections:        m.Grid.Connections,
+		Concurrency:        m.Grid.Concurrency,
+		RequestConcurrency: m.Grid.RequestConcurrency,
+		PerScenario:        map[string]schema.ScenarioAxes{},
+	}
+	if axes.LinkProfiles == nil {
+		axes.LinkProfiles = []string{}
+	}
+	for _, s := range m.Scenarios {
+		axes.PerScenario[s.Name] = schema.ScenarioAxes{
+			Files:              s.Files,
+			Connections:        s.Connections,
+			Concurrency:        s.Concurrency,
+			RequestConcurrency: s.RequestConcurrency,
+		}
+	}
+	return axes
+}
+
+func matrixCells(runs []RunRecord) []schema.Cell {
+	groups := stats.GroupBy(runs, func(r RunRecord) stats.Key {
+		return stats.Key{r.LinkProfile, r.Label, r.Scenario,
+			intKey(r.Connections), intKey(r.Concurrency), intKey(r.RequestConcurrency)}
+	})
+
+	out := make([]schema.Cell, 0, len(groups))
+	for _, group := range groups {
+		ms := metricsOf(group, func(r RunRecord) *schema.Metrics { return r.Metrics })
+		durations := durationsOf(group)
+		files := maxOf(group, func(r RunRecord) float64 { return r.Files })
+		bytes := maxOf(group, func(r RunRecord) float64 { return r.Bytes })
+		median := stats.MedianOf(durations)
+
+		process := func(f func(*schema.MetricsProcess) *float64) *float64 {
+			return stats.Median(processField(ms, f))
+		}
+
+		out = append(out, schema.Cell{
+			Scenario:           group[0].Scenario,
+			Label:              group[0].Label,
+			Ref:                group[0].Ref,
+			LinkProfile:        group[0].LinkProfile,
+			Connections:        deref(group[0].Connections),
+			Concurrency:        deref(group[0].Concurrency),
+			RequestConcurrency: group[0].RequestConcurrency,
+			Repeats:            len(group),
+			FailedRuns:         failedRuns(group),
+			Files:              files,
+			Bytes:              bytes,
+			DurationsMS:        durations,
+			MedianMS:           median,
+			MinMS:              stats.Or(stats.Min(stats.Nums(durations)), 0),
+			MaxMS:              stats.Or(stats.Max(stats.Nums(durations)), 0),
+			MadMS:              stats.Mad(durations),
+			Retries:            sumOf(group, func(r RunRecord) float64 { return r.Retries }),
+			Errors:             sumOf(group, func(r RunRecord) float64 { return r.Errors }),
+
+			UserCPUMS:        process(func(p *schema.MetricsProcess) *float64 { return p.UserCPUMS }),
+			SysCPUMS:         process(func(p *schema.MetricsProcess) *float64 { return p.SysCPUMS }),
+			CPUPercent:       process(func(p *schema.MetricsProcess) *float64 { return p.CPUPercent }),
+			MaxRSSBytes:      process(func(p *schema.MetricsProcess) *float64 { return p.MaxRSSBytes }),
+			GoGCCount:        process(func(p *schema.MetricsProcess) *float64 { return p.GCCount }),
+			GoPeakGoroutines: stats.Max(processField(ms, func(p *schema.MetricsProcess) *float64 { return p.PeakGoroutines })),
+			NetWriteBytes:    process(func(p *schema.MetricsProcess) *float64 { return p.NetWriteBytes }),
+
+			ConnectionsOpened: stats.Median(counterOr(ms, "connections_opened", 0)),
+			ConnectionsUsed:   stats.Median(counterOr(ms, "connections_used", 0)),
+			// What the run actually ran with, not what the axis asked for: the
+			// request axis has a pass that sets nothing, and a null coordinate
+			// on its own does not say which value that was.
+			RequestConcurrencyUsed: stats.Median(counterValues(ms, "config_request_concurrency")),
+			ConnectionsRefused:     stats.Add(counterOr(ms, "connections_refused", 0)),
+			Reconnects:             stats.Add(counterOr(ms, "reconnects", 0)),
+			UploadPhaseMS:          uploadPhase(ms),
+
+			Phases:     aggregatePhases(ms),
+			Operations: aggregateOperations(ms),
+			MiBPerS:    stats.MiBPerS(bytes, median),
+			FilesPerS:  stats.Ratio(files, median),
+		})
+	}
+
+	stats.SortByKey(out, func(c schema.Cell) stats.Key {
+		return stats.Key{c.LinkProfile, c.Scenario, c.Label,
+			c.Connections, c.Concurrency, intKey(c.RequestConcurrency)}
+	})
+	return out
+}
+
+// uploadPhase is the wall clock of the upload phase alone, which is the one
+// number a cell kept before it carried its whole phase list (issue #184,
+// phase 2). It stays for the CSV and for results stored against the old shape.
+func uploadPhase(ms []*schema.Metrics) *float64 {
+	var values []*float64
+	for _, m := range ms {
+		for _, p := range m.Phases {
+			if p.Name == "upload" {
+				values = append(values, p.WallMS)
+			}
+		}
+	}
+	return stats.Median(values)
+}
+
+func matrixDeletes(records []DeleteRecord) []schema.MatrixDelete {
+	groups := stats.GroupBy(records, func(d DeleteRecord) stats.Key {
+		return stats.Key{d.LinkProfile, d.Label, d.Scenario,
+			intKey(d.Connections), intKey(d.Concurrency), intKey(d.RequestConcurrency)}
+	})
+	out := make([]schema.MatrixDelete, 0, len(groups))
+	for _, group := range groups {
+		agg := aggregateDeletes(group)
+		if agg.Sweeps == 0 {
+			continue
+		}
+		out = append(out, schema.MatrixDelete{
+			Scenario:           group[0].Scenario,
+			Label:              group[0].Label,
+			LinkProfile:        group[0].LinkProfile,
+			Connections:        deref(group[0].Connections),
+			Concurrency:        deref(group[0].Concurrency),
+			RequestConcurrency: group[0].RequestConcurrency,
+			DeleteStats:        agg,
+		})
+	}
+	stats.SortByKey(out, func(d schema.MatrixDelete) stats.Key {
+		return stats.Key{d.LinkProfile, d.Scenario, d.Label,
+			d.Connections, d.Concurrency, intKey(d.RequestConcurrency)}
+	})
+	return out
+}
+
+// matrixScaling pre-groups the cells into the curve a reader usually wants, per
+// link profile, scenario and build.
+func matrixScaling(cells []schema.Cell) []schema.Scaling {
+	groups := stats.GroupBy(cells, func(c schema.Cell) stats.Key {
+		return stats.Key{c.LinkProfile, c.Scenario, c.Label}
+	})
+
+	out := make([]schema.Scaling, 0, len(groups))
+	for _, group := range groups {
+		fastest := append([]schema.Cell(nil), group...)
+		sort.SliceStable(fastest, func(i, j int) bool { return fastest[i].MedianMS < fastest[j].MedianMS })
+		best := fastest[0]
+
+		points := append([]schema.Cell(nil), group...)
+		stats.SortByKey(points, func(c schema.Cell) stats.Key {
+			return stats.Key{c.Connections, c.Concurrency}
+		})
+		curve := make([]schema.Point, 0, len(points))
+		for _, c := range points {
+			curve = append(curve, schema.Point{
+				Connections:            c.Connections,
+				Concurrency:            c.Concurrency,
+				RequestConcurrency:     c.RequestConcurrency,
+				RequestConcurrencyUsed: c.RequestConcurrencyUsed,
+				MedianMS:               c.MedianMS,
+				MiBPerS:                c.MiBPerS,
+				FilesPerS:              c.FilesPerS,
+				ConnectionsUsed:        c.ConnectionsUsed,
+				ConnectionsRefused:     c.ConnectionsRefused,
+				MaxRSSBytes:            c.MaxRSSBytes,
+				UserCPUMS:              c.UserCPUMS,
+			})
+		}
+
+		out = append(out, schema.Scaling{
+			Scenario:      group[0].Scenario,
+			Label:         group[0].Label,
+			LinkProfile:   group[0].LinkProfile,
+			Points:        curve,
+			Best:          bestOf(best),
+			BestAtAxisMax: bestAtAxisMax(group, best),
+		})
+	}
+	return out
+}
+
+func bestOf(c schema.Cell) schema.Best {
+	return schema.Best{
+		Connections:        c.Connections,
+		Concurrency:        c.Concurrency,
+		RequestConcurrency: c.RequestConcurrency,
+		MedianMS:           c.MedianMS,
+		MiBPerS:            c.MiBPerS,
+		FilesPerS:          c.FilesPerS,
+	}
+}
+
+// bestAtAxisMax names the axes whose largest swept value is the best cell.
+//
+// This is the honesty check the whole sweep rests on: where it is non-empty the
+// optimum sits at or beyond the edge of the grid, so it was cut off rather than
+// measured, and anything fitted to those numbers extrapolates. An axis with a
+// single swept value is not reported, because one value has no edge.
+func bestAtAxisMax(group []schema.Cell, best schema.Cell) []string {
+	out := []string{}
+
+	connections := map[int]bool{}
+	concurrency := map[int]bool{}
+	requests := map[int]bool{}
+	maxConnections, maxConcurrency, maxRequest := 0, 0, 0
+	sweptRequest := false
+	for _, c := range group {
+		connections[c.Connections] = true
+		concurrency[c.Concurrency] = true
+		if c.Connections > maxConnections {
+			maxConnections = c.Connections
+		}
+		if c.Concurrency > maxConcurrency {
+			maxConcurrency = c.Concurrency
+		}
+		if c.RequestConcurrency != nil {
+			requests[*c.RequestConcurrency] = true
+			sweptRequest = true
+			if *c.RequestConcurrency > maxRequest {
+				maxRequest = *c.RequestConcurrency
+			}
+		} else {
+			// A null coordinate is a distinct value of the axis for the purpose
+			// of "was more than one thing swept".
+			requests[-1] = true
+		}
+	}
+
+	if len(connections) > 1 && best.Connections == maxConnections {
+		out = append(out, "connections")
+	}
+	if len(concurrency) > 1 && best.Concurrency == maxConcurrency {
+		out = append(out, "concurrency")
+	}
+	if len(requests) > 1 && sweptRequest && best.RequestConcurrency != nil && *best.RequestConcurrency == maxRequest {
+		out = append(out, "request_concurrency")
+	}
+	return out
+}
+
+// matrixAuto is the policy measurement: what easySFTP picked when asked to
+// pick, what the grid says was best, and the gap between them (issue #184,
+// phase 5).
+//
+// The regret is per link profile on purpose. A policy that is only good on the
+// benchmark host's line is the failure class of #62 all over again.
+func matrixAuto(runs []RunRecord, cells []schema.Cell) []schema.Auto {
+	// Empty rather than absent: a sweep that measured no auto run still has an
+	// auto block, the same way it has an empty comparison without a baseline.
+	// Absent is reserved for the sweeps stored before the block existed.
+	if len(runs) == 0 {
+		return []schema.Auto{}
+	}
+	groups := stats.GroupBy(runs, func(r RunRecord) stats.Key {
+		return stats.Key{r.LinkProfile, r.Scenario}
+	})
+
+	out := make([]schema.Auto, 0, len(groups))
+	for _, group := range groups {
+		ms := metricsOf(group, func(r RunRecord) *schema.Metrics { return r.Metrics })
+		durations := durationsOf(group)
+		files := maxOf(group, func(r RunRecord) float64 { return r.Files })
+		bytes := maxOf(group, func(r RunRecord) float64 { return r.Bytes })
+		median := stats.MedianOf(durations)
+
+		// Read back from the run's own counters, so it says what easySFTP did
+		// rather than what the harness believes it does.
+		chosen := schema.Chosen{
+			Connections:        stats.Median(counterValues(ms, "config_connections")),
+			Concurrency:        stats.Median(counterValues(ms, "config_concurrency")),
+			RequestConcurrency: stats.Median(counterValues(ms, "config_request_concurrency")),
+		}
+
+		auto := schema.Auto{
+			Scenario:    group[0].Scenario,
+			Label:       "auto",
+			Ref:         group[0].Ref,
+			LinkProfile: group[0].LinkProfile,
+			Repeats:     len(group),
+			FailedRuns:  failedRuns(group),
+			Files:       files,
+			Bytes:       bytes,
+			DurationsMS: durations,
+			MedianMS:    median,
+			MinMS:       stats.Or(stats.Min(stats.Nums(durations)), 0),
+			MaxMS:       stats.Or(stats.Max(stats.Nums(durations)), 0),
+			MadMS:       stats.Mad(durations),
+			Chosen:      chosen,
+			MiBPerS:     stats.MiBPerS(bytes, median),
+			FilesPerS:   stats.Ratio(files, median),
+		}
+
+		// Scored against the candidate build only: a regret against a baseline
+		// build's grid would compare two different products.
+		best := bestCandidateCell(cells, auto.Scenario, auto.LinkProfile)
+		if best != nil {
+			b := bestOf(*best)
+			auto.Best = &b
+			auto.RegretMS = stats.Ptr(auto.MedianMS - best.MedianMS)
+			auto.RegretPercent = stats.Pct(auto.MedianMS, best.MedianMS)
+		}
+		if at := chosenCell(cells, auto, chosen); at != nil {
+			auto.ChosenInGrid = true
+			auto.ChosenCellMedianMS = stats.Ptr(at.MedianMS)
+		}
+		out = append(out, auto)
+	}
+
+	stats.SortByKey(out, func(a schema.Auto) stats.Key {
+		return stats.Key{a.LinkProfile, a.Scenario}
+	})
+	return out
+}
+
+func bestCandidateCell(cells []schema.Cell, scenario, profile string) *schema.Cell {
+	var best *schema.Cell
+	for i := range cells {
+		c := &cells[i]
+		if c.Label != "candidate" || c.Scenario != scenario || c.LinkProfile != profile {
+			continue
+		}
+		if best == nil || c.MedianMS < best.MedianMS {
+			best = c
+		}
+	}
+	return best
+}
+
+// chosenCell finds the settings the policy picked measured as an ordinary cell.
+// It is a control and not a result: a large gap between the two means the runs
+// saw different conditions, and then the regret next to it is drift rather than
+// policy.
+func chosenCell(cells []schema.Cell, auto schema.Auto, chosen schema.Chosen) *schema.Cell {
+	if chosen.Connections == nil || chosen.Concurrency == nil {
+		return nil
+	}
+	for i := range cells {
+		c := &cells[i]
+		if c.Label != "candidate" || c.Scenario != auto.Scenario || c.LinkProfile != auto.LinkProfile {
+			continue
+		}
+		if float64(c.Connections) != *chosen.Connections || float64(c.Concurrency) != *chosen.Concurrency {
+			continue
+		}
+		// Compared against what the cell actually ran with, not against its
+		// coordinate: the coordinate is null on the pass that sets nothing.
+		if !sameNumber(c.RequestConcurrencyUsed, chosen.RequestConcurrency) {
+			continue
+		}
+		return c
+	}
+	return nil
+}
+
+func matrixComparison(cells []schema.Cell, reference string) []schema.MatrixCompare {
+	out := []schema.MatrixCompare{}
+	for _, candidate := range cells {
+		if candidate.Label == reference {
+			continue
+		}
+		var ref *schema.Cell
+		for i := range cells {
+			c := &cells[i]
+			if c.Label == reference && c.Scenario == candidate.Scenario &&
+				c.LinkProfile == candidate.LinkProfile &&
+				c.Connections == candidate.Connections && c.Concurrency == candidate.Concurrency &&
+				sameInt(c.RequestConcurrency, candidate.RequestConcurrency) {
+				ref = c
+				break
+			}
+		}
+		if ref == nil {
+			continue
+		}
+		out = append(out, schema.MatrixCompare{
+			Scenario:           candidate.Scenario,
+			Label:              candidate.Label,
+			ReferenceLabel:     reference,
+			LinkProfile:        candidate.LinkProfile,
+			Connections:        candidate.Connections,
+			Concurrency:        candidate.Concurrency,
+			RequestConcurrency: candidate.RequestConcurrency,
+			MedianMS:           candidate.MedianMS,
+			ReferenceMedianMS:  ref.MedianMS,
+			DeltaMS:            candidate.MedianMS - ref.MedianMS,
+			DeltaPercent:       stats.Pct(candidate.MedianMS, ref.MedianMS),
+		})
+	}
+	return out
+}
+
+// intKey turns a nullable coordinate into a grouping key element, keeping null
+// distinct from every number the way jq does.
+func intKey(v *int) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func deref(v *int) int {
+	if v == nil {
+		return 0
+	}
+	return *v
+}
+
+func sameInt(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func sameNumber(a, b *float64) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}

--- a/internal/benchmark/records.go
+++ b/internal/benchmark/records.go
@@ -1,0 +1,141 @@
+package benchmark
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// The records below are exactly what the measuring scripts already append to
+// their JSONL files. They are not a new interface: keeping them byte-for-byte
+// what the shell writes today is what lets the aggregation move without the
+// measurement path moving with it.
+
+// RunRecord is one measured run. A standard run fills Refused and leaves the
+// axis coordinates empty; a matrix cell does the opposite.
+type RunRecord struct {
+	Label       string `json:"label"`
+	Ref         string `json:"ref"`
+	Scenario    string `json:"scenario"`
+	LinkProfile string `json:"link_profile"`
+
+	Connections        *int `json:"connections"`
+	Concurrency        *int `json:"concurrency"`
+	RequestConcurrency *int `json:"request_concurrency"`
+
+	Repeat     int             `json:"repeat"`
+	ExitCode   int             `json:"exit_code"`
+	DurationMS float64         `json:"duration_ms"`
+	Files      float64         `json:"files"`
+	Bytes      float64         `json:"bytes"`
+	Retries    float64         `json:"retries"`
+	Errors     float64         `json:"errors"`
+	Refused    float64         `json:"refused"`
+	Metrics    *schema.Metrics `json:"metrics"`
+}
+
+// DeleteRecord is one pre-clean, which is a pure delete sweep (issue #184,
+// phase 4). Its coordinates are added by the caller that appended it, so a
+// standard sweep and a matrix sweep read through the same type.
+type DeleteRecord struct {
+	Label       string `json:"label"`
+	Scenario    string `json:"scenario"`
+	LinkProfile string `json:"link_profile"`
+
+	Connections        *int `json:"connections"`
+	Concurrency        *int `json:"concurrency"`
+	RequestConcurrency *int `json:"request_concurrency"`
+
+	Repeat       int             `json:"repeat"`
+	ExitCode     int             `json:"exit_code"`
+	DurationMS   float64         `json:"duration_ms"`
+	FilesDeleted float64         `json:"files_deleted"`
+	Metrics      *schema.Metrics `json:"metrics"`
+}
+
+// CanaryRecord is one measurement of the fixed cell. It is stored verbatim:
+// what it measures is the server's steadiness, and aggregating the three would
+// hide exactly what they are there to show.
+type CanaryRecord = schema.Canary
+
+// ProbeRecord is one link probe, already wrapped with the profile it belongs to
+// and whether it was taken before or after that profile's runs.
+type ProbeRecord = schema.Probe
+
+// readJSONL decodes one JSON document per line.
+//
+// A missing file is an empty measurement and not an error: a run without a
+// probe binary stores no probes, and a standard run has neither canary nor auto
+// runs. An unreadable *line* is an error, because that is a truncated
+// measurement and silently dropping it would change the numbers.
+func readJSONL[T any](path string) ([]T, error) {
+	if path == "" {
+		return nil, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer file.Close()
+
+	var out []T
+	scanner := bufio.NewScanner(file)
+	// A metrics document with a long operation list comfortably exceeds the
+	// default 64 KiB line limit.
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		if len(scanner.Bytes()) == 0 {
+			continue
+		}
+		var value T
+		if err := json.Unmarshal(scanner.Bytes(), &value); err != nil {
+			return nil, fmt.Errorf("%s line %d: %w", path, line, err)
+		}
+		out = append(out, value)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return out, nil
+}
+
+// Inputs is everything a run measured, read back off disk.
+type Inputs struct {
+	Runs    []RunRecord
+	Deletes []DeleteRecord
+	Canary  []CanaryRecord
+	Auto    []RunRecord
+	Probes  []ProbeRecord
+}
+
+// Load reads every JSONL file the manifest names.
+func Load(m *Manifest) (*Inputs, error) {
+	var in Inputs
+	var err error
+	if in.Runs, err = readJSONL[RunRecord](m.Files.Runs); err != nil {
+		return nil, err
+	}
+	if in.Deletes, err = readJSONL[DeleteRecord](m.Files.Deletes); err != nil {
+		return nil, err
+	}
+	if in.Canary, err = readJSONL[CanaryRecord](m.Files.Canary); err != nil {
+		return nil, err
+	}
+	if in.Auto, err = readJSONL[RunRecord](m.Files.Auto); err != nil {
+		return nil, err
+	}
+	if in.Probes, err = readJSONL[ProbeRecord](m.Files.Probes); err != nil {
+		return nil, err
+	}
+	return &in, nil
+}

--- a/internal/benchmark/report/link.go
+++ b/internal/benchmark/report/link.go
@@ -1,0 +1,105 @@
+package report
+
+import (
+	"strings"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// linkSection is link_markdown from scripts/benchmark-link.sh: the section that
+// says which path the numbers were measured over.
+//
+// A result without a link object gets no section at all, which is how a run
+// measured before the probe existed reads.
+func linkSection(b *buf, link *schema.Link) {
+	if link == nil {
+		return
+	}
+	b.line("### The link")
+	b.line("")
+	b.line("| Profile | When | RTT p50 | RTT p90 | Handshake | Control 1 stream | Control N streams | Host load |")
+	b.line("|---|---|---|---|---|---|---|---|")
+	for _, p := range link.Probes {
+		b.line("| %s | %s | %s ms | %s ms | %s ms | %s MiB/s | %s MiB/s | %s |",
+			orDash(p.Profile), orDash(p.At),
+			dash(rtt(p, func(r *schema.RTT) *float64 { return r.P50 })),
+			dash(rtt(p, func(r *schema.RTT) *float64 { return r.P90 })),
+			dash(p.HandshakeMS),
+			dash(control(p, func(c *schema.Control) *float64 { return c.SingleStreamMiBPerS })),
+			dash(control(p, func(c *schema.Control) *float64 { return c.NStreamMiBPerS })),
+			hostLoad(p))
+	}
+	if len(link.Probes) == 0 {
+		b.line("| - | - | - | - | - | - | - | - |")
+		b.line("")
+		b.line("No link probe ran for this result, so the numbers above cannot be told apart from the line they were measured on.")
+	}
+	b.line("")
+	b.line("%s", shapingSentence(link.Shaping))
+	b.line("")
+	b.line("The control measurement uses `x/crypto/ssh` and `pkg/sftp` directly, never easySFTP's uploader. It separates \"the line is slow\" from \"easySFTP is slow\", and a single-stream control close to a scenario's own MiB/s means the run was network bound, where a code delta says nothing.")
+	b.line("")
+}
+
+// shapingSentence distinguishes three states, and conflating the first two is
+// exactly the kind of thing that makes a stored result unreadable a month
+// later: nothing was asked for, something was asked for and could not be done,
+// or it was done.
+func shapingSentence(s schema.Shaping) string {
+	shaped := 0
+	for _, profile := range s.Requested {
+		if strings.ContainsAny(profile, "+/") {
+			shaped++
+		}
+	}
+	switch {
+	case shaped == 0:
+		return "No link shaping was requested: every profile here is the real line."
+	case s.Available:
+		return "Link shaping was available. Requested profiles: " + strings.Join(s.Requested, ", ") +
+			"; applied: " + strings.Join(s.Applied, ", ") + "."
+	default:
+		reason := "unknown"
+		if s.Reason != nil && *s.Reason != "" {
+			reason = *s.Reason
+		}
+		return "Link shaping was **not** available (" + reason + "), so every profile was measured on the real line and the profile names say what was asked for, not what happened."
+	}
+}
+
+func rtt(p schema.Probe, field func(*schema.RTT) *float64) *float64 {
+	if p.RTTMS == nil {
+		return nil
+	}
+	return field(p.RTTMS)
+}
+
+func control(p schema.Probe, field func(*schema.Control) *float64) *float64 {
+	if p.Control == nil {
+		return nil
+	}
+	return field(p.Control)
+}
+
+// hostLoad prints "n/a" where the host's load could not be read at all, which
+// is a different statement from a load of zero.
+//
+// A probe that reports the load as available and then carries no value is the
+// probe contradicting itself, and this prints that rather than hiding it as
+// "n/a": the reader should see the contradiction, not a plausible gap.
+func hostLoad(p schema.Probe) string {
+	if p.HostLoad == nil || !p.HostLoad.Available {
+		return "n/a"
+	}
+	if p.HostLoad.Load1 == nil {
+		return "null"
+	}
+	return num(*p.HostLoad.Load1)
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/benchmark/report/matrix.go
+++ b/internal/benchmark/report/matrix.go
@@ -1,0 +1,391 @@
+package report
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// Matrix is what the sweep's summary needs beyond the measurement: the display
+// strings the script owns and the order it loops in.
+type Matrix struct {
+	Result *schema.Matrix
+
+	CandidateRef  string
+	BaselineRef   string
+	Repeats       int
+	RunnerDisplay string
+	LinkRequested string
+
+	ConnectionsDisplay string
+	ConcurrencyDisplay string
+	RequestDisplay     string
+
+	Labels       []string
+	LinkProfiles []string
+	Scenarios    []MatrixScenario
+
+	Canary      schema.Canary
+	HasBaseline bool
+}
+
+// MatrixScenario is one scenario as the summary prints it: what it is, how it
+// was deployed, and the axis values it was actually swept over.
+type MatrixScenario struct {
+	Name               string
+	Description        string
+	Mode               string
+	ConnectionsDisplay string
+	ConcurrencyDisplay string
+	RequestDisplay     string
+	Connections        []int
+	Concurrency        []int
+	RequestConcurrency []*int
+}
+
+// CSV is matrix.csv: one flat row per cell, which is the file a heatmap or a
+// scaling plot reads. The nested phases and operations stay in the JSON.
+func (m Matrix) CSV() string {
+	var b buf
+	b.line("%s", csvRow(
+		"scenario", "build", "ref", "link_profile", "rtt_p50_ms", "control_single_mib_per_s",
+		"connections", "concurrency", "request_concurrency", "request_concurrency_used", "repeats",
+		"files", "bytes", "median_ms", "min_ms", "max_ms", "mad_ms", "mib_per_s", "files_per_s",
+		"upload_phase_ms", "net_write_bytes", "user_cpu_ms", "sys_cpu_ms", "cpu_percent", "max_rss_bytes", "go_gc_count",
+		"go_peak_goroutines", "connections_opened", "connections_used", "connections_refused",
+		"reconnects", "retries", "errors", "failed_runs"))
+
+	for _, c := range m.Result.Cells {
+		probe := startProbe(m.Result.Link, c.LinkProfile)
+		b.line("%s", csvRow(
+			c.Scenario, c.Label, c.Ref, c.LinkProfile,
+			rttP50(probe), controlSingle(probe),
+			c.Connections, c.Concurrency, c.RequestConcurrency, c.RequestConcurrencyUsed, c.Repeats,
+			c.Files, c.Bytes, c.MedianMS, c.MinMS, c.MaxMS, c.MadMS, c.MiBPerS, c.FilesPerS,
+			c.UploadPhaseMS, c.NetWriteBytes, c.UserCPUMS, c.SysCPUMS, c.CPUPercent, c.MaxRSSBytes, c.GoGCCount,
+			c.GoPeakGoroutines, c.ConnectionsOpened, c.ConnectionsUsed, c.ConnectionsRefused,
+			c.Reconnects, c.Retries, c.Errors, c.FailedRuns))
+	}
+	return b.String()
+}
+
+// Markdown is matrix.md.
+func (m Matrix) Markdown() string {
+	var b buf
+	result := m.Result
+
+	b.line("## easySFTP connections/concurrency matrix")
+	b.line("")
+	b.line("| Setting | Value |")
+	b.line("|---|---|")
+	b.line("| Candidate | `%s` |", m.CandidateRef)
+	b.line("| Baseline | `%s` |", orNone(m.BaselineRef))
+	b.line("| Repeats per cell | %d |", m.Repeats)
+	b.line("| Runner | %s |", m.RunnerDisplay)
+	b.line("| connections | %s |", m.ConnectionsDisplay)
+	b.line("| concurrency | %s |", m.ConcurrencyDisplay)
+	b.line("| request_concurrency | %s |", orDefault(m.RequestDisplay))
+	b.line("| Link profiles | %s |", orRealLine(m.LinkRequested))
+	b.line("| Scenarios | %s |", strings.Join(m.scenarioNames(), " "))
+	b.line("")
+	// What each scenario is, next to the numbers: "sync" and "redeploy" are a
+	// deploy shape and not only a payload, and a MiB/s of theirs is over the few
+	// changed files rather than over the tree.
+	b.line("| Scenario | Mode | Payload | connections | concurrency | request_concurrency |")
+	b.line("|---|---|---|---|---|---|")
+	for _, s := range m.Scenarios {
+		b.line("| `%s` | %s | %s | %s | %s | %s |",
+			s.Name, s.Mode, s.Description, s.ConnectionsDisplay, s.ConcurrencyDisplay, s.RequestDisplay)
+	}
+	b.line("")
+	b.line("The last three columns are the axis values this scenario was swept over, which are not always the ones requested above. A value larger than the payload's file count is the same configuration under another name (only the per-file upload path spreads over connections and workers), and `request_concurrency` is a per-file setting that a payload of small files cannot use at all, so both are capped against the payload rather than measured twice.")
+	b.line("")
+	linkSection(&b, result.Link)
+	b.line("Each grid below is median wall-clock milliseconds: rows are `advanced.connections`, columns are `advanced.concurrency`. Lower is better. `connections > concurrency` is measured, not skipped; easySFTP caps the pool at the concurrency (a connection no worker picks is a handshake for nothing), so those cells are expected to flatten out rather than improve.")
+	b.line("")
+
+	m.grids(&b)
+	m.bestCells(&b)
+	if m.HasBaseline {
+		m.candidateAgainstBaseline(&b)
+	}
+	m.autoCost(&b)
+	m.canary(&b)
+	m.deletes(&b)
+
+	var refused float64
+	for _, c := range result.Cells {
+		refused += stats.Or(c.ConnectionsRefused, 0)
+	}
+	if refused != 0 {
+		b.line("")
+		b.line("**%s connection(s) were refused by the server** across the sweep and fell back to the run's first connection. Those cells had fewer connections than configured, which is the server's limit showing up in the data, not easySFTP's.", num(refused))
+	}
+	b.line("")
+	b.line("Raw data: `matrix.json` (every cell with its own phases and round-trip percentiles, plus the pre-grouped `scaling` view, the `auto` policy runs, the `canary` runs and the `deletes` sweeps), `matrix.csv` (one flat row per cell). Data only: nothing here fails a build.")
+	return b.String()
+}
+
+// grids prints one heatmap per scenario, build, link profile and swept
+// request_concurrency value.
+func (m Matrix) grids(b *buf) {
+	for _, s := range m.Scenarios {
+		for _, label := range m.Labels {
+			for _, profile := range m.LinkProfiles {
+				for _, request := range s.RequestConcurrency {
+					title := "`" + s.Name + "` / " + label + " / " + profile
+					if request != nil {
+						title += " / request_concurrency " + num(float64(*request))
+					}
+					b.line("#### %s", title)
+					b.line("")
+
+					header := "| connections \\ concurrency |"
+					separator := "|---|"
+					for _, conc := range s.Concurrency {
+						header += " " + num(float64(conc)) + " |"
+						separator += "---|"
+					}
+					b.line("%s", header)
+					b.line("%s", separator)
+
+					for _, conns := range s.Connections {
+						row := "| " + num(float64(conns)) + " |"
+						for _, conc := range s.Concurrency {
+							row += " " + m.cellText(s.Name, label, profile, conns, conc, request) + " |"
+						}
+						b.line("%s", row)
+					}
+					b.line("")
+				}
+			}
+		}
+	}
+}
+
+// cellText is one square of a grid: the median, the throughput, and the refused
+// connections where the server turned any down.
+func (m Matrix) cellText(scenario, label, profile string, conns, conc int, request *int) string {
+	for i := range m.Result.Cells {
+		c := &m.Result.Cells[i]
+		if c.Scenario != scenario || c.Label != label || c.LinkProfile != profile {
+			continue
+		}
+		if c.Connections != conns || c.Concurrency != conc {
+			continue
+		}
+		if !sameInt(c.RequestConcurrency, request) {
+			continue
+		}
+		text := num(c.MedianMS) + " ms<br>" + num(c.MiBPerS) + " MiB/s"
+		if stats.Or(c.ConnectionsRefused, 0) > 0 {
+			text += "<br>" + num(*c.ConnectionsRefused) + " refused"
+		}
+		return text
+	}
+	return "-"
+}
+
+func (m Matrix) bestCells(b *buf) {
+	b.line("### Best cell per scenario, build and link profile")
+	b.line("")
+	b.line("| Scenario | Build | Profile | connections | concurrency | request_concurrency | Median | MiB/s | files/s | On an axis edge |")
+	b.line("|---|---|---|---|---|---|---|---|---|---|")
+	for _, s := range m.Result.Scaling {
+		edge := "no"
+		if len(s.BestAtAxisMax) > 0 {
+			edge = strings.Join(s.BestAtAxisMax, ", ")
+		}
+		b.line("| %s | %s | %s | %d | %d | %s | %s ms | %s | %s | %s |",
+			s.Scenario, s.Label, s.LinkProfile, s.Best.Connections, s.Best.Concurrency,
+			requestOrDefault(s.Best.RequestConcurrency), num(s.Best.MedianMS),
+			num(s.Best.MiBPerS), num(s.Best.FilesPerS), edge)
+	}
+	b.line("")
+
+	// The check the auto-config work rests on: a best cell sitting on the
+	// largest value of an axis is a cut-off, not an optimum, and anything fitted
+	// to it extrapolates. Only the upper edge is reported; the lower one is 1
+	// and there is nothing below it to sweep.
+	var cutoff []string
+	for _, s := range m.Result.Scaling {
+		if len(s.BestAtAxisMax) == 0 {
+			continue
+		}
+		cutoff = append(cutoff, s.Scenario+"/"+s.Label+"/"+s.LinkProfile+": "+strings.Join(s.BestAtAxisMax, ", "))
+	}
+	if len(cutoff) > 0 {
+		b.line("**The optimum sits on the edge of the grid** for %s. The best value measured is the largest one swept, so the real optimum is at or beyond it and this sweep does not contain it. Extend that axis before fitting anything to these numbers.", strings.Join(cutoff, "; "))
+	} else {
+		b.line("Every best cell is interior to its axes, so each optimum was measured rather than cut off.")
+	}
+}
+
+// candidateAgainstBaseline prints the worst and the best cell of each scenario
+// and profile.
+//
+// Grouped per profile as well: the worst cell of one profile and the best of
+// another are not two ends of one distribution.
+func (m Matrix) candidateAgainstBaseline(b *buf) {
+	b.line("")
+	b.line("### Candidate against baseline, worst and best cell")
+	b.line("")
+	b.line("| Scenario | Profile | connections | concurrency | Candidate | Baseline | Delta |")
+	b.line("|---|---|---|---|---|---|---|")
+
+	groups := stats.GroupBy(m.Result.Comparison, func(c schema.MatrixCompare) stats.Key {
+		return stats.Key{c.LinkProfile, c.Scenario}
+	})
+	var picked []schema.MatrixCompare
+	for _, group := range groups {
+		sorted := append([]schema.MatrixCompare(nil), group...)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return stats.Or(sorted[i].DeltaPercent, 0) < stats.Or(sorted[j].DeltaPercent, 0)
+		})
+		picked = append(picked, sorted[0], sorted[len(sorted)-1])
+	}
+	// jq's unique_by both deduplicates and sorts, so the rows come out ordered
+	// by their coordinates rather than by which end of a group they came from.
+	stats.SortByKey(picked, func(c schema.MatrixCompare) stats.Key {
+		return stats.Key{c.LinkProfile, c.Scenario, c.Connections, c.Concurrency}
+	})
+	// A group with a single cell contributes that cell as both its worst and its
+	// best, which is where the deduplication earns its keep.
+	seen := map[string]bool{}
+	for _, c := range picked {
+		key := csvRow(c.LinkProfile, c.Scenario, c.Connections, c.Concurrency)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		b.line("| %s | %s | %d | %d | %s ms | %s ms | %s |",
+			c.Scenario, c.LinkProfile, c.Connections, c.Concurrency,
+			num(c.MedianMS), num(c.ReferenceMedianMS), percent(c.DeltaPercent))
+	}
+}
+
+func (m Matrix) autoCost(b *buf) {
+	b.line("")
+	b.line("### What `auto` costs (policy regret)")
+	b.line("")
+	// Through "%s": the sentence carries a literal per cent sign, and vet reads
+	// a bare string here as a format.
+	b.line("%s", "One run per scenario and profile with `connections`, `concurrency` and `request_concurrency` all set to `auto`, on the candidate build, measured next to the cells it is scored against. `Picked` is read out of the run's own counters, so it is what easySFTP did and not what this script assumes; `Best` is the fastest cell of the same scenario and profile. `Regret` is the gap between them: how much slower the policy is than the settings a sweep would have chosen. A policy within ~15% on every profile is defensible, one that only wins on the house line is not (issue #184, phase 5; the policy itself is #156).")
+	b.line("")
+	b.line("| Scenario | Profile | Picked (conn/conc/req) | auto | Best cell | Best | Regret | Same cell in grid |")
+	b.line("|---|---|---|---|---|---|---|---|")
+	for _, a := range m.Result.Auto {
+		best := "-"
+		bestMS := "-"
+		if a.Best != nil {
+			best = num(float64(a.Best.Connections)) + "/" + num(float64(a.Best.Concurrency)) + "/" +
+				requestOrDefault(a.Best.RequestConcurrency)
+			bestMS = num(a.Best.MedianMS) + " ms"
+		}
+		inGrid := "not swept"
+		if a.ChosenInGrid {
+			inGrid = raw(a.ChosenCellMedianMS) + " ms"
+		}
+		b.line("| %s | %s | %s/%s/%s | %s ms | %s | %s | %s | %s |",
+			a.Scenario, a.LinkProfile,
+			raw(a.Chosen.Connections), raw(a.Chosen.Concurrency), raw(a.Chosen.RequestConcurrency),
+			num(a.MedianMS), best, bestMS, percent(a.RegretPercent), inGrid)
+	}
+	b.line("")
+	b.line("The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the `auto` column means the two runs saw different conditions, and then the regret next to it is drift rather than policy. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all.")
+}
+
+func (m Matrix) canary(b *buf) {
+	b.line("")
+	b.line("### Canary")
+	b.line("")
+	b.line("One fixed cell (`%s`, connections %d, concurrency %d, candidate build) measured at the start, the middle and the end of each profile's grid. Spread is the gap between the fastest and the slowest of them. A spread larger than the deltas below it means the server or the line moved during the sweep, and the whole run is a poor comparison basis.",
+		m.Canary.Scenario, m.Canary.Connections, m.Canary.Concurrency)
+	b.line("")
+	b.line("| Profile | Start | Middle | End | Spread |")
+	b.line("|---|---|---|---|---|")
+
+	groups := stats.GroupBy(m.Result.Canary, func(c schema.Canary) stats.Key {
+		return stats.Key{c.LinkProfile}
+	})
+	for _, group := range groups {
+		durations := make([]float64, 0, len(group))
+		for _, c := range group {
+			durations = append(durations, c.DurationMS)
+		}
+		low := stats.Or(stats.Min(stats.Nums(durations)), 0)
+		high := stats.Or(stats.Max(stats.Nums(durations)), 0)
+		spread := "-"
+		if low > 0 {
+			spread = num(math.Round((high-low)/low*100)) + "%"
+		}
+		b.line("| %s | %s | %s | %s | %s |", group[0].LinkProfile,
+			canaryAt(group, "start"), canaryAt(group, "mid"), canaryAt(group, "end"), spread)
+	}
+}
+
+func canaryAt(group []schema.Canary, at string) string {
+	for _, c := range group {
+		if c.At == at {
+			return num(c.DurationMS) + " ms"
+		}
+	}
+	// The middle canary needs a middle to sit in; a grid of a single measured
+	// run per profile only gets a start and an end.
+	return "-"
+}
+
+func (m Matrix) deletes(b *buf) {
+	b.line("")
+	b.line("### Delete sweeps")
+	b.line("")
+	b.line("Every cell's pre-clean wipes the tree the cell before it left behind, at that cell's own `connections`/`concurrency`. It has always run and cost nothing extra; what is new is that it is measured (issue #184, phase 4). Cells whose pre-clean found an empty directory are not listed. Read the two columns on the right against #157: deletions are one round-trip per entry and the pool has nowhere to spread them.")
+	b.line("")
+	b.line("<details><summary>Per-cell delete sweeps</summary>")
+	b.line("")
+	b.line("| Scenario | Build | Profile | conn | conc | Files deleted | Median | files/s | remote_scan | delete_sweep | sftp_remove p50 | sftp_rmdir p50 |")
+	b.line("|---|---|---|---|---|---|---|---|---|---|---|---|")
+	for _, d := range m.Result.Deletes {
+		b.line("| %s | %s | %s | %d | %d | %s | %s ms | %s | %s | %s | %s | %s |",
+			d.Scenario, d.Label, d.LinkProfile, d.Connections, d.Concurrency,
+			num(d.FilesDeleted), num(d.MedianMS), num(d.DeletesPerS),
+			ms(phaseOf(d.Phases, "remote_scan")), ms(phaseOf(d.Phases, "delete_sweep")),
+			ms(opOf(d.Operations, "sftp_remove")), ms(opOf(d.Operations, "sftp_rmdir")))
+	}
+	b.line("")
+	b.line("</details>")
+}
+
+func (m Matrix) scenarioNames() []string {
+	names := make([]string, 0, len(m.Scenarios))
+	for _, s := range m.Scenarios {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+// requestOrDefault prints the pass that sets nothing as "default", which is what
+// it is: easySFTP's own value rather than an axis coordinate.
+func requestOrDefault(v *int) string {
+	if v == nil {
+		return "default"
+	}
+	return num(float64(*v))
+}
+
+func orDefault(s string) string {
+	if s == "" {
+		return "easySFTP default"
+	}
+	return s
+}
+
+func sameInt(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}

--- a/internal/benchmark/report/report.go
+++ b/internal/benchmark/report/report.go
@@ -1,0 +1,116 @@
+// Package report renders a measured benchmark into the files a reader gets:
+// the CSV a plot plots and the Markdown a pull request shows.
+//
+// Everything here is a transcription of what scripts/benchmark.sh and
+// scripts/benchmark-matrix.sh printed with jq, down to the wording and the
+// column order. That is the point of the first Go version (issue #190):
+// improving a table is a separate change, and one made deliberately.
+package report
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// buf is a tiny line-oriented builder, so the code below reads like the shell
+// it replaces: one call per line printed.
+type buf struct {
+	sb strings.Builder
+}
+
+// line writes one line. An empty call is the shell's bare "echo".
+func (b *buf) line(format string, args ...any) {
+	if len(args) > 0 {
+		fmt.Fprintf(&b.sb, format, args...)
+	} else {
+		b.sb.WriteString(format)
+	}
+	b.sb.WriteByte('\n')
+}
+
+func (b *buf) String() string { return b.sb.String() }
+
+// num renders a number the way jq interpolates one.
+func num(f float64) string { return stats.Format(f) }
+
+// dash renders a nullable number, or "-" when it is null, which is what the
+// Markdown tables print where they guard against a null.
+func dash(f *float64) string { return stats.FormatOr(f, "-") }
+
+// raw renders a nullable number the way jq's bare string interpolation does,
+// which prints an unguarded null as the word "null".
+//
+// Several tables interpolate a metric without a guard, and a run whose metrics
+// file never appeared reaches them. Printing "null" there is deliberate: it is
+// what the stored results contain, and a "-" would be this rewrite quietly
+// changing a document while claiming to reproduce it.
+func raw(f *float64) string { return stats.FormatOr(f, "null") }
+
+// ms renders a nullable duration as jq's "if . == null then \"-\" else \"\(.) ms\"".
+func ms(f *float64) string {
+	if f == nil {
+		return "-"
+	}
+	return num(*f) + " ms"
+}
+
+// percent renders a delta the way both summaries do: an explicit plus sign on a
+// regression, and "-" where there is no reference to compare against.
+func percent(p *float64) string {
+	if p == nil {
+		return "-"
+	}
+	sign := ""
+	if *p > 0 {
+		sign = "+"
+	}
+	return sign + num(*p) + "%"
+}
+
+// mib renders a byte count as jq's "((x / 1048576) * 10 | round / 10)".
+func mib(bytes float64) string { return num(stats.Round1(bytes / 1048576)) }
+
+// mibOf is mib for a nullable byte count. A null renders as "-" rather than as
+// a zero, because a metric that did not exist yet is not a measurement of zero.
+func mibOf(bytes *float64) string {
+	if bytes == nil {
+		return "-"
+	}
+	return mib(*bytes)
+}
+
+// csvRow renders one row the way jq's @csv does: strings quoted with inner
+// quotes doubled, numbers bare, and null as an empty field.
+func csvRow(fields ...any) string {
+	out := make([]string, 0, len(fields))
+	for _, field := range fields {
+		switch value := field.(type) {
+		case nil:
+			out = append(out, "")
+		case string:
+			out = append(out, `"`+strings.ReplaceAll(value, `"`, `""`)+`"`)
+		case *float64:
+			if value == nil {
+				out = append(out, "")
+			} else {
+				out = append(out, num(*value))
+			}
+		case *int:
+			if value == nil {
+				out = append(out, "")
+			} else {
+				out = append(out, strconv.Itoa(*value))
+			}
+		case float64:
+			out = append(out, num(value))
+		case int:
+			out = append(out, strconv.Itoa(value))
+		default:
+			out = append(out, fmt.Sprint(value))
+		}
+	}
+	return strings.Join(out, ",")
+}

--- a/internal/benchmark/report/standard.go
+++ b/internal/benchmark/report/standard.go
@@ -1,0 +1,288 @@
+package report
+
+import (
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// Standard is what the summary of a standard run needs beyond the measurement
+// itself: the display strings the script owns and the order it loops in.
+type Standard struct {
+	Result *schema.Standard
+
+	CandidateRef  string
+	BaselineRef   string
+	Repeats       int
+	RunnerDisplay string
+	LinkRequested string
+	Settings      string
+
+	Labels       []string
+	Scenarios    []string
+	LinkProfiles []string
+}
+
+// CSV is results.csv: one flat row per (build, scenario), so a spreadsheet or a
+// plot can read a stored result without a JSON parser.
+//
+// link_profile, rtt_p50_ms and control_single_mib_per_s make a row readable on
+// its own: without them a throughput number cannot be told apart from the line
+// it was measured on. The two link numbers come from the profile's own start
+// probe, which is the one taken right before these runs.
+func (s Standard) CSV() string {
+	var b buf
+	b.line("%s", csvRow(
+		"scenario", "build", "ref", "link_profile", "rtt_p50_ms", "control_single_mib_per_s",
+		"repeats", "files", "bytes", "median_ms", "min_ms", "max_ms", "mad_ms",
+		"mib_per_s", "files_per_s", "user_cpu_ms", "sys_cpu_ms", "cpu_percent", "max_rss_bytes",
+		"go_gc_count", "go_peak_goroutines", "net_write_bytes", "connections_opened", "connections_refused",
+		"retries", "errors", "failed_runs"))
+
+	for _, row := range s.Result.Results {
+		probe := startProbe(s.Result.Link, row.LinkProfile)
+		p := row.Process
+		if p == nil {
+			p = &schema.Process{}
+		}
+		b.line("%s", csvRow(
+			row.Scenario, row.Label, row.Ref, row.LinkProfile,
+			rttP50(probe), controlSingle(probe),
+			row.Repeats, row.Files, row.Bytes, row.MedianMS, row.MinMS, row.MaxMS, row.MadMS,
+			row.MiBPerS, row.FilesPerS, p.UserCPUMS, p.SysCPUMS, p.CPUPercent,
+			p.MaxRSSBytes, p.GoGCCount, p.GoPeakGoroutines, p.NetWriteBytes,
+			counter(row.Counters, "connections_opened"), counter(row.Counters, "connections_refused"),
+			row.Retries, row.Errors, row.FailedRuns))
+	}
+	return b.String()
+}
+
+// Markdown is summary.md: the same numbers, readable.
+func (s Standard) Markdown() string {
+	var b buf
+	result := s.Result
+
+	b.line("## easySFTP benchmark")
+	b.line("")
+	b.line("| Setting | Value |")
+	b.line("|---|---|")
+	b.line("| Candidate | `%s` |", s.CandidateRef)
+	b.line("| Baseline | `%s` |", orNone(s.BaselineRef))
+	b.line("| Repeats per scenario | %d |", s.Repeats)
+	b.line("| Runner | %s |", s.RunnerDisplay)
+	b.line("| Link profiles | %s |", orRealLine(s.LinkRequested))
+	b.line("| Settings | %s |", s.Settings)
+	b.line("")
+	linkSection(&b, result.Link)
+
+	b.line("### Throughput")
+	b.line("")
+	b.line("| Scenario | Build | Profile | Files | Size | Median | Min | Max | MAD | MiB/s | files/s | Retries | Errors | Failed runs | Delta |")
+	b.line("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|")
+	// Looped in the script's own order rather than in the aggregation's, so the
+	// table reads scenario by scenario. A combination that was not measured
+	// prints no row at all.
+	s.each(func(row *schema.Result) {
+		b.line("| %s | %s | %s | %s | %s MiB | %s ms | %s ms | %s ms | %s | %s | %s | %s | %s | %d | %s |",
+			row.Scenario, row.Label, row.LinkProfile, num(row.Files), mib(row.Bytes),
+			num(row.MedianMS), num(row.MinMS), num(row.MaxMS), ms(row.MadMS),
+			num(row.MiBPerS), num(row.FilesPerS), num(row.Retries), num(row.Errors), row.FailedRuns,
+			percent(deltaOf(result.Comparison, row)))
+	})
+	b.line("")
+	b.line("Delta compares each build's median against the `%s` build **on the same link profile**; negative is faster. MAD is the median absolute deviation of the repeats: a delta smaller than it is inside this host's own noise.", result.ReferenceLabel)
+	b.line("")
+	b.line("### Resources (median per run)")
+	b.line("")
+	b.line("%s", "| Scenario | Build | Profile | User CPU | Sys CPU | CPU % | Peak RSS | Go allocs | GCs | GC pause | Peak goroutines | Net sent |")
+	b.line("|---|---|---|---|---|---|---|---|---|---|---|---|")
+	s.each(func(row *schema.Result) {
+		p := row.Process
+		if p == nil {
+			p = &schema.Process{}
+		}
+		b.line("| %s | %s | %s | %s ms | %s ms | %s%% | %s MiB | %s MiB | %s | %s ms | %s | %s MiB |",
+			row.Scenario, row.Label, row.LinkProfile,
+			raw(p.UserCPUMS), raw(p.SysCPUMS), raw(p.CPUPercent),
+			mibOf(p.MaxRSSBytes), mibOf(p.GoTotalAllocBytes), raw(p.GoGCCount),
+			raw(p.GoGCPauseTotalMS), raw(p.GoPeakGoroutines), mibOf(p.NetWriteBytes))
+	})
+
+	b.line("")
+	b.line("### Where the time goes")
+	b.line("")
+	b.line("Phases are wall clock and add up to roughly the run's duration. Operation totals are **cumulative across parallel workers** and are normally larger than the phase they belong to; read them for their share and their per-call cost, never as wall clock.")
+	b.line("")
+	for _, scenario := range s.Scenarios {
+		b.line("<details><summary><code>%s</code> phases and round-trips</summary>", scenario)
+		b.line("")
+		b.line("| Build | Profile | Phase | Wall |")
+		b.line("|---|---|---|---|")
+		for _, row := range result.Results {
+			if row.Scenario != scenario {
+				continue
+			}
+			for _, phase := range row.Phases {
+				if phase.MedianMS <= 0 {
+					continue
+				}
+				b.line("| %s | %s | %s | %s ms |", row.Label, row.LinkProfile, phase.Name, num(phase.MedianMS))
+			}
+		}
+		b.line("")
+		b.line("| Build | Profile | Operation | Count | Cumulative | Avg | p50 | p90 | p99 | Max |")
+		b.line("|---|---|---|---|---|---|---|---|---|---|")
+		for _, row := range result.Results {
+			if row.Scenario != scenario {
+				continue
+			}
+			for _, op := range row.Operations {
+				if stats.Or(op.Count, 0) <= 0 {
+					continue
+				}
+				b.line("| %s | %s | %s | %s | %s ms | %s ms | %s ms | %s ms | %s ms | %s ms |",
+					row.Label, row.LinkProfile, op.Name, raw(op.Count), raw(op.MedianTotalMS),
+					raw(op.AvgMS), raw(op.P50MS), raw(op.P90MS), raw(op.P99MS), raw(op.MaxMS))
+			}
+		}
+		b.line("")
+		b.line("</details>")
+		b.line("")
+	}
+
+	b.line("### Delete sweeps")
+	b.line("")
+	b.line("The pre-clean before every measured run wipes the tree the previous repeat left behind, which makes it a pure delete sweep. It costs no extra time (it has always run) and its numbers never enter the upload tables above. Sweeps that found an empty directory are not counted.")
+	b.line("")
+	b.line("| Scenario | Build | Profile | Sweeps | Files deleted | Median | files/s | remote_scan | delete_sweep |")
+	b.line("|---|---|---|---|---|---|---|---|---|")
+	for _, d := range result.Deletes {
+		b.line("| %s | %s | %s | %d | %s | %s ms | %s | %s | %s |",
+			d.Scenario, d.Label, d.LinkProfile, d.Sweeps, num(d.FilesDeleted),
+			num(d.MedianMS), num(d.DeletesPerS),
+			ms(phaseOf(d.Phases, "remote_scan")), ms(phaseOf(d.Phases, "delete_sweep")))
+	}
+	b.line("")
+	b.line("| Scenario | Build | Profile | Operation | Count | Cumulative | p50 | p90 | p99 | Max |")
+	b.line("|---|---|---|---|---|---|---|---|---|---|")
+	// sftp_remove and sftp_rmdir are the numbers issue #157 is about: one
+	// round-trip per entry, strictly sequential, no concurrency anywhere near
+	// them.
+	for _, d := range result.Deletes {
+		for _, op := range d.Operations {
+			if stats.Or(op.Count, 0) <= 0 {
+				continue
+			}
+			b.line("| %s | %s | %s | %s | %s | %s ms | %s ms | %s ms | %s ms | %s ms |",
+				d.Scenario, d.Label, d.LinkProfile, op.Name, raw(op.Count), raw(op.MedianTotalMS),
+				raw(op.P50MS), raw(op.P90MS), raw(op.P99MS), raw(op.MaxMS))
+		}
+	}
+	b.line("")
+
+	// Without this line a pool run whose extra connections the server refused
+	// reads as "the pool did nothing", which is the wrong conclusion entirely.
+	var refused float64
+	for _, row := range result.Results {
+		refused += stats.Or(row.RefusedConnections, 0)
+	}
+	if refused != 0 {
+		b.line("**%s connection(s) were refused by the server** and fell back to the run's first connection, so a pool build measured here had fewer connections than configured.", num(refused))
+		b.line("")
+	}
+	b.line("Data only: these numbers set no threshold and fail no build. Collected to evaluate the single-connection ceiling discussed in issue #158 and to show where a run spends its time.")
+	return b.String()
+}
+
+// each walks the results in the script's loop order: scenario, then build, then
+// link profile.
+func (s Standard) each(fn func(*schema.Result)) {
+	for _, scenario := range s.Scenarios {
+		for _, label := range s.Labels {
+			for _, profile := range s.LinkProfiles {
+				for i := range s.Result.Results {
+					row := &s.Result.Results[i]
+					if row.Scenario == scenario && row.Label == label && row.LinkProfile == profile {
+						fn(row)
+					}
+				}
+			}
+		}
+	}
+}
+
+// deltaOf finds a row's entry in comparison[]. The reference build has none,
+// and its Delta column is then "-".
+func deltaOf(comparisons []schema.Comparison, row *schema.Result) *float64 {
+	for _, c := range comparisons {
+		if c.Scenario == row.Scenario && c.Label == row.Label && c.LinkProfile == row.LinkProfile {
+			return c.DeltaPercent
+		}
+	}
+	return nil
+}
+
+func phaseOf(phases []schema.Phase, name string) *float64 {
+	for _, p := range phases {
+		if p.Name == name {
+			value := p.MedianMS
+			return &value
+		}
+	}
+	return nil
+}
+
+func opOf(ops []schema.Operation, name string) *float64 {
+	for _, o := range ops {
+		if o.Name == name {
+			return o.P50MS
+		}
+	}
+	return nil
+}
+
+func counter(c schema.Counters, name string) float64 {
+	if c == nil {
+		return 0
+	}
+	return stats.Or(c[name], 0)
+}
+
+func startProbe(link *schema.Link, profile string) *schema.Probe {
+	if link == nil {
+		return nil
+	}
+	for i := range link.Probes {
+		if link.Probes[i].Profile == profile && link.Probes[i].At == "start" {
+			return &link.Probes[i]
+		}
+	}
+	return nil
+}
+
+func rttP50(p *schema.Probe) *float64 {
+	if p == nil || p.RTTMS == nil {
+		return nil
+	}
+	return p.RTTMS.P50
+}
+
+func controlSingle(p *schema.Probe) *float64 {
+	if p == nil || p.Control == nil {
+		return nil
+	}
+	return p.Control.SingleStreamMiBPerS
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "none"
+	}
+	return s
+}
+
+func orRealLine(s string) string {
+	if s == "" {
+		return "the real line"
+	}
+	return s
+}

--- a/internal/benchmark/schema/fixtures_test.go
+++ b/internal/benchmark/schema/fixtures_test.go
@@ -1,0 +1,188 @@
+package schema_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// benchmarksDir is the repository's own stored results, used here as fixtures.
+//
+// They are the reason this package exists: "current stored results remain
+// readable" is an acceptance criterion of issue #190, and the only way to keep
+// it true while the types move is to decode every file that is actually
+// committed, strictly, on every test run.
+func benchmarksDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(filepath.Join("..", "..", "..", "benchmarks"))
+	if err != nil {
+		t.Fatalf("locating benchmarks/: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("benchmarks/ is not readable: %v", err)
+	}
+	return dir
+}
+
+// storedResults lists every stored result pair, latest.json included. The two
+// top-level exports (index.json and trend.csv) are not results and are checked
+// separately.
+func storedResults(t *testing.T) []string {
+	t.Helper()
+	root := benchmarksDir(t)
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		if filepath.Base(path) == "index.json" {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking benchmarks/: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no stored results found; the fixture test would pass vacuously")
+	}
+	return files
+}
+
+func TestStoredResultsDecodeStrictly(t *testing.T) {
+	for _, path := range storedResults(t) {
+		t.Run(name(t, path), func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("reading: %v", err)
+			}
+			env, err := schema.DecodeStrict[schema.Envelope](data)
+			if err != nil {
+				t.Fatalf("decoding the envelope: %v", err)
+			}
+			if err := env.Validate(); err != nil {
+				t.Fatalf("validating: %v", err)
+			}
+		})
+	}
+}
+
+// TestStoredResultsSurviveARoundTrip is the other half of strict decoding: a
+// type may cover every stored field and still lose data, by dropping a null or
+// by turning one into a zero. Re-encoding and comparing the decoded values
+// catches that, which matters because step 4 of issue #190 will have the store
+// rewrite index.json from these types.
+func TestStoredResultsSurviveARoundTrip(t *testing.T) {
+	for _, path := range storedResults(t) {
+		t.Run(name(t, path), func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("reading: %v", err)
+			}
+			env, err := schema.DecodeStrict[schema.Envelope](data)
+			if err != nil {
+				t.Fatalf("decoding the envelope: %v", err)
+			}
+			kind, err := env.BenchmarkKind()
+			if err != nil {
+				t.Fatalf("reading the benchmark kind: %v", err)
+			}
+
+			switch kind {
+			case schema.BenchmarkMatrix:
+				m, err := env.Matrix()
+				if err != nil {
+					t.Fatalf("decoding: %v", err)
+				}
+				assertRoundTrip(t, env.Benchmark, m)
+			default:
+				s, err := env.Standard()
+				if err != nil {
+					t.Fatalf("decoding: %v", err)
+				}
+				assertRoundTrip(t, env.Benchmark, s)
+			}
+		})
+	}
+}
+
+func TestStoredIndexDecodesStrictly(t *testing.T) {
+	path := filepath.Join(benchmarksDir(t), "index.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading index.json: %v", err)
+	}
+	index, err := schema.DecodeStrict[schema.Index](data)
+	if err != nil {
+		t.Fatalf("decoding index.json: %v", err)
+	}
+	if index.SchemaVersion != schema.IndexSchemaVersion {
+		t.Errorf("index schema_version = %d, want %d", index.SchemaVersion, schema.IndexSchemaVersion)
+	}
+	if len(index.Entries) == 0 {
+		t.Fatal("index.json lists no entries")
+	}
+
+	// Every entry must point at a file that is on disk: the index is
+	// regenerated in full on every store precisely so it describes what is
+	// there, and a dangling path means it does not.
+	root := benchmarksDir(t)
+	for _, e := range index.Entries {
+		for _, rel := range []string{e.JSON, e.Markdown} {
+			if rel == "" {
+				t.Errorf("%s: an entry has no path", e.RecordedAt)
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+				t.Errorf("%s: %v", e.RecordedAt, err)
+			}
+		}
+		if e.CSV != nil {
+			if _, err := os.Stat(filepath.Join(root, *e.CSV)); err != nil {
+				t.Errorf("%s: %v", e.RecordedAt, err)
+			}
+		}
+		// A matrix entry reports a best cell per scenario and a standard one a
+		// median per scenario. Neither fills the other's map, because the two
+		// are different numbers.
+		if e.BenchmarkKind == schema.BenchmarkMatrix && len(e.MedianMS) > 0 {
+			t.Errorf("%s: a matrix entry must not report median_ms", e.RecordedAt)
+		}
+		if e.BenchmarkKind != schema.BenchmarkMatrix && len(e.BestMS) > 0 {
+			t.Errorf("%s: a standard entry must not report best_ms", e.RecordedAt)
+		}
+	}
+}
+
+// TestLatestIsCopiedFromARelease pins the invariant the whole store rests on:
+// latest.* is only ever a copy of an official release result.
+func TestLatestIsCopiedFromARelease(t *testing.T) {
+	root := benchmarksDir(t)
+	data, err := os.ReadFile(filepath.Join(root, "latest.json"))
+	if err != nil {
+		t.Fatalf("reading latest.json: %v", err)
+	}
+	env, err := schema.DecodeStrict[schema.Envelope](data)
+	if err != nil {
+		t.Fatalf("decoding latest.json: %v", err)
+	}
+	if env.Kind != schema.KindRelease || !env.Official {
+		t.Fatalf("latest.json is kind %q, official %v; want an official release", env.Kind, env.Official)
+	}
+}
+
+func name(t *testing.T, path string) string {
+	t.Helper()
+	rel, err := filepath.Rel(benchmarksDir(t), path)
+	if err != nil {
+		return filepath.Base(path)
+	}
+	return strings.ReplaceAll(filepath.ToSlash(rel), "/", "_")
+}

--- a/internal/benchmark/schema/index.go
+++ b/internal/benchmark/schema/index.go
@@ -1,0 +1,56 @@
+package schema
+
+// IndexSchemaVersion is the current version of benchmarks/index.json.
+const IndexSchemaVersion = 2
+
+// Index is benchmarks/index.json: every stored result, newest first, with
+// enough of each one that a reader does not have to open every file.
+//
+// It is regenerated in full on every store, so it always describes what is
+// actually on disk.
+type Index struct {
+	SchemaVersion int               `json:"schema_version"`
+	GeneratedAt   string            `json:"generated_at"`
+	GeneratedBy   string            `json:"generated_by"`
+	Documentation string            `json:"documentation"`
+	Layout        map[string]string `json:"layout"`
+	KeepReleases  int               `json:"keep_releases"`
+	LatestRelease *string           `json:"latest_release"`
+	Entries       []IndexEntry      `json:"entries"`
+}
+
+// IndexEntry is one stored result as the index lists it.
+//
+// MedianMS carries the candidate's median per scenario for a standard result
+// and BestMS the best cell per scenario for a matrix one. Each kind fills its
+// own and leaves the other empty, because the two are not the same number and a
+// single field would invite reading them as one.
+type IndexEntry struct {
+	Kind         string  `json:"kind"`
+	Version      *string `json:"version"`
+	Label        *string `json:"label"`
+	Official     bool    `json:"official"`
+	RecordedAt   string  `json:"recorded_at"`
+	Commit       string  `json:"commit"`
+	RunURL       string  `json:"run_url"`
+	CandidateRef string  `json:"candidate_ref"`
+
+	BenchmarkKind          string       `json:"benchmark_kind"`
+	BenchmarkSchemaVersion int          `json:"benchmark_schema_version"`
+	Runner                 string       `json:"runner"`
+	Environment            *Environment `json:"environment"`
+
+	// LinkProfiles and RTTP50MS keep a chart from reading a slower line as a
+	// slower release. RTTP50MS is the baseline profile's probed value and is
+	// null for results measured before the probe existed.
+	LinkProfiles []string `json:"link_profiles"`
+	RTTP50MS     *float64 `json:"rtt_p50_ms"`
+
+	Archived bool    `json:"archived"`
+	JSON     string  `json:"json"`
+	Markdown string  `json:"markdown"`
+	CSV      *string `json:"csv,omitzero"`
+
+	MedianMS map[string]float64 `json:"median_ms"`
+	BestMS   map[string]float64 `json:"best_ms"`
+}

--- a/internal/benchmark/schema/link.go
+++ b/internal/benchmark/schema/link.go
@@ -1,0 +1,121 @@
+package schema
+
+import "encoding/json"
+
+// UnmarshalJSON keeps the document as it was read, alongside the fields the
+// reports need.
+func (p *Probe) UnmarshalJSON(data []byte) error {
+	type probe Probe // avoids recursing into this method
+	var fields probe
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*p = Probe(fields)
+	p.raw = append(json.RawMessage(nil), data...)
+	return nil
+}
+
+// MarshalJSON writes the document back exactly as it arrived.
+//
+// A probe is a measurement taken by another program, and a result stores it
+// verbatim. Re-encoding it from the fields above would silently drop anything
+// cmd/linkprobe reports that this package does not model, and would rewrite the
+// numbers it does model: a probe that measured a load of "1.0" would come back
+// as "1", which is the same value and a different document. A reader comparing
+// a stored probe against the probe output it came from should find them equal.
+func (p Probe) MarshalJSON() ([]byte, error) {
+	if len(p.raw) > 0 {
+		return p.raw, nil
+	}
+	type probe Probe
+	return json.Marshal(probe(p))
+}
+
+// Link is the network path a result was measured over (issue #184, phase 1).
+//
+// It is a measurement and varies from run to run by design, which is why it
+// sits next to Environment rather than inside it: Environment is the
+// comparability key, Link is data. An absent Link, or one with an empty probe
+// list, means no probe binary was available for that run. That is honest and
+// readable; an invented entry would not be.
+type Link struct {
+	// Iface is the interface towards the server, null when unknown.
+	Iface   *string `json:"iface"`
+	Shaping Shaping `json:"shaping"`
+	Probes  []Probe `json:"probes"`
+	Note    string  `json:"note,omitzero"`
+}
+
+// Shaping records what tc was asked for and what it managed to do. Shaping that
+// is unavailable is recorded, never fatal: the run then measures every profile
+// on the real line, and the profile names say what was asked for rather than
+// what happened.
+type Shaping struct {
+	Available bool     `json:"available"`
+	Reason    *string  `json:"reason"`
+	Requested []string `json:"requested"`
+	Applied   []string `json:"applied"`
+}
+
+// Probe is one link measurement, taken before or after a profile's own runs.
+//
+// It comes from cmd/linkprobe, which uses x/crypto/ssh and pkg/sftp directly
+// and imports nothing from internal/uploader: a control taken through the code
+// under test would not be a control. The document never names the host or the
+// user, because it lands in results.json, which is an artifact and is committed.
+//
+// A probe document is stored whole: the fields below exist so a report can read
+// an RTT out of one, not so the document can be rebuilt from them. See
+// MarshalJSON.
+type Probe struct {
+	// raw is the document exactly as it was read, and what MarshalJSON writes
+	// back.
+	raw json.RawMessage
+
+	Profile string `json:"profile"`
+
+	// At is "start" or "end" of that profile's own runs. Two probes of the same
+	// profile are comparable, which is what makes drift over a multi-hour sweep
+	// visible. Two probes of different profiles are not.
+	At string `json:"at"`
+
+	SchemaVersion int    `json:"schema_version,omitzero"`
+	Note          string `json:"note,omitzero"`
+	MeasuredAt    string `json:"measured_at,omitzero"`
+
+	HandshakeMS *float64  `json:"handshake_ms"`
+	RTTMS       *RTT      `json:"rtt_ms"`
+	Control     *Control  `json:"control"`
+	HostLoad    *HostLoad `json:"host_load"`
+	Errors      []string  `json:"errors"`
+}
+
+// RTT is the round-trip time of N sequential no-op SFTP requests.
+type RTT struct {
+	P50     *float64 `json:"p50"`
+	P90     *float64 `json:"p90"`
+	Min     *float64 `json:"min"`
+	Max     *float64 `json:"max"`
+	Samples int      `json:"samples"`
+}
+
+// Control is the throughput measurement that does not involve easySFTP.
+// Without it, "easySFTP is slow" and "the line is slow" are indistinguishable.
+type Control struct {
+	Streams             int      `json:"streams"`
+	Bytes               int64    `json:"bytes"`
+	SingleStreamMiBPerS *float64 `json:"single_stream_mib_per_s"`
+	NStreamMiBPerS      *float64 `json:"n_stream_mib_per_s"`
+	Note                string   `json:"note,omitzero"`
+}
+
+// HostLoad is the SFTP host's own load where it is reachable. A fixed server is
+// not a constant server, and a matrix run takes hours.
+type HostLoad struct {
+	Available bool     `json:"available"`
+	Method    string   `json:"method,omitzero"`
+	Reason    string   `json:"reason,omitzero"`
+	Load1     *float64 `json:"load1,omitzero"`
+	Load5     *float64 `json:"load5,omitzero"`
+	Load15    *float64 `json:"load15,omitzero"`
+}

--- a/internal/benchmark/schema/matrix.go
+++ b/internal/benchmark/schema/matrix.go
@@ -1,0 +1,235 @@
+package schema
+
+// MatrixSchemaVersion is the current version of a matrix measurement.
+const MatrixSchemaVersion = 2
+
+// Matrix is matrix.json: the sweep scripts/benchmark-matrix.sh produces.
+//
+// A matrix run has no runs[]. Its cell is the finest grain it keeps, which is
+// why the cell itself carries phases and round-trip percentiles rather than
+// only the upload_phase_ms it used to (issue #184, phase 2).
+type Matrix struct {
+	SchemaVersion  int               `json:"schema_version,omitzero"`
+	BenchmarkKind  string            `json:"benchmark_kind,omitzero"`
+	CandidateRef   string            `json:"candidate_ref"`
+	BaselineRef    string            `json:"baseline_ref"`
+	ReferenceLabel string            `json:"reference_label"`
+	Repeats        int               `json:"repeats"`
+	Runner         string            `json:"runner"`
+	Environment    *Environment      `json:"environment,omitzero"`
+	Link           *Link             `json:"link,omitzero"`
+	Canary         []Canary          `json:"canary,omitzero"`
+	Settings       string            `json:"settings"`
+	Scenarios      map[string]string `json:"scenarios"`
+	Note           string            `json:"note,omitzero"`
+
+	Axes       Axes            `json:"axes"`
+	Cells      []Cell          `json:"cells"`
+	Deletes    []MatrixDelete  `json:"deletes,omitzero"`
+	Scaling    []Scaling       `json:"scaling"`
+	Auto       []Auto          `json:"auto,omitzero"`
+	Comparison []MatrixCompare `json:"comparison"`
+}
+
+// Axes is the grid as requested, plus what each scenario was actually measured
+// over. The two are kept apart on purpose: a cell missing from the declared
+// grid was not skipped, it would have been the same configuration twice
+// (issue #184, phase 5).
+type Axes struct {
+	LinkProfiles       []string                `json:"link_profiles"`
+	Connections        []int                   `json:"connections"`
+	Concurrency        []int                   `json:"concurrency"`
+	RequestConcurrency []*int                  `json:"request_concurrency"`
+	PerScenario        map[string]ScenarioAxes `json:"per_scenario,omitzero"`
+}
+
+// ScenarioAxes is one scenario's own grid, and the file count both axes were
+// capped against.
+//
+// A null in RequestConcurrency is the pass that sets nothing and leaves
+// easySFTP its own value.
+type ScenarioAxes struct {
+	Files              int    `json:"files"`
+	Connections        []int  `json:"connections"`
+	Concurrency        []int  `json:"concurrency"`
+	RequestConcurrency []*int `json:"request_concurrency"`
+}
+
+// Cell is one row per (link profile, scenario, build, connections, concurrency,
+// request_concurrency).
+type Cell struct {
+	Scenario    string `json:"scenario"`
+	Label       string `json:"label"`
+	Ref         string `json:"ref"`
+	LinkProfile string `json:"link_profile,omitzero"`
+	Connections int    `json:"connections"`
+	Concurrency int    `json:"concurrency"`
+
+	// RequestConcurrency is the coordinate that was asked for, null on the pass
+	// that sets nothing. RequestConcurrencyUsed is what the run actually ran
+	// with, read back from its own counters, because that null alone does not
+	// say which value it was.
+	RequestConcurrency *int `json:"request_concurrency"`
+
+	Repeats     int       `json:"repeats"`
+	FailedRuns  int       `json:"failed_runs"`
+	Files       float64   `json:"files"`
+	Bytes       float64   `json:"bytes"`
+	DurationsMS []float64 `json:"durations_ms"`
+	MedianMS    float64   `json:"median_ms"`
+	MinMS       float64   `json:"min_ms"`
+	MaxMS       float64   `json:"max_ms"`
+	MadMS       *float64  `json:"mad_ms"`
+	Retries     float64   `json:"retries"`
+	Errors      float64   `json:"errors"`
+
+	UserCPUMS              *float64 `json:"user_cpu_ms"`
+	SysCPUMS               *float64 `json:"sys_cpu_ms"`
+	CPUPercent             *float64 `json:"cpu_percent"`
+	MaxRSSBytes            *float64 `json:"max_rss_bytes"`
+	GoGCCount              *float64 `json:"go_gc_count"`
+	GoPeakGoroutines       *float64 `json:"go_peak_goroutines"`
+	NetWriteBytes          *float64 `json:"net_write_bytes"`
+	ConnectionsOpened      *float64 `json:"connections_opened"`
+	ConnectionsUsed        *float64 `json:"connections_used"`
+	RequestConcurrencyUsed *float64 `json:"request_concurrency_used"`
+	ConnectionsRefused     *float64 `json:"connections_refused"`
+	Reconnects             *float64 `json:"reconnects"`
+	UploadPhaseMS          *float64 `json:"upload_phase_ms"`
+
+	Phases     []Phase     `json:"phases"`
+	Operations []Operation `json:"operations"`
+
+	MiBPerS   float64 `json:"mib_per_s"`
+	FilesPerS float64 `json:"files_per_s"`
+}
+
+// MatrixDelete is a delete sweep at a cell's coordinates.
+type MatrixDelete struct {
+	Scenario           string `json:"scenario"`
+	Label              string `json:"label"`
+	LinkProfile        string `json:"link_profile"`
+	Connections        int    `json:"connections"`
+	Concurrency        int    `json:"concurrency"`
+	RequestConcurrency *int   `json:"request_concurrency"`
+	DeleteStats
+}
+
+// Scaling is the cells of one (link profile, scenario, build) pre-grouped into
+// the curve a reader usually wants, ordered along the axes.
+type Scaling struct {
+	Scenario    string  `json:"scenario"`
+	Label       string  `json:"label"`
+	LinkProfile string  `json:"link_profile,omitzero"`
+	Points      []Point `json:"points"`
+	Best        Best    `json:"best"`
+
+	// BestAtAxisMax names the axes whose largest swept value is the best cell.
+	// Where it is non-empty the optimum was cut off rather than measured, and
+	// anything fitted to those numbers extrapolates.
+	BestAtAxisMax []string `json:"best_at_axis_max,omitzero"`
+}
+
+// Point is one cell reduced to what a scaling curve plots.
+type Point struct {
+	Connections            int      `json:"connections"`
+	Concurrency            int      `json:"concurrency"`
+	RequestConcurrency     *int     `json:"request_concurrency"`
+	RequestConcurrencyUsed *float64 `json:"request_concurrency_used"`
+	MedianMS               float64  `json:"median_ms"`
+	MiBPerS                float64  `json:"mib_per_s"`
+	FilesPerS              float64  `json:"files_per_s"`
+	ConnectionsUsed        *float64 `json:"connections_used"`
+	ConnectionsRefused     *float64 `json:"connections_refused"`
+	MaxRSSBytes            *float64 `json:"max_rss_bytes"`
+	UserCPUMS              *float64 `json:"user_cpu_ms"`
+}
+
+// Best is the fastest cell of a group.
+type Best struct {
+	Connections        int     `json:"connections"`
+	Concurrency        int     `json:"concurrency"`
+	RequestConcurrency *int    `json:"request_concurrency"`
+	MedianMS           float64 `json:"median_ms"`
+	MiBPerS            float64 `json:"mib_per_s"`
+	FilesPerS          float64 `json:"files_per_s"`
+}
+
+// Auto is the settings easySFTP picked for itself, scored against the best cell
+// of the same scenario and link profile (issue #184, phase 5).
+//
+// It is not a cell: auto chooses a coordinate rather than sitting at one, which
+// is why it stays out of cells[], scaling[], comparison[] and the CSV.
+type Auto struct {
+	Scenario    string `json:"scenario"`
+	Label       string `json:"label"`
+	Ref         string `json:"ref"`
+	LinkProfile string `json:"link_profile"`
+
+	Repeats     int       `json:"repeats"`
+	FailedRuns  int       `json:"failed_runs"`
+	Files       float64   `json:"files"`
+	Bytes       float64   `json:"bytes"`
+	DurationsMS []float64 `json:"durations_ms"`
+	MedianMS    float64   `json:"median_ms"`
+	MinMS       float64   `json:"min_ms"`
+	MaxMS       float64   `json:"max_ms"`
+	MadMS       *float64  `json:"mad_ms"`
+
+	// Chosen is read back from the run's own counters, so it says what easySFTP
+	// did rather than what the script believes it does.
+	Chosen Chosen `json:"chosen"`
+
+	MiBPerS   float64 `json:"mib_per_s"`
+	FilesPerS float64 `json:"files_per_s"`
+
+	Best *Best `json:"best"`
+
+	// ChosenInGrid and ChosenCellMedianMS are a control, not a result: the same
+	// settings measured a second time as an ordinary cell. A large gap between
+	// the two means the runs saw different conditions, and the regret next to it
+	// is then drift rather than policy.
+	ChosenInGrid       bool     `json:"chosen_in_grid"`
+	ChosenCellMedianMS *float64 `json:"chosen_cell_median_ms"`
+	RegretMS           *float64 `json:"regret_ms"`
+	RegretPercent      *float64 `json:"regret_percent"`
+}
+
+// Chosen is what an auto run resolved its three knobs to.
+type Chosen struct {
+	Connections        *float64 `json:"connections"`
+	Concurrency        *float64 `json:"concurrency"`
+	RequestConcurrency *float64 `json:"request_concurrency"`
+}
+
+// MatrixCompare pairs a build's cell with the reference build's cell at
+// identical coordinates, including the same link profile.
+type MatrixCompare struct {
+	Scenario           string   `json:"scenario"`
+	Label              string   `json:"label"`
+	ReferenceLabel     string   `json:"reference_label"`
+	LinkProfile        string   `json:"link_profile,omitzero"`
+	Connections        int      `json:"connections"`
+	Concurrency        int      `json:"concurrency"`
+	RequestConcurrency *int     `json:"request_concurrency"`
+	MedianMS           float64  `json:"median_ms"`
+	ReferenceMedianMS  float64  `json:"reference_median_ms"`
+	DeltaMS            float64  `json:"delta_ms"`
+	DeltaPercent       *float64 `json:"delta_percent"`
+}
+
+// Canary is the fixed cell, measured at the start, the middle and the end of
+// each profile's grid. Read it before reading the grid: when the spread between
+// the three is larger than the deltas in the grid, the run measured drift and
+// not settings.
+type Canary struct {
+	LinkProfile string  `json:"link_profile"`
+	At          string  `json:"at"`
+	Scenario    string  `json:"scenario"`
+	Connections int     `json:"connections"`
+	Concurrency int     `json:"concurrency"`
+	ExitCode    int     `json:"exit_code"`
+	DurationMS  float64 `json:"duration_ms"`
+	Files       float64 `json:"files"`
+	Bytes       float64 `json:"bytes"`
+}

--- a/internal/benchmark/schema/metrics.go
+++ b/internal/benchmark/schema/metrics.go
@@ -1,0 +1,73 @@
+package schema
+
+// Metrics is the instrumentation document one run wrote, as a *reader* sees it.
+//
+// It deliberately does not reuse metrics.Report from internal/metrics, for two
+// reasons. Stored results embed metrics documents written by older easySFTP
+// versions, and a reader must keep decoding one that is missing half of today's
+// fields. And the aggregation has to tell "the run never reported this" from
+// "the run reported zero": a median over a field that only half the repeats
+// carry is not the same number as a median over zeroes, so every value here is
+// nullable and the aggregation propagates that null.
+//
+// The fields easySFTP writes today live in metrics.Report; that type stays the
+// producer and this one stays the consumer.
+type Metrics struct {
+	SchemaVersion int                 `json:"schema_version,omitzero"`
+	Note          string              `json:"note,omitzero"`
+	Process       *MetricsProcess     `json:"process,omitzero"`
+	Phases        []MetricsPhase      `json:"phases,omitzero"`
+	Operations    []MetricsOp         `json:"operations,omitzero"`
+	Counters      map[string]*float64 `json:"counters,omitzero"`
+}
+
+// MetricsProcess is what the run cost the machine.
+type MetricsProcess struct {
+	WallMS          *float64 `json:"wall_ms"`
+	UserCPUMS       *float64 `json:"user_cpu_ms"`
+	SysCPUMS        *float64 `json:"sys_cpu_ms"`
+	CPUPercent      *float64 `json:"cpu_percent"`
+	MaxRSSBytes     *float64 `json:"max_rss_bytes"`
+	TotalAllocBytes *float64 `json:"go_total_alloc_bytes"`
+	Mallocs         *float64 `json:"go_mallocs"`
+	HeapSysBytes    *float64 `json:"go_heap_sys_bytes"`
+	GCCount         *float64 `json:"go_gc_count"`
+	GCPauseTotalMS  *float64 `json:"go_gc_pause_total_ms"`
+	PeakGoroutines  *float64 `json:"go_peak_goroutines"`
+	MaxProcs        *float64 `json:"go_max_procs"`
+	DiskReadBytes   *float64 `json:"disk_read_bytes"`
+	DiskWriteBytes  *float64 `json:"disk_write_bytes"`
+	NetReadBytes    *float64 `json:"net_read_bytes"`
+	NetWriteBytes   *float64 `json:"net_write_bytes"`
+}
+
+// MetricsPhase is one wall-clock span, summed over its occurrences.
+type MetricsPhase struct {
+	Name   string   `json:"name"`
+	WallMS *float64 `json:"wall_ms"`
+	Count  *float64 `json:"count"`
+}
+
+// MetricsOp is one operation name, cumulative across the parallel workers.
+type MetricsOp struct {
+	Name    string   `json:"name"`
+	Count   *float64 `json:"count"`
+	Errors  *float64 `json:"errors"`
+	TotalMS *float64 `json:"total_ms"`
+	AvgMS   *float64 `json:"avg_ms"`
+	MinMS   *float64 `json:"min_ms"`
+	P50MS   *float64 `json:"p50_ms"`
+	P90MS   *float64 `json:"p90_ms"`
+	P99MS   *float64 `json:"p99_ms"`
+	MaxMS   *float64 `json:"max_ms"`
+}
+
+// Counter returns the named counter, or nil when the run did not report it.
+// Nil is the value the aggregation then carries forward, which is what keeps a
+// missing counter from being averaged in as a zero.
+func (m *Metrics) Counter(name string) *float64 {
+	if m == nil || m.Counters == nil {
+		return nil
+	}
+	return m.Counters[name]
+}

--- a/internal/benchmark/schema/roundtrip_test.go
+++ b/internal/benchmark/schema/roundtrip_test.go
@@ -1,0 +1,142 @@
+package schema_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// assertRoundTrip re-encodes a decoded document and compares it against the
+// original, value by value.
+//
+// Two normalizations are applied to both sides first, and both are properties
+// of JSON rather than concessions to these types:
+//
+//   - Object key order is not data. Comparing parsed values rather than bytes
+//     is what makes that true here.
+//   - An absent key and a null one carry the same information. A schema_version
+//     1 result simply has no mad_ms, a version 2 one has mad_ms: null where a
+//     single repeat left no spread, and both mean "no value". Dropping nulls on
+//     both sides is what lets one set of types read both without the round trip
+//     failing on the difference.
+//
+// Everything else is compared exactly, so a value that changed, was dropped or
+// changed type still fails.
+func assertRoundTrip(t *testing.T, original json.RawMessage, decoded any) {
+	t.Helper()
+
+	reencoded, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("re-encoding: %v", err)
+	}
+
+	want := normalize(t, original)
+	got := normalize(t, reencoded)
+	if reflect.DeepEqual(want, got) {
+		return
+	}
+	for _, d := range diff(nil, want, got) {
+		t.Errorf("round trip: %s", d)
+	}
+}
+
+func normalize(t *testing.T, data []byte) any {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	return dropNulls(v)
+}
+
+func dropNulls(v any) any {
+	switch value := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(value))
+		for k, inner := range value {
+			if inner == nil {
+				continue
+			}
+			out[k] = dropNulls(inner)
+		}
+		return out
+	case []any:
+		out := make([]any, len(value))
+		for i, inner := range value {
+			out[i] = dropNulls(inner)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// diff reports where two parsed documents differ, as paths rather than as two
+// walls of JSON: a stored result is thousands of lines and the useful part of a
+// failure is which key moved.
+func diff(path []string, want, got any) []string {
+	at := "$"
+	if len(path) > 0 {
+		at = fmt.Sprintf("$.%s", joinPath(path))
+	}
+
+	switch expected := want.(type) {
+	case map[string]any:
+		actual, ok := got.(map[string]any)
+		if !ok {
+			return []string{fmt.Sprintf("%s: expected an object, got %T", at, got)}
+		}
+		var out []string
+		for _, k := range sortedKeys(expected) {
+			inner, ok := actual[k]
+			if !ok {
+				out = append(out, fmt.Sprintf("%s: key %q was dropped", at, k))
+				continue
+			}
+			out = append(out, diff(append(path, k), expected[k], inner)...)
+		}
+		for _, k := range sortedKeys(actual) {
+			if _, ok := expected[k]; !ok {
+				out = append(out, fmt.Sprintf("%s: key %q was added", at, k))
+			}
+		}
+		return out
+	case []any:
+		actual, ok := got.([]any)
+		if !ok {
+			return []string{fmt.Sprintf("%s: expected an array, got %T", at, got)}
+		}
+		if len(expected) != len(actual) {
+			return []string{fmt.Sprintf("%s: length %d, want %d", at, len(actual), len(expected))}
+		}
+		var out []string
+		for i := range expected {
+			out = append(out, diff(append(path, fmt.Sprint(i)), expected[i], actual[i])...)
+		}
+		return out
+	default:
+		if !reflect.DeepEqual(want, got) {
+			return []string{fmt.Sprintf("%s: %v, want %v", at, got, want)}
+		}
+		return nil
+	}
+}
+
+func joinPath(path []string) string {
+	out := path[0]
+	for _, part := range path[1:] {
+		out += "." + part
+	}
+	return out
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/benchmark/schema/schema.go
+++ b/internal/benchmark/schema/schema.go
@@ -1,0 +1,181 @@
+// Package schema describes what a stored benchmark result looks like on disk.
+//
+// It is deliberately separate from the rest of internal/benchmark: this package
+// is about files that already exist under benchmarks/ and must stay readable
+// forever, while the packages around it are about what a live run produces.
+// Nothing here may gain a required field, because a result stored before that
+// field existed would stop decoding, and benchmarks/README.md promises the
+// opposite (issue #190).
+//
+// Two conventions run through every type:
+//
+//   - A pointer means the value is genuinely nullable in the stored JSON and
+//     null means something other than zero. mad_ms is the worked example: a
+//     single repeat has no measured spread, and a 0 there would read as perfect
+//     precision (issue #184, phase 2).
+//   - A plain field means "absent decodes as the zero value and that is
+//     harmless". Everything a schema_version 1 result simply does not have,
+//     such as link_profile, is of that kind.
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Kinds a stored result can have. The kind decides the subdirectory, whether
+// the result is official, and whether latest.* may ever be copied from it.
+const (
+	KindRelease = "release"
+	KindManual  = "manual"
+	KindMatrix  = "matrix"
+)
+
+// Benchmark kinds, i.e. which script produced the measurement.
+const (
+	BenchmarkStandard = "standard"
+	BenchmarkMatrix   = "matrix"
+)
+
+// EnvelopeSchemaVersion is the current version of the stored wrapper. Version 1
+// predates the kind subdirectories; its files are otherwise identical.
+const EnvelopeSchemaVersion = 2
+
+// Envelope is the stored file: provenance around a measurement kept verbatim.
+type Envelope struct {
+	SchemaVersion int     `json:"schema_version"`
+	Kind          string  `json:"kind"`
+	Version       *string `json:"version"`
+	Label         *string `json:"label"`
+	Official      bool    `json:"official"`
+	RecordedAt    string  `json:"recorded_at"`
+	Commit        string  `json:"commit"`
+	RunURL        string  `json:"run_url"`
+
+	// Benchmark is results.json or matrix.json exactly as the measuring script
+	// wrote it. Kept raw so an envelope can be read, listed and rewritten
+	// without the measurement having to round-trip through these types.
+	Benchmark json.RawMessage `json:"benchmark"`
+}
+
+// BenchmarkKind reports which script produced the wrapped measurement.
+//
+// It reads the wrapped document rather than the envelope's own kind: a matrix
+// measurement is always stored under kind "matrix", but a standard measurement
+// is stored under both "release" and "manual". Results from before the field
+// existed carry no benchmark_kind and are standard runs.
+func (e *Envelope) BenchmarkKind() (string, error) {
+	var probe struct {
+		BenchmarkKind string `json:"benchmark_kind"`
+	}
+	if err := json.Unmarshal(e.Benchmark, &probe); err != nil {
+		return "", fmt.Errorf("reading benchmark_kind: %w", err)
+	}
+	if probe.BenchmarkKind == "" {
+		return BenchmarkStandard, nil
+	}
+	return probe.BenchmarkKind, nil
+}
+
+// Standard decodes the wrapped measurement as a standard run.
+func (e *Envelope) Standard() (*Standard, error) {
+	var s Standard
+	if err := json.Unmarshal(e.Benchmark, &s); err != nil {
+		return nil, fmt.Errorf("decoding standard benchmark: %w", err)
+	}
+	return &s, nil
+}
+
+// Matrix decodes the wrapped measurement as a matrix sweep.
+func (e *Envelope) Matrix() (*Matrix, error) {
+	var m Matrix
+	if err := json.Unmarshal(e.Benchmark, &m); err != nil {
+		return nil, fmt.Errorf("decoding matrix benchmark: %w", err)
+	}
+	return &m, nil
+}
+
+// Environment is the machine and toolchain a result was measured on, and the
+// comparability key between two results: benchmarks/README.md says two numbers
+// may only be compared when this matches. Empty fields are dropped when it is
+// written, so every field is optional here.
+//
+// The link a result was measured over is deliberately not part of this. It is a
+// measurement and varies per run, which is exactly why it must not sit in the
+// key that decides comparability (issue #184, phase 1).
+type Environment struct {
+	Runner     string `json:"runner,omitzero"`
+	OS         string `json:"os,omitzero"`
+	Kernel     string `json:"kernel,omitzero"`
+	Arch       string `json:"arch,omitzero"`
+	CPUModel   string `json:"cpu_model,omitzero"`
+	CPUs       int    `json:"cpus,omitzero"`
+	GoVersion  string `json:"go_version,omitzero"`
+	RunnerName string `json:"runner_name,omitzero"`
+}
+
+// Stats is the duration_ms sub-object of a standard result: every repeat's
+// value alongside the summary. Mad is null below two samples.
+type Stats struct {
+	Values  []float64 `json:"values"`
+	Median  float64   `json:"median"`
+	Min     float64   `json:"min"`
+	Max     float64   `json:"max"`
+	Mad     *float64  `json:"mad"`
+	Samples int       `json:"samples"`
+}
+
+// Phase is wall clock spent in one phase of a run. Phases add up to roughly the
+// run's duration; operations do not (see Operation).
+type Phase struct {
+	Name     string  `json:"name"`
+	MedianMS float64 `json:"median_ms"`
+}
+
+// Operation is one kind of round-trip, summarised over the repeats.
+//
+// MedianTotalMS is cumulative across the parallel upload workers and is
+// normally larger than the phase it happened in. It is a share of the work and
+// a per-call cost, never elapsed time.
+type Operation struct {
+	Name          string   `json:"name"`
+	Count         *float64 `json:"count"`
+	MedianTotalMS *float64 `json:"median_total_ms"`
+	AvgMS         *float64 `json:"avg_ms"`
+	P50MS         *float64 `json:"p50_ms"`
+	P90MS         *float64 `json:"p90_ms"`
+	P99MS         *float64 `json:"p99_ms"`
+	MaxMS         *float64 `json:"max_ms"`
+	Errors        *float64 `json:"errors"`
+}
+
+// Counters is the run's own bookkeeping (connections opened/used/refused,
+// reconnects, retries, the resolved config_* values). An open map on purpose:
+// internal/metrics gains counters without this package being a place they have
+// to be declared a second time.
+type Counters map[string]*float64
+
+// DeleteStats is one aggregated delete sweep without its coordinates. The
+// pre-clean that runs before every measured run is a pure delete sweep, and
+// these are the only deletion numbers there are (issue #184, phase 4).
+//
+// Sweeps that found nothing are not counted, and a coordinate left with no
+// sweep at all has no row. The coordinates themselves differ by benchmark kind,
+// so they sit in StandardDelete and MatrixDelete rather than here.
+type DeleteStats struct {
+	Sweeps       int       `json:"sweeps"`
+	FailedSweeps int       `json:"failed_sweeps"`
+	FilesDeleted float64   `json:"files_deleted"`
+	DurationsMS  []float64 `json:"durations_ms"`
+	MedianMS     float64   `json:"median_ms"`
+	MinMS        float64   `json:"min_ms"`
+	MaxMS        float64   `json:"max_ms"`
+	MadMS        *float64  `json:"mad_ms"`
+
+	Phases     []Phase     `json:"phases"`
+	Operations []Operation `json:"operations"`
+
+	// DeletesPerS is appended after the block above, which is why it sits
+	// behind the nested arrays rather than next to the other statistics.
+	DeletesPerS float64 `json:"deletes_per_s"`
+}

--- a/internal/benchmark/schema/standard.go
+++ b/internal/benchmark/schema/standard.go
@@ -1,0 +1,133 @@
+package schema
+
+// StandardSchemaVersion is the current version of a standard measurement.
+//
+// Version 1 (up to and including v3.3.2) carries only candidate_ref,
+// baseline_ref, repeats, runner, settings, scenarios and a smaller results[].
+// Every key it had still exists and still means the same thing in version 2,
+// which is why one set of types reads both.
+const StandardSchemaVersion = 2
+
+// Standard is results.json: the measurement scripts/benchmark.sh produces.
+//
+// Field order matches what the script writes, so a re-encoded document diffs
+// against the original by text and not only by value.
+type Standard struct {
+	SchemaVersion  int               `json:"schema_version,omitzero"`
+	BenchmarkKind  string            `json:"benchmark_kind,omitzero"`
+	CandidateRef   string            `json:"candidate_ref"`
+	BaselineRef    string            `json:"baseline_ref"`
+	Repeats        int               `json:"repeats"`
+	Runner         string            `json:"runner"`
+	Environment    *Environment      `json:"environment,omitzero"`
+	Link           *Link             `json:"link,omitzero"`
+	Settings       string            `json:"settings"`
+	ReferenceLabel string            `json:"reference_label,omitzero"`
+	Scenarios      map[string]string `json:"scenarios"`
+	Note           string            `json:"note,omitzero"`
+
+	Results    []Result         `json:"results"`
+	Deletes    []StandardDelete `json:"deletes,omitzero"`
+	Comparison []Comparison     `json:"comparison,omitzero"`
+	Runs       []Run            `json:"runs,omitzero"`
+}
+
+// Result is one aggregate row per (link profile, build, scenario).
+//
+// The timing fields at the top are exactly the ones version 1 had, so anything
+// already reading a stored benchmark keeps working; everything version 2 added
+// sits in its own sub-object.
+type Result struct {
+	Label       string `json:"label"`
+	Ref         string `json:"ref"`
+	Scenario    string `json:"scenario"`
+	LinkProfile string `json:"link_profile,omitzero"`
+
+	Repeats     int       `json:"repeats"`
+	FailedRuns  int       `json:"failed_runs"`
+	Files       float64   `json:"files"`
+	Bytes       float64   `json:"bytes"`
+	DurationsMS []float64 `json:"durations_ms"`
+	MedianMS    float64   `json:"median_ms"`
+	MinMS       float64   `json:"min_ms"`
+	MaxMS       float64   `json:"max_ms"`
+
+	// MadMS is absent in version 1 results and null where a single repeat left
+	// no spread to measure.
+	MadMS      *float64 `json:"mad_ms"`
+	DurationMS *Stats   `json:"duration_ms"`
+
+	Retries            float64  `json:"retries"`
+	Errors             float64  `json:"errors"`
+	RefusedConnections *float64 `json:"refused_connections"`
+
+	Process    *Process    `json:"process"`
+	Counters   Counters    `json:"counters"`
+	Phases     []Phase     `json:"phases"`
+	Operations []Operation `json:"operations"`
+
+	MiBPerS   float64 `json:"mib_per_s"`
+	FilesPerS float64 `json:"files_per_s"`
+}
+
+// Process is what a run cost the machine, median over the repeats.
+type Process struct {
+	UserCPUMS         *float64 `json:"user_cpu_ms"`
+	SysCPUMS          *float64 `json:"sys_cpu_ms"`
+	CPUPercent        *float64 `json:"cpu_percent"`
+	MaxRSSBytes       *float64 `json:"max_rss_bytes"`
+	GoTotalAllocBytes *float64 `json:"go_total_alloc_bytes"`
+	GoMallocs         *float64 `json:"go_mallocs"`
+	GoGCCount         *float64 `json:"go_gc_count"`
+	GoGCPauseTotalMS  *float64 `json:"go_gc_pause_total_ms"`
+	GoPeakGoroutines  *float64 `json:"go_peak_goroutines"`
+	DiskReadBytes     *float64 `json:"disk_read_bytes"`
+	NetReadBytes      *float64 `json:"net_read_bytes"`
+	NetWriteBytes     *float64 `json:"net_write_bytes"`
+}
+
+// StandardDelete is a delete sweep keyed the way a standard run keys one.
+type StandardDelete struct {
+	Label       string `json:"label"`
+	Scenario    string `json:"scenario"`
+	LinkProfile string `json:"link_profile"`
+	DeleteStats
+}
+
+// Comparison is one build against the reference build, at the same scenario and
+// on the same link profile.
+//
+// WithinNoise answers the only question a delta can honestly answer on a shared
+// host: is it larger than the reference's own median absolute deviation. It is
+// null where there is no measured spread to compare against.
+type Comparison struct {
+	Scenario          string   `json:"scenario"`
+	Label             string   `json:"label"`
+	LinkProfile       string   `json:"link_profile,omitzero"`
+	ReferenceLabel    string   `json:"reference_label"`
+	MedianMS          float64  `json:"median_ms"`
+	ReferenceMedianMS float64  `json:"reference_median_ms"`
+	DeltaMS           float64  `json:"delta_ms"`
+	DeltaPercent      *float64 `json:"delta_percent"`
+	ReferenceMadMS    *float64 `json:"reference_mad_ms"`
+	WithinNoise       *bool    `json:"within_noise"`
+}
+
+// Run is one individual repeat, verbatim, including the metrics document the
+// run itself wrote. A matrix result has no equivalent: its cell is the finest
+// grain it keeps.
+type Run struct {
+	Label       string   `json:"label"`
+	Ref         string   `json:"ref"`
+	Scenario    string   `json:"scenario"`
+	LinkProfile string   `json:"link_profile,omitzero"`
+	Repeat      int      `json:"repeat"`
+	ExitCode    int      `json:"exit_code"`
+	DurationMS  float64  `json:"duration_ms"`
+	Files       float64  `json:"files"`
+	Bytes       float64  `json:"bytes"`
+	Retries     float64  `json:"retries"`
+	Errors      float64  `json:"errors"`
+	Refused     float64  `json:"refused"`
+	Metrics     *Metrics `json:"metrics"`
+}

--- a/internal/benchmark/schema/validate.go
+++ b/internal/benchmark/schema/validate.go
@@ -1,0 +1,195 @@
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// DecodeStrict decodes a stored document and refuses any field these types do
+// not model.
+//
+// Strictness is the point rather than a precaution: it is what turns "the types
+// compile" into "the types cover what is actually on disk". A stored result
+// that grew a field nobody declared here fails the fixture test instead of
+// being silently dropped on the next rewrite.
+func DecodeStrict[T any](data []byte) (*T, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var v T
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	// A stored document is exactly one JSON value. Trailing content means the
+	// file was concatenated or truncated, which is worth an error and not a
+	// shrug.
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("trailing content after the JSON document")
+	}
+	return &v, nil
+}
+
+// Validate checks the invariants benchmarks/README.md states about a stored
+// result. It reports every problem it finds rather than the first, because a
+// file that is wrong is usually wrong in more than one way.
+//
+// It deliberately does not check numbers. Whether a measurement is plausible is
+// not something this package can know, and a validator that rejects a slow run
+// would be a threshold, which the benchmarks explicitly do not have.
+func (e *Envelope) Validate() error {
+	var problems []error
+	add := func(format string, args ...any) {
+		problems = append(problems, fmt.Errorf(format, args...))
+	}
+
+	if e.SchemaVersion < 1 || e.SchemaVersion > EnvelopeSchemaVersion {
+		add("envelope schema_version %d is not between 1 and %d", e.SchemaVersion, EnvelopeSchemaVersion)
+	}
+
+	switch e.Kind {
+	case KindRelease:
+		// Only a release is official, and only a release names a version:
+		// latest.* is copied from these and from nothing else.
+		if !e.Official {
+			add("a release must be official")
+		}
+		if e.Version == nil || *e.Version == "" {
+			add("a release must name its version")
+		}
+		if e.Label != nil {
+			add("a release must not carry a label")
+		}
+	case KindManual, KindMatrix:
+		if e.Official {
+			add("a %s result must not be official", e.Kind)
+		}
+		if e.Version != nil {
+			add("a %s result must not name a version", e.Kind)
+		}
+	default:
+		add("unknown kind %q", e.Kind)
+	}
+
+	if e.RecordedAt == "" {
+		add("recorded_at is empty")
+	}
+	if len(e.Benchmark) == 0 {
+		add("the envelope carries no benchmark")
+		return errors.Join(problems...)
+	}
+
+	kind, err := e.BenchmarkKind()
+	if err != nil {
+		add("%s", err)
+		return errors.Join(problems...)
+	}
+	switch {
+	case e.Kind == KindMatrix && kind != BenchmarkMatrix:
+		add("a matrix result must wrap a matrix benchmark, got %q", kind)
+	case e.Kind != KindMatrix && kind == BenchmarkMatrix:
+		// A sweep measures settings a normal deploy does not use, so it answers
+		// a different question than a release number does and can never become
+		// one.
+		add("a matrix benchmark may only be stored as kind %q, not %q", KindMatrix, e.Kind)
+	}
+
+	switch kind {
+	case BenchmarkMatrix:
+		m, err := DecodeStrict[Matrix](e.Benchmark)
+		if err != nil {
+			add("decoding the matrix benchmark: %s", err)
+			break
+		}
+		problems = append(problems, m.validate()...)
+	default:
+		s, err := DecodeStrict[Standard](e.Benchmark)
+		if err != nil {
+			add("decoding the standard benchmark: %s", err)
+			break
+		}
+		problems = append(problems, s.validate()...)
+	}
+
+	return errors.Join(problems...)
+}
+
+func (s *Standard) validate() []error {
+	var problems []error
+	add := func(format string, args ...any) {
+		problems = append(problems, fmt.Errorf(format, args...))
+	}
+
+	// Absent is version 1, which predates the field entirely.
+	if s.SchemaVersion > StandardSchemaVersion {
+		add("standard schema_version %d is newer than %d", s.SchemaVersion, StandardSchemaVersion)
+	}
+	if s.CandidateRef == "" {
+		add("candidate_ref is empty")
+	}
+	if len(s.Results) == 0 {
+		add("the result has no results[]")
+	}
+	for i, r := range s.Results {
+		if r.Label == "" || r.Scenario == "" {
+			add("results[%d] has no label or no scenario", i)
+		}
+		if r.Repeats != len(r.DurationsMS) {
+			add("results[%d] reports %d repeats but keeps %d durations", i, r.Repeats, len(r.DurationsMS))
+		}
+	}
+	// A single repeat has no measured spread, so mad_ms is null rather than 0
+	// (issue #184, phase 2). Results stored before that change carry 0 there,
+	// which is why this only looks the other way round: a spread reported for a
+	// sample of one is a claim of perfect precision.
+	for i, r := range s.Results {
+		if len(r.DurationsMS) < 2 && r.MadMS != nil && *r.MadMS != 0 {
+			add("results[%d] reports a spread over %d sample(s)", i, len(r.DurationsMS))
+		}
+	}
+	for i, d := range s.Deletes {
+		if d.Sweeps == 0 {
+			add("deletes[%d] is a row with no sweep", i)
+		}
+	}
+	return problems
+}
+
+func (m *Matrix) validate() []error {
+	var problems []error
+	add := func(format string, args ...any) {
+		problems = append(problems, fmt.Errorf(format, args...))
+	}
+
+	if m.SchemaVersion > MatrixSchemaVersion {
+		add("matrix schema_version %d is newer than %d", m.SchemaVersion, MatrixSchemaVersion)
+	}
+	if m.CandidateRef == "" {
+		add("candidate_ref is empty")
+	}
+	if len(m.Cells) == 0 {
+		add("the sweep has no cells[]")
+	}
+	for i, c := range m.Cells {
+		if c.Connections < 1 || c.Concurrency < 1 {
+			add("cells[%d] has a non-positive axis coordinate", i)
+		}
+		if c.Repeats != len(c.DurationsMS) {
+			add("cells[%d] reports %d repeats but keeps %d durations", i, c.Repeats, len(c.DurationsMS))
+		}
+	}
+	for i, d := range m.Deletes {
+		if d.Sweeps == 0 {
+			add("deletes[%d] is a row with no sweep", i)
+		}
+	}
+	// auto chooses a coordinate rather than sitting at one, so it must not
+	// appear as a build label anywhere in the grid (issue #184, phase 5).
+	for i, c := range m.Cells {
+		if c.Label == "auto" {
+			add("cells[%d] is labelled auto, which is not a coordinate of the grid", i)
+		}
+	}
+	return problems
+}

--- a/internal/benchmark/standard.go
+++ b/internal/benchmark/standard.go
@@ -1,0 +1,203 @@
+package benchmark
+
+import (
+	"math"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// standardNote is stored with every standard result. It is the sentence that
+// keeps a phase and an operation total from being read as the same kind of
+// number.
+const standardNote = "phases are wall clock and add up to the duration; operations are cumulative across parallel workers and do not"
+
+// BuildStandard aggregates a standard run into results.json.
+//
+// The layers are the order a reader needs them in: what was measured, the
+// aggregate per build and scenario, the deltas, the delete sweeps, and finally
+// every individual repeat verbatim. Every key schema_version 1 had still exists
+// and still means the same thing.
+func BuildStandard(m *Manifest, in *Inputs) *schema.Standard {
+	results := standardResults(in.Runs)
+
+	out := &schema.Standard{
+		SchemaVersion:  schema.StandardSchemaVersion,
+		BenchmarkKind:  schema.BenchmarkStandard,
+		CandidateRef:   m.CandidateRef,
+		BaselineRef:    m.BaselineRef,
+		Repeats:        m.Repeats,
+		Runner:         m.Runner,
+		Environment:    m.Environment,
+		Link:           buildLink(m, in.Probes),
+		Settings:       m.Settings,
+		ReferenceLabel: m.ReferenceLabel,
+		Scenarios:      m.ScenarioDocs(),
+		Note:           standardNote,
+		Results:        results,
+		Deletes:        standardDeletes(in.Deletes),
+		Comparison:     standardComparison(results, m.ReferenceLabel),
+		Runs:           standardRuns(in.Runs),
+	}
+	return out
+}
+
+// standardResults is one aggregate row per (link profile, build, scenario).
+//
+// With no profiles requested there is exactly one profile, "baseline", and the
+// row count is what it always was.
+func standardResults(runs []RunRecord) []schema.Result {
+	groups := stats.GroupBy(runs, func(r RunRecord) stats.Key {
+		return stats.Key{r.LinkProfile, r.Label, r.Scenario}
+	})
+
+	out := make([]schema.Result, 0, len(groups))
+	for _, group := range groups {
+		ms := metricsOf(group, func(r RunRecord) *schema.Metrics { return r.Metrics })
+		durations := durationsOf(group)
+		files := maxOf(group, func(r RunRecord) float64 { return r.Files })
+		bytes := maxOf(group, func(r RunRecord) float64 { return r.Bytes })
+		median := stats.MedianOf(durations)
+
+		out = append(out, schema.Result{
+			Label:              group[0].Label,
+			Ref:                group[0].Ref,
+			Scenario:           group[0].Scenario,
+			LinkProfile:        group[0].LinkProfile,
+			Repeats:            len(group),
+			FailedRuns:         failedRuns(group),
+			Files:              files,
+			Bytes:              bytes,
+			DurationsMS:        durations,
+			MedianMS:           median,
+			MinMS:              stats.Or(stats.Min(stats.Nums(durations)), 0),
+			MaxMS:              stats.Or(stats.Max(stats.Nums(durations)), 0),
+			MadMS:              stats.Mad(durations),
+			DurationMS:         durationStats(durations),
+			Retries:            sumOf(group, func(r RunRecord) float64 { return r.Retries }),
+			Errors:             sumOf(group, func(r RunRecord) float64 { return r.Errors }),
+			RefusedConnections: stats.Ptr(sumOf(group, func(r RunRecord) float64 { return r.Refused })),
+			Process:            aggregateProcess(ms),
+			Counters:           aggregateCounters(ms),
+			Phases:             aggregatePhases(ms),
+			Operations:         aggregateOperations(ms),
+			MiBPerS:            stats.MiBPerS(bytes, median),
+			FilesPerS:          stats.Ratio(files, median),
+		})
+	}
+	return out
+}
+
+// durationStats is the duration_ms sub-object: every repeat's value next to the
+// summary, so a reader never has to recompute one from the other.
+func durationStats(durations []float64) *schema.Stats {
+	values := durations
+	if values == nil {
+		values = []float64{}
+	}
+	return &schema.Stats{
+		Values:  values,
+		Median:  stats.MedianOf(durations),
+		Min:     stats.Or(stats.Min(stats.Nums(durations)), 0),
+		Max:     stats.Or(stats.Max(stats.Nums(durations)), 0),
+		Mad:     stats.Mad(durations),
+		Samples: len(durations),
+	}
+}
+
+func standardDeletes(records []DeleteRecord) []schema.StandardDelete {
+	groups := stats.GroupBy(records, func(d DeleteRecord) stats.Key {
+		return stats.Key{d.LinkProfile, d.Label, d.Scenario}
+	})
+	out := make([]schema.StandardDelete, 0, len(groups))
+	for _, group := range groups {
+		agg := aggregateDeletes(group)
+		// A coordinate whose every pre-clean found an empty directory has no
+		// row at all, rather than a row of zeroes.
+		if agg.Sweeps == 0 {
+			continue
+		}
+		out = append(out, schema.StandardDelete{
+			Label:       group[0].Label,
+			Scenario:    group[0].Scenario,
+			LinkProfile: group[0].LinkProfile,
+			DeleteStats: agg,
+		})
+	}
+	return out
+}
+
+// standardComparison measures every build against the reference build, on the
+// same scenario and the same link profile.
+//
+// A row whose reference was never measured is dropped rather than compared
+// against nothing, which is what the jq's "as $b" over an empty generator does.
+func standardComparison(results []schema.Result, reference string) []schema.Comparison {
+	out := []schema.Comparison{}
+	for _, candidate := range results {
+		if candidate.Label == reference {
+			continue
+		}
+		var ref *schema.Result
+		for i := range results {
+			r := &results[i]
+			if r.Label == reference && r.Scenario == candidate.Scenario && r.LinkProfile == candidate.LinkProfile {
+				ref = r
+				break
+			}
+		}
+		if ref == nil {
+			continue
+		}
+		delta := candidate.MedianMS - ref.MedianMS
+		out = append(out, schema.Comparison{
+			Scenario:          candidate.Scenario,
+			Label:             candidate.Label,
+			LinkProfile:       candidate.LinkProfile,
+			ReferenceLabel:    reference,
+			MedianMS:          candidate.MedianMS,
+			ReferenceMedianMS: ref.MedianMS,
+			DeltaMS:           delta,
+			DeltaPercent:      stats.Pct(candidate.MedianMS, ref.MedianMS),
+			ReferenceMadMS:    ref.MadMS,
+			WithinNoise:       withinNoise(delta, ref.MadMS),
+		})
+	}
+	return out
+}
+
+// withinNoise answers whether a delta is smaller than the reference's own
+// median absolute deviation, and null where there is no measured spread to
+// compare against. A candidate inside the noise has not been shown to be faster
+// or slower, which is the only honest reading of a delta on a shared host.
+func withinNoise(delta float64, mad *float64) *bool {
+	if stats.Or(mad, 0) == 0 {
+		return nil
+	}
+	within := math.Abs(delta) <= *mad
+	return &within
+}
+
+// standardRuns keeps every individual repeat verbatim, metrics document
+// included. It is what makes a stored result re-aggregatable later.
+func standardRuns(runs []RunRecord) []schema.Run {
+	out := make([]schema.Run, 0, len(runs))
+	for _, r := range runs {
+		out = append(out, schema.Run{
+			Label:       r.Label,
+			Ref:         r.Ref,
+			Scenario:    r.Scenario,
+			LinkProfile: r.LinkProfile,
+			Repeat:      r.Repeat,
+			ExitCode:    r.ExitCode,
+			DurationMS:  r.DurationMS,
+			Files:       r.Files,
+			Bytes:       r.Bytes,
+			Retries:     r.Retries,
+			Errors:      r.Errors,
+			Refused:     r.Refused,
+			Metrics:     r.Metrics,
+		})
+	}
+	return out
+}

--- a/internal/benchmark/stats/format.go
+++ b/internal/benchmark/stats/format.go
@@ -1,0 +1,28 @@
+package stats
+
+import "strconv"
+
+// Format renders a number the way jq's string interpolation does, which is what
+// the Markdown tables and the CSV columns of a stored result contain: no
+// trailing ".0" on a whole number, and no exponent for anything a benchmark
+// produces.
+//
+// Everything these reports print is either a whole number (milliseconds, byte
+// counts, round-trip counts) or has already been rounded to one or two decimals,
+// so the shortest representation is always short.
+func Format(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+// FormatOr renders a nullable number, or the given placeholder when it is null.
+// The placeholder is "-" in every Markdown table and the empty string in every
+// CSV: an empty column says "this metric did not exist yet", and a 0 there would
+// be a measurement that was never taken.
+func FormatOr(f *float64, placeholder string) string {
+	if f == nil {
+		return placeholder
+	}
+	return Format(*f)
+}
+
+func formatNumber(f float64) string { return Format(f) }

--- a/internal/benchmark/stats/order.go
+++ b/internal/benchmark/stats/order.go
@@ -1,0 +1,144 @@
+package stats
+
+import (
+	"sort"
+	"strings"
+)
+
+// Key is a grouping key, the Go equivalent of the arrays both scripts pass to
+// jq's group_by, for example [.link_profile, .label, .scenario].
+//
+// Its elements may be strings, numbers or nil. Nothing else appears in a
+// benchmark grouping key.
+type Key []any
+
+// CompareKeys orders two keys the way jq's group_by and sort_by order them:
+// element by element, with jq's own type order (null before every number,
+// numbers before strings). Reproducing that ordering is what makes the rows of
+// a Go-generated result come out in the same sequence as the rows of the stored
+// ones, so the two can be diffed as text and not only as sets.
+func CompareKeys(a, b Key) int {
+	for i := range a {
+		if i >= len(b) {
+			return 1
+		}
+		if c := compareValues(a[i], b[i]); c != 0 {
+			return c
+		}
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	return 0
+}
+
+// rank is jq's type order, reduced to the types a benchmark key can hold.
+func rank(v any) int {
+	switch v.(type) {
+	case nil:
+		return 0
+	case int, int64, float64:
+		return 1
+	case string:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func compareValues(a, b any) int {
+	if ra, rb := rank(a), rank(b); ra != rb {
+		if ra < rb {
+			return -1
+		}
+		return 1
+	}
+	switch left := a.(type) {
+	case nil:
+		return 0
+	case string:
+		return strings.Compare(left, b.(string))
+	default:
+		x, y := number(a), number(b)
+		switch {
+		case x < y:
+			return -1
+		case x > y:
+			return 1
+		default:
+			return 0
+		}
+	}
+}
+
+func number(v any) float64 {
+	switch n := v.(type) {
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case float64:
+		return n
+	default:
+		return 0
+	}
+}
+
+// GroupBy is jq's group_by: it partitions the items by key and returns the
+// groups ordered by that key.
+//
+// Like jq's, the grouping is order-preserving inside a group, so the repeats of
+// one coordinate stay in the order they were measured in.
+func GroupBy[T any](items []T, key func(T) Key) [][]T {
+	type group struct {
+		key   Key
+		items []T
+	}
+	var groups []*group
+	index := map[string]*group{}
+	for _, item := range items {
+		k := key(item)
+		id := keyID(k)
+		g, ok := index[id]
+		if !ok {
+			g = &group{key: k}
+			index[id] = g
+			groups = append(groups, g)
+		}
+		g.items = append(g.items, item)
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		return CompareKeys(groups[i].key, groups[j].key) < 0
+	})
+	out := make([][]T, len(groups))
+	for i, g := range groups {
+		out[i] = g.items
+	}
+	return out
+}
+
+// SortByKey orders a slice by a key function, stably.
+func SortByKey[T any](items []T, key func(T) Key) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return CompareKeys(key(items[i]), key(items[j])) < 0
+	})
+}
+
+// keyID is an identity for map lookup only. It never decides ordering, which is
+// what CompareKeys is for, so it only has to separate keys that differ.
+func keyID(k Key) string {
+	var b strings.Builder
+	for _, v := range k {
+		switch value := v.(type) {
+		case nil:
+			b.WriteString("\x00null")
+		case string:
+			b.WriteString("\x00s")
+			b.WriteString(value)
+		default:
+			b.WriteString("\x00n")
+			b.WriteString(formatNumber(number(value)))
+		}
+	}
+	return b.String()
+}

--- a/internal/benchmark/stats/stats.go
+++ b/internal/benchmark/stats/stats.go
@@ -1,0 +1,173 @@
+// Package stats is the JQ_STATS block of scripts/benchmark-lib.sh, in Go.
+//
+// It exists to be boring and exact. The functions here are not "a median" and
+// "a spread": they are the median and the spread the stored benchmark results
+// were computed with, down to the edge cases, because a result recomputed with
+// a slightly different rule is not comparable to the ones already published
+// (issue #190).
+//
+// Three of those edge cases are load-bearing and are pinned by tests:
+//
+//   - The median is the *lower* middle value for an even sample count, which is
+//     why an odd number of repeats is the better choice.
+//   - The median absolute deviation is null below two samples rather than 0: a
+//     single repeat has no measured spread at all, and a 0 there reads as
+//     perfect precision (issue #184, phase 2).
+//   - A value that was never reported is null, and null is not zero. jq sorts
+//     null below every number, treats it as the identity of addition, and
+//     propagates it out of min and max over an empty list. A median over a
+//     field that only half the repeats carried is therefore not the median over
+//     the same list with the gaps filled in as zeroes, and this package keeps
+//     that difference.
+package stats
+
+import (
+	"math"
+	"sort"
+)
+
+// Ptr is the nullable number these functions work in. Nil is JSON null.
+func Ptr(f float64) *float64 { return &f }
+
+// Nums lifts plain numbers into the nullable form.
+func Nums(xs []float64) []*float64 {
+	out := make([]*float64, len(xs))
+	for i := range xs {
+		out[i] = Ptr(xs[i])
+	}
+	return out
+}
+
+// Median is jq's "median": the lower middle value of the sorted list, and 0 for
+// an empty list.
+//
+// It returns 0 rather than null for the empty case because that is what the
+// stored results were computed with. Nulls sort below every number, so a list
+// with gaps can have a null median, which is the honest answer: the middle
+// sample did not report the value.
+func Median(xs []*float64) *float64 {
+	if len(xs) == 0 {
+		return Ptr(0)
+	}
+	sorted := sortValues(xs)
+	return sorted[(len(sorted)-1)/2]
+}
+
+// MedianOf is Median over values that are known to be present.
+func MedianOf(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), xs...)
+	sort.Float64s(sorted)
+	return sorted[(len(sorted)-1)/2]
+}
+
+// Mad is the median absolute deviation, and null below two samples.
+//
+// It is the spread metric to compare a delta against: a single slow repeat,
+// which is the normal failure mode of a shared host, moves it far less than it
+// moves a standard deviation.
+func Mad(xs []float64) *float64 {
+	if len(xs) < 2 {
+		return nil
+	}
+	m := MedianOf(xs)
+	deviations := make([]float64, len(xs))
+	for i, x := range xs {
+		deviations[i] = math.Abs(x - m)
+	}
+	return Ptr(MedianOf(deviations))
+}
+
+// Min is jq's "min": null over an empty list, and null below any number.
+func Min(xs []*float64) *float64 {
+	if len(xs) == 0 {
+		return nil
+	}
+	return sortValues(xs)[0]
+}
+
+// Max is jq's "max": null over an empty list.
+func Max(xs []*float64) *float64 {
+	if len(xs) == 0 {
+		return nil
+	}
+	sorted := sortValues(xs)
+	return sorted[len(sorted)-1]
+}
+
+// Add is jq's "add": null over an empty list and over a list of nothing but
+// nulls, and otherwise the sum with the nulls skipped, because null is the
+// identity of addition in jq.
+func Add(xs []*float64) *float64 {
+	var sum float64
+	seen := false
+	for _, x := range xs {
+		if x == nil {
+			continue
+		}
+		sum += *x
+		seen = true
+	}
+	if !seen {
+		return nil
+	}
+	return Ptr(sum)
+}
+
+// Or is jq's "// 0" on a nullable number: the value, or 0 when it is null.
+func Or(x *float64, fallback float64) float64 {
+	if x == nil {
+		return fallback
+	}
+	return *x
+}
+
+// Round1 and Round2 are jq's "(. * 10 | round) / 10" and its hundredths
+// sibling. jq rounds half away from zero, which is what math.Round does.
+func Round1(f float64) float64 { return math.Round(f*10) / 10 }
+
+// Round2 rounds to two decimals, half away from zero.
+func Round2(f float64) float64 { return math.Round(f*100) / 100 }
+
+// Pct is jq's "pct(a; b)": the change from b to a in percent, rounded to two
+// decimals, and null where b is null or zero and the question has no answer.
+func Pct(a, b float64) *float64 {
+	if b == 0 {
+		return nil
+	}
+	return Ptr(Round2(((a - b) / b) * 100))
+}
+
+// Ratio is the "X per second" both scripts compute the same way: null-safe,
+// rounded to two decimals, and 0 where there is no duration to divide by.
+func Ratio(count, durationMS float64) float64 {
+	if durationMS <= 0 {
+		return 0
+	}
+	return Round2(count / (durationMS / 1000))
+}
+
+// MiBPerS is Ratio over bytes, which the scripts write out inline every time.
+func MiBPerS(bytes, durationMS float64) float64 {
+	return Ratio(bytes/1048576, durationMS)
+}
+
+// sortValues sorts nullable numbers the way jq sorts them: null first, then the
+// numbers ascending. The sort is stable so equal values keep the order they
+// were measured in.
+func sortValues(xs []*float64) []*float64 {
+	sorted := append([]*float64(nil), xs...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		switch {
+		case sorted[i] == nil:
+			return sorted[j] != nil
+		case sorted[j] == nil:
+			return false
+		default:
+			return *sorted[i] < *sorted[j]
+		}
+	})
+	return sorted
+}

--- a/internal/benchmark/stats/stats_test.go
+++ b/internal/benchmark/stats/stats_test.go
@@ -1,0 +1,189 @@
+package stats_test
+
+import (
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+func TestMedianTakesTheLowerMiddle(t *testing.T) {
+	// The rule an odd repeat count exists to avoid: with an even sample count
+	// the median is a measured value and not the average of two, so it never
+	// invents a number that was not observed.
+	if got := stats.MedianOf([]float64{10, 20, 30, 40}); got != 20 {
+		t.Errorf("median = %v, want 20", got)
+	}
+	if got := stats.MedianOf([]float64{30, 10, 20}); got != 20 {
+		t.Errorf("median = %v, want 20", got)
+	}
+}
+
+func TestMedianOfNothingIsZero(t *testing.T) {
+	// Not null: this is what the stored results were computed with, and a group
+	// with no metrics documents at all reaches it.
+	got := stats.Median(nil)
+	if got == nil || *got != 0 {
+		t.Errorf("median of an empty list = %v, want 0", got)
+	}
+}
+
+func TestMedianSortsNullBelowEveryNumber(t *testing.T) {
+	// A field only some repeats reported. Nulls sort below every number, so they
+	// take the low half of the list and can reach the middle themselves, and
+	// then the median is null: the middle sample did not report the value. That
+	// is deliberately not the median of the values that happen to be there.
+	half := []*float64{stats.Ptr(5), nil, nil, stats.Ptr(9)}
+	if got := stats.Median(half); got != nil {
+		t.Errorf("median = %v, want null", *got)
+	}
+
+	// One missing value out of three does not reach the middle, so the median is
+	// still a measured number.
+	one := []*float64{stats.Ptr(5), nil, stats.Ptr(9)}
+	if got := stats.Median(one); got == nil || *got != 5 {
+		t.Errorf("median = %v, want 5", got)
+	}
+}
+
+func TestMadIsNullBelowTwoSamples(t *testing.T) {
+	// Issue #184, phase 2: a single repeat has no measured spread, and a 0 here
+	// would read as perfect precision. That is the normal case for a matrix run,
+	// whose REPEATS default is 1.
+	if got := stats.Mad([]float64{42}); got != nil {
+		t.Errorf("mad of one sample = %v, want null", *got)
+	}
+	if got := stats.Mad(nil); got != nil {
+		t.Errorf("mad of no samples = %v, want null", *got)
+	}
+}
+
+func TestMadIsTheMedianDeviation(t *testing.T) {
+	// Deviations from the median 20 are 10, 0, 10, 20; their lower-middle value
+	// is 10. A standard deviation would have been dragged up by the outlier,
+	// which is the whole reason this is the spread metric here.
+	got := stats.Mad([]float64{10, 20, 30, 40})
+	if got == nil || *got != 10 {
+		t.Errorf("mad = %v, want 10", got)
+	}
+}
+
+func TestMinAndMaxAreNullOverNothing(t *testing.T) {
+	if got := stats.Min(nil); got != nil {
+		t.Errorf("min = %v, want null", *got)
+	}
+	if got := stats.Max(nil); got != nil {
+		t.Errorf("max = %v, want null", *got)
+	}
+}
+
+func TestAddSkipsNullsAndIsNullOverNothing(t *testing.T) {
+	// null is the identity of addition in jq, so a counter half the repeats did
+	// not report still sums to what the others reported.
+	got := stats.Add([]*float64{nil, stats.Ptr(2), stats.Ptr(3)})
+	if got == nil || *got != 5 {
+		t.Errorf("add = %v, want 5", got)
+	}
+	if got := stats.Add([]*float64{nil, nil}); got != nil {
+		t.Errorf("add over nulls = %v, want null", *got)
+	}
+	if got := stats.Add(nil); got != nil {
+		t.Errorf("add over nothing = %v, want null", *got)
+	}
+}
+
+func TestPctIsNullWithoutAReference(t *testing.T) {
+	// A delta against a reference of zero has no answer, and 0 or infinity would
+	// both be an invented one.
+	if got := stats.Pct(10, 0); got != nil {
+		t.Errorf("pct against 0 = %v, want null", *got)
+	}
+	got := stats.Pct(110, 100)
+	if got == nil || *got != 10 {
+		t.Errorf("pct = %v, want 10", got)
+	}
+}
+
+func TestRoundingIsHalfAwayFromZero(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want float64
+	}{
+		{0.125, 0.13},
+		{0.005, 0.01},
+		{-0.005, -0.01},
+	}
+	for _, c := range cases {
+		if got := stats.Round2(c.in); got != c.want {
+			t.Errorf("round2(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRatioIsZeroWithoutADuration(t *testing.T) {
+	// The scripts guard every throughput division with "if median > 0", because
+	// a run that died before writing its duration must not produce an infinity.
+	if got := stats.Ratio(100, 0); got != 0 {
+		t.Errorf("ratio = %v, want 0", got)
+	}
+	if got := stats.MiBPerS(1048576*2, 1000); got != 2 {
+		t.Errorf("mib_per_s = %v, want 2", got)
+	}
+}
+
+func TestFormatDropsTheTrailingZero(t *testing.T) {
+	if got := stats.Format(624); got != "624" {
+		t.Errorf("format = %q, want %q", got, "624")
+	}
+	if got := stats.Format(0.38); got != "0.38" {
+		t.Errorf("format = %q, want %q", got, "0.38")
+	}
+	if got := stats.Format(33554432); got != "33554432" {
+		t.Errorf("format = %q, want %q", got, "33554432")
+	}
+}
+
+func TestGroupByOrdersTheWayJqDoes(t *testing.T) {
+	type row struct {
+		profile string
+		conns   int
+		request *int
+	}
+	four := 4
+	rows := []row{
+		{"baseline", 2, &four},
+		{"+50ms", 1, nil},
+		{"baseline", 1, nil},
+		{"baseline", 1, &four},
+		{"baseline", 2, &four},
+	}
+	groups := stats.GroupBy(rows, func(r row) stats.Key {
+		var request any
+		if r.request != nil {
+			request = *r.request
+		}
+		return stats.Key{r.profile, r.conns, request}
+	})
+
+	var got []string
+	for _, g := range groups {
+		got = append(got, g[0].profile)
+	}
+	// "+" sorts below "b" by codepoint, and within a profile the null
+	// request_concurrency sorts below the number, which is the order the stored
+	// results are in.
+	want := []string{"+50ms", "baseline", "baseline", "baseline"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d groups, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("group order = %v, want %v", got, want)
+		}
+	}
+	if len(groups[len(groups)-1]) != 2 {
+		t.Errorf("the two identical coordinates did not end up in one group")
+	}
+	if groups[1][0].request != nil {
+		t.Errorf("a null coordinate must sort below a number")
+	}
+}

--- a/scripts/benchmark-aggregate-jq.sh
+++ b/scripts/benchmark-aggregate-jq.sh
@@ -1,0 +1,890 @@
+#!/usr/bin/env bash
+#
+# The jq aggregation the benchmark scripts used before issue #190 moved it into
+# cmd/easysftp-bench, kept alive as the parity oracle for that move.
+#
+# This is scaffolding, not a second implementation to maintain. It exists so
+# scripts/test-benchmark.sh can aggregate one measurement twice, once here and
+# once with the Go command, and diff the two: a rewrite that claims to reproduce
+# a stored document has to be shown doing it, on the live scripts and not on a
+# fixture captured once. Step 6 of issue #190 deletes this file together with
+# the last shell path it checks.
+#
+# It reads the same manifest the Go command reads, so the two get identical
+# inputs by construction:
+#
+#   MANIFEST   the run manifest a measuring script wrote
+#   OUT_DIR    where results.json/matrix.json and their CSV and Markdown land
+#
+# Nothing here may be "cleaned up". A tidier oracle is an oracle that no longer
+# says what the old output was.
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+# shellcheck source=scripts/benchmark-lib.sh disable=SC1091
+source "$script_dir/benchmark-lib.sh"
+# shellcheck source=scripts/benchmark-link.sh disable=SC1091
+source "$script_dir/benchmark-link.sh"
+
+: "${MANIFEST:?MANIFEST is required}"
+: "${OUT_DIR:?OUT_DIR is required}"
+require_tools jq
+mkdir -p "$OUT_DIR"
+
+# The manifest holds everything the measuring script knew. Read back into the
+# variable names the code below already used, so that code stays a move rather
+# than a rewrite.
+CANDIDATE_REF=$(jq -r '.candidate_ref' "$MANIFEST")
+BASELINE_REF=$(jq -r '.baseline_ref' "$MANIFEST")
+reference_label=$(jq -r '.reference_label' "$MANIFEST")
+REPEATS=$(jq -r '.repeats' "$MANIFEST")
+runner=$(jq -r '.runner' "$MANIFEST")
+runner_display=$(jq -r '.runner_display' "$MANIFEST")
+settings=$(jq -r '.settings' "$MANIFEST")
+link_requested=$(jq -r '.link.requested // ""' "$MANIFEST")
+connections_display=$(jq -r '.grid.connections_display // ""' "$MANIFEST")
+concurrency_display=$(jq -r '.grid.concurrency_display // ""' "$MANIFEST")
+request_display=$(jq -r '.grid.request_display // ""' "$MANIFEST")
+CANARY_SCENARIO=$(jq -r '.grid.canary.scenario // ""' "$MANIFEST")
+CANARY_CONNECTIONS=$(jq -r '.grid.canary.connections // ""' "$MANIFEST")
+CANARY_CONCURRENCY=$(jq -r '.grid.canary.concurrency // ""' "$MANIFEST")
+BASELINE_BIN=''
+if [[ -n "$BASELINE_REF" ]]; then
+  BASELINE_BIN='measured'
+fi
+
+runs_file=$(jq -r '.files.runs' "$MANIFEST")
+deletes_file=$(jq -r '.files.deletes // ""' "$MANIFEST")
+probes_file=$(jq -r '.files.probes // ""' "$MANIFEST")
+canary_file=$(jq -r '.files.canary // ""' "$MANIFEST")
+auto_file=$(jq -r '.files.auto // ""' "$MANIFEST")
+
+LOG_DIR=$(mktemp -d)
+trap 'rm -rf "$LOG_DIR"' EXIT
+# The intermediate files the aggregation writes. In the measuring scripts these
+# were named next to the JSONL; here they are scratch and go away with LOG_DIR.
+aggregate_file="$LOG_DIR/aggregate.json"
+for name in deletes_file canary_file auto_file probes_file; do
+  path=${!name}
+  if [[ -z "$path" || ! -f "$path" ]]; then
+    printf -v "$name" '%s' "$LOG_DIR/empty-$name.jsonl"
+    : >"${!name}"
+  fi
+done
+
+mapfile -t SCENARIOS < <(jq -r '.scenarios[].name' "$MANIFEST")
+mapfile -t labels < <(jq -r '.labels[]' "$MANIFEST")
+mapfile -t link_profiles < <(jq -r '.link.profiles[]' "$MANIFEST")
+scenarios=("${SCENARIOS[@]}")
+
+# The declared grid, i.e. what was asked for before each scenario's payload
+# capped it. A standard manifest has no grid and leaves these empty. The null
+# element of the request axis travels as the token "default", which is how it
+# travelled through the measuring script too.
+mapfile -t connections_axis < <(jq -r '.grid.connections[]?' "$MANIFEST")
+mapfile -t concurrency_axis < <(jq -r '.grid.concurrency[]?' "$MANIFEST")
+mapfile -t request_axis < <(jq -r '.grid.request_concurrency[]? | if . == null then "default" else tostring end' "$MANIFEST")
+
+declare -A scenario_conn_axis scenario_conc_axis scenario_req_axis
+while IFS=$'	' read -r name conn conc req; do
+  scenario_conn_axis[$name]=$conn
+  scenario_conc_axis[$name]=$conc
+  scenario_req_axis[$name]=$req
+done < <(jq -r '.scenarios[] | [.name, .connections_display, .concurrency_display, .request_display] | @tsv' "$MANIFEST")
+
+scenario_docs=$(jq -c '[.scenarios[] | {key: .name, value: .description}] | from_entries' "$MANIFEST")
+per_scenario_axes=$(jq -c '[.scenarios[] | {key: .name, value: {files, connections, concurrency, request_concurrency}}] | from_entries' "$MANIFEST")
+
+# oracle_link_json is link_json with its shaping half taken from the manifest
+# rather than from the globals a measuring run would have set.
+oracle_link_json() {
+  local probes_json='[]'
+  if [[ -s "$probes_file" ]]; then
+    probes_json=$(jq -s '.' "$probes_file")
+  fi
+  jq -n \
+    --argjson link "$(jq -c '.link' "$MANIFEST")" \
+    --argjson probes "$probes_json" \
+    '{
+       iface: $link.iface,
+       shaping: $link.shaping,
+       probes: $probes,
+       note: "environment describes the runner and is the comparability key; link is measured and varies per run. Under a network ceiling a code delta cannot be interpreted."
+     }'
+}
+
+aggregate_standard() {
+# One aggregate row per (link profile, build, scenario). The timing fields at the
+# top level are exactly the ones results.json v1 had, so anything already reading
+# a stored benchmark keeps working; everything new sits in its own sub-object.
+# With no profiles requested there is exactly one profile, "baseline", and the
+# row count is what it always was.
+#
+# duration_ms.* is wall clock. process.* is what the run cost the machine.
+# phases[] is wall clock per phase and adds up to roughly the duration.
+# operations[] is cumulative across parallel workers and does not: see the
+# "note" field the metrics file carries.
+jq -s "
+  $JQ_STATS
+  group_by([.link_profile, .label, .scenario])
+  | map(
+      (map(select(.metrics != null)) | map(.metrics)) as \$m
+      | {
+        label: .[0].label,
+        ref: .[0].ref,
+        scenario: .[0].scenario,
+        link_profile: .[0].link_profile,
+        repeats: length,
+        failed_runs: (map(select(.exit_code != 0)) | length),
+        files: (map(.files) | max),
+        bytes: (map(.bytes) | max),
+        durations_ms: map(.duration_ms),
+        median_ms: (map(.duration_ms) | median),
+        min_ms: (map(.duration_ms) | min),
+        max_ms: (map(.duration_ms) | max),
+        mad_ms: (map(.duration_ms) | mad),
+        duration_ms: (map(.duration_ms) | stats),
+        retries: (map(.retries) | add),
+        errors: (map(.errors) | add),
+        refused_connections: (map(.refused) | add),
+        process: {
+          user_cpu_ms: (\$m | map(.process.user_cpu_ms) | median),
+          sys_cpu_ms: (\$m | map(.process.sys_cpu_ms) | median),
+          cpu_percent: (\$m | map(.process.cpu_percent) | median),
+          max_rss_bytes: (\$m | map(.process.max_rss_bytes) | median),
+          go_total_alloc_bytes: (\$m | map(.process.go_total_alloc_bytes) | median),
+          go_mallocs: (\$m | map(.process.go_mallocs) | median),
+          go_gc_count: (\$m | map(.process.go_gc_count) | median),
+          go_gc_pause_total_ms: (\$m | map(.process.go_gc_pause_total_ms) | median),
+          go_peak_goroutines: (\$m | map(.process.go_peak_goroutines) | max),
+          disk_read_bytes: (\$m | map(.process.disk_read_bytes) | median),
+          net_read_bytes: (\$m | map(.process.net_read_bytes) | median),
+          net_write_bytes: (\$m | map(.process.net_write_bytes) | median)
+        },
+        counters: (\$m | map(.counters // {}) | map(to_entries) | add // []
+          | group_by(.key)
+          | map({key: .[0].key, value: (map(.value) | median)}) | from_entries),
+        phases: (\$m | map(.phases // []) | add // []
+          | group_by(.name)
+          | map({name: .[0].name, median_ms: (map(.wall_ms) | median)})
+          | sort_by(-.median_ms)),
+        operations: (\$m | map(.operations // []) | add // []
+          | group_by(.name)
+          | map({
+              name: .[0].name,
+              count: (map(.count) | median),
+              median_total_ms: (map(.total_ms) | median),
+              avg_ms: (map(.avg_ms) | median),
+              p50_ms: (map(.p50_ms) | median),
+              p90_ms: (map(.p90_ms) | median),
+              p99_ms: (map(.p99_ms) | median),
+              max_ms: (map(.max_ms) | median),
+              errors: (map(.errors) | add)
+            })
+          | sort_by(-.median_total_ms))
+      })
+  | map(. + {
+      mib_per_s: (if .median_ms > 0 then ((.bytes / 1048576) / (.median_ms / 1000) | round2) else 0 end),
+      files_per_s: (if .median_ms > 0 then (.files / (.median_ms / 1000) | round2) else 0 end)
+    })
+" "$runs_file" >"$aggregate_file"
+
+# The delete sweeps, aggregated the same way and kept strictly apart: one row per
+# (link profile, build, scenario), sweeps that deleted nothing dropped, and a
+# group left with none dropped entirely rather than stored as a row of zeroes.
+delete_file="$LOG_DIR/delete.json"
+jq -s "
+  $JQ_STATS
+  $JQ_DELETE
+  group_by([.link_profile, .label, .scenario])
+  | map({label: .[0].label, scenario: .[0].scenario, link_profile: .[0].link_profile} + delete_agg)
+  | map(select(.sweeps > 0))
+" "$deletes_file" >"$delete_file"
+
+# reference_label, settings and scenario_docs were built here when this code
+# lived in the measuring script. They now come from the manifest, read at the
+# top of this file, exactly as they reach the Go command: what is under
+# comparison is the aggregation, and feeding the two sides different metadata
+# would only prove that two different inputs give two different documents.
+
+# results.json, schema_version 2. Layers, in the order a reader needs them:
+#   metadata (candidate_ref, baseline_ref, repeats, runner, settings, env)
+#   results   aggregated per build and scenario, incl. process/phases/operations
+#   comparison  candidate (and pool) against the reference build
+#   deletes   the pre-clean sweeps, aggregated apart from everything above
+#   runs      every individual repeat, verbatim, metrics included
+# v1's top-level keys all still exist and mean the same thing.
+# Through a file, not a process substitution: jq's --slurpfile wants a real
+# path, and /dev/fd is not one everywhere this may be run.
+runs_array="$LOG_DIR/runs.json"
+jq -s '.' "$runs_file" >"$runs_array"
+
+jq -n \
+  --slurpfile results "$aggregate_file" \
+  --slurpfile runs "$runs_array" \
+  --slurpfile deletes "$delete_file" \
+  --arg candidate_ref "$CANDIDATE_REF" \
+  --arg baseline_ref "$BASELINE_REF" \
+  --arg reference_label "$reference_label" \
+  --argjson repeats "$REPEATS" \
+  --arg runner "$runner" \
+  --argjson environment "$(jq -c .environment "$MANIFEST")" \
+  --argjson link "$(oracle_link_json)" \
+  --arg settings "$settings" \
+  --argjson scenarios "$scenario_docs" \
+  "
+  $JQ_STATS
+  (\$results[0]) as \$r
+  | {
+     schema_version: 2,
+     benchmark_kind: \"standard\",
+     candidate_ref: \$candidate_ref,
+     baseline_ref: \$baseline_ref,
+     repeats: \$repeats,
+     runner: \$runner,
+     environment: \$environment,
+     link: \$link,
+     settings: \$settings,
+     reference_label: \$reference_label,
+     scenarios: \$scenarios,
+     note: \"phases are wall clock and add up to the duration; operations are cumulative across parallel workers and do not\",
+     results: \$r,
+     deletes: \$deletes[0],
+     comparison: [
+       \$r[] | select(.label != \$reference_label) as \$c
+       | (\$r[] | select(.label == \$reference_label and .scenario == \$c.scenario
+            and .link_profile == \$c.link_profile)) as \$b
+       | {
+           scenario: \$c.scenario,
+           label: \$c.label,
+           link_profile: \$c.link_profile,
+           reference_label: \$reference_label,
+           median_ms: \$c.median_ms,
+           reference_median_ms: \$b.median_ms,
+           delta_ms: (\$c.median_ms - \$b.median_ms),
+           delta_percent: pct(\$c.median_ms; \$b.median_ms),
+           reference_mad_ms: \$b.mad_ms,
+           within_noise: (if (\$b.mad_ms // 0) == 0 then null
+             else ((if \$c.median_ms - \$b.median_ms < 0 then \$b.median_ms - \$c.median_ms else \$c.median_ms - \$b.median_ms end) <= \$b.mad_ms) end)
+         }
+     ],
+     runs: \$runs[0]
+   }" >"$OUT_DIR/results.json"
+
+# CSV alongside the JSON: one row per (build, scenario), so a spreadsheet or a
+# plot can read a stored result without a JSON parser. Deliberately flat and
+# aggregate-only; the raw repeats stay in results.json.
+#
+# link_profile, rtt_p50_ms and control_single_mib_per_s make a row readable on
+# its own: without them a throughput number cannot be told apart from the line
+# it was measured on. The two link numbers come from the profile's own start
+# probe, which is the one taken right before these runs.
+jq -r '
+  (.link.probes // []) as $probes
+  | ["scenario","build","ref","link_profile","rtt_p50_ms","control_single_mib_per_s",
+     "repeats","files","bytes","median_ms","min_ms","max_ms","mad_ms",
+     "mib_per_s","files_per_s","user_cpu_ms","sys_cpu_ms","cpu_percent","max_rss_bytes",
+     "go_gc_count","go_peak_goroutines","net_write_bytes","connections_opened","connections_refused",
+     "retries","errors","failed_runs"],
+  (.results[]
+   | . as $row
+   | ([$probes[] | select(.profile == $row.link_profile and .at == "start")] | first) as $p
+   | [
+    .scenario, .label, .ref, .link_profile,
+    ($p.rtt_ms.p50 // null), ($p.control.single_stream_mib_per_s // null),
+    .repeats, .files, .bytes, .median_ms, .min_ms, .max_ms, .mad_ms,
+    .mib_per_s, .files_per_s, .process.user_cpu_ms, .process.sys_cpu_ms, .process.cpu_percent,
+    .process.max_rss_bytes, .process.go_gc_count, .process.go_peak_goroutines, .process.net_write_bytes,
+    (.counters.connections_opened // 0), (.counters.connections_refused // 0),
+    .retries, .errors, .failed_runs
+  ])
+  | @csv
+' "$OUT_DIR/results.json" >"$OUT_DIR/results.csv"
+
+# summary.md carries the same numbers, readable. The delta column compares
+# every build's median against the reference build's; negative means faster.
+{
+  echo "## easySFTP benchmark"
+  echo
+  echo "| Setting | Value |"
+  echo "|---|---|"
+  echo "| Candidate | \`$CANDIDATE_REF\` |"
+  echo "| Baseline | \`${BASELINE_REF:-none}\` |"
+  echo "| Repeats per scenario | $REPEATS |"
+  echo "| Runner | $runner_display |"
+  echo "| Link profiles | ${link_requested:-the real line} |"
+  echo "| Settings | $settings |"
+  echo
+  link_markdown "$OUT_DIR/results.json"
+  echo "### Throughput"
+  echo
+  echo "| Scenario | Build | Profile | Files | Size | Median | Min | Max | MAD | MiB/s | files/s | Retries | Errors | Failed runs | Delta |"
+  echo "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|"
+  for scenario in "${SCENARIOS[@]}"; do
+    for label in "${labels[@]}"; do
+      for profile in "${link_profiles[@]}"; do
+        jq -r --arg s "$scenario" --arg l "$label" --arg p "$profile" '
+        (.results[] | select(.scenario == $s and .label == $l and .link_profile == $p)) as $row
+        # Through a list: the reference build has no comparison entry, and a
+        # bare "as" over an empty generator would drop its whole row.
+        | ([.comparison[] | select(.scenario == $s and .label == $l and .link_profile == $p) | .delta_percent] | first) as $delta
+        | "| \($s) | \($l) | \($p) | \($row.files) | \((($row.bytes / 1048576) * 10 | round / 10)) MiB "
+          + "| \($row.median_ms) ms | \($row.min_ms) ms | \($row.max_ms) ms | \(if $row.mad_ms == null then "-" else "\($row.mad_ms) ms" end) "
+          + "| \($row.mib_per_s) | \($row.files_per_s) | \($row.retries) | \($row.errors) | \($row.failed_runs) "
+          + "| \(if $delta == null then "-" else (if $delta > 0 then "+" else "" end) + ($delta | tostring) + "%" end) |"
+        ' "$OUT_DIR/results.json"
+      done
+    done
+  done
+  echo
+  echo "Delta compares each build's median against the \`$reference_label\` build **on the same link profile**; negative is faster. MAD is the median absolute deviation of the repeats: a delta smaller than it is inside this host's own noise."
+
+  echo
+  echo "### Resources (median per run)"
+  echo
+  echo "| Scenario | Build | Profile | User CPU | Sys CPU | CPU % | Peak RSS | Go allocs | GCs | GC pause | Peak goroutines | Net sent |"
+  echo "|---|---|---|---|---|---|---|---|---|---|---|---|"
+  # Looped rather than one jq pass over .results, so the rows come out in
+  # scenario order like the throughput table above instead of in jq's
+  # group_by order.
+  for scenario in "${SCENARIOS[@]}"; do
+    for label in "${labels[@]}"; do
+      for profile in "${link_profiles[@]}"; do
+        jq -r --arg s "$scenario" --arg l "$label" --arg p "$profile" \
+          '.results[] | select(.scenario == $s and .label == $l and .link_profile == $p)
+        | "| \(.scenario) | \(.label) | \(.link_profile) | \(.process.user_cpu_ms) ms | \(.process.sys_cpu_ms) ms | \(.process.cpu_percent)% "
+          + "| \(((.process.max_rss_bytes / 1048576) * 10 | round / 10)) MiB "
+          + "| \(((.process.go_total_alloc_bytes / 1048576) * 10 | round / 10)) MiB | \(.process.go_gc_count) "
+          + "| \(.process.go_gc_pause_total_ms) ms | \(.process.go_peak_goroutines) "
+          + "| \(((.process.net_write_bytes / 1048576) * 10 | round / 10)) MiB |"
+        ' "$OUT_DIR/results.json"
+      done
+    done
+  done
+
+  echo
+  echo "### Where the time goes"
+  echo
+  echo "Phases are wall clock and add up to roughly the run's duration. Operation totals are **cumulative across parallel workers** and are normally larger than the phase they belong to; read them for their share and their per-call cost, never as wall clock."
+  echo
+  for scenario in "${SCENARIOS[@]}"; do
+    echo "<details><summary><code>$scenario</code> phases and round-trips</summary>"
+    echo
+    echo "| Build | Profile | Phase | Wall |"
+    echo "|---|---|---|---|"
+    jq -r --arg s "$scenario" '.results[] | select(.scenario == $s) as $row
+      | $row.phases[] | select(.median_ms > 0)
+      | "| \($row.label) | \($row.link_profile) | \(.name) | \(.median_ms) ms |"' "$OUT_DIR/results.json"
+    echo
+    echo "| Build | Profile | Operation | Count | Cumulative | Avg | p50 | p90 | p99 | Max |"
+    echo "|---|---|---|---|---|---|---|---|---|---|"
+    jq -r --arg s "$scenario" '.results[] | select(.scenario == $s) as $row
+      | $row.operations[] | select(.count > 0)
+      | "| \($row.label) | \($row.link_profile) | \(.name) | \(.count) | \(.median_total_ms) ms | \(.avg_ms) ms | \(.p50_ms) ms | \(.p90_ms) ms | \(.p99_ms) ms | \(.max_ms) ms |"' "$OUT_DIR/results.json"
+    echo
+    echo "</details>"
+    echo
+  done
+
+  echo "### Delete sweeps"
+  echo
+  echo "The pre-clean before every measured run wipes the tree the previous repeat left behind, which makes it a pure delete sweep. It costs no extra time (it has always run) and its numbers never enter the upload tables above. Sweeps that found an empty directory are not counted."
+  echo
+  echo "| Scenario | Build | Profile | Sweeps | Files deleted | Median | files/s | remote_scan | delete_sweep |"
+  echo "|---|---|---|---|---|---|---|---|---|"
+  jq -r '
+    def phase($n): [.phases[] | select(.name == $n) | .median_ms] | first;
+    def ms: if . == null then "-" else "\(.) ms" end;
+    .deletes[]
+    | "| \(.scenario) | \(.label) | \(.link_profile) | \(.sweeps) | \(.files_deleted) | \(.median_ms) ms "
+      + "| \(.deletes_per_s) | \(phase("remote_scan") | ms) | \(phase("delete_sweep") | ms) |"
+  ' "$OUT_DIR/results.json"
+  echo
+  echo "| Scenario | Build | Profile | Operation | Count | Cumulative | p50 | p90 | p99 | Max |"
+  echo "|---|---|---|---|---|---|---|---|---|---|"
+  # sftp_remove and sftp_rmdir are the numbers issue #157 is about: one
+  # round-trip per entry, strictly sequential, no concurrency anywhere near them.
+  jq -r '.deletes[] as $d | $d.operations[] | select(.count > 0)
+    | "| \($d.scenario) | \($d.label) | \($d.link_profile) | \(.name) | \(.count) | \(.median_total_ms) ms "
+      + "| \(.p50_ms) ms | \(.p90_ms) ms | \(.p99_ms) ms | \(.max_ms) ms |"' "$OUT_DIR/results.json"
+  echo
+
+  # Without this line a pool run whose extra connections the server refused
+  # reads as "the pool did nothing", which is the wrong conclusion entirely.
+  refused=$(jq '[.results[].refused_connections] | add // 0' "$OUT_DIR/results.json")
+  if [[ "$refused" != 0 ]]; then
+    echo "**$refused connection(s) were refused by the server** and fell back to the run's first connection, so a pool build measured here had fewer connections than configured."
+    echo
+  fi
+  echo "Data only: these numbers set no threshold and fail no build. Collected to evaluate the single-connection ceiling discussed in issue #158 and to show where a run spends its time."
+} >"$OUT_DIR/summary.md"
+
+}
+
+aggregate_matrix() {
+cells_file="$LOG_DIR/cells.json"
+jq -s "
+  $JQ_STATS
+  group_by([.link_profile, .label, .scenario, .connections, .concurrency, .request_concurrency])
+  | map(
+      (map(select(.metrics != null)) | map(.metrics)) as \$m
+      | {
+        scenario: .[0].scenario,
+        label: .[0].label,
+        ref: .[0].ref,
+        link_profile: .[0].link_profile,
+        connections: .[0].connections,
+        concurrency: .[0].concurrency,
+        request_concurrency: .[0].request_concurrency,
+        repeats: length,
+        failed_runs: (map(select(.exit_code != 0)) | length),
+        files: (map(.files) | max),
+        bytes: (map(.bytes) | max),
+        durations_ms: map(.duration_ms),
+        median_ms: (map(.duration_ms) | median),
+        min_ms: (map(.duration_ms) | min),
+        max_ms: (map(.duration_ms) | max),
+        mad_ms: (map(.duration_ms) | mad),
+        retries: (map(.retries) | add),
+        errors: (map(.errors) | add),
+        user_cpu_ms: (\$m | map(.process.user_cpu_ms) | median),
+        sys_cpu_ms: (\$m | map(.process.sys_cpu_ms) | median),
+        cpu_percent: (\$m | map(.process.cpu_percent) | median),
+        max_rss_bytes: (\$m | map(.process.max_rss_bytes) | median),
+        go_gc_count: (\$m | map(.process.go_gc_count) | median),
+        go_peak_goroutines: (\$m | map(.process.go_peak_goroutines) | max),
+        net_write_bytes: (\$m | map(.process.net_write_bytes) | median),
+        connections_opened: (\$m | map(.counters.connections_opened // 0) | median),
+        connections_used: (\$m | map(.counters.connections_used // 0) | median),
+        # What the run actually ran with, not what the axis asked for: the
+        # request axis has a pass that sets nothing, and a null coordinate on
+        # its own does not say which value that was (issue #184, phase 5).
+        request_concurrency_used: (\$m | map(.counters.config_request_concurrency) | median),
+        connections_refused: (\$m | map(.counters.connections_refused // 0) | add),
+        reconnects: (\$m | map(.counters.reconnects // 0) | add),
+        upload_phase_ms: (\$m | map(.phases // []) | add // []
+          | map(select(.name == \"upload\") | .wall_ms) | median),
+        phases: (\$m | map(.phases // []) | add // []
+          | group_by(.name)
+          | map({name: .[0].name, median_ms: (map(.wall_ms) | median)})
+          | sort_by(-.median_ms)),
+        operations: (\$m | map(.operations // []) | add // []
+          | group_by(.name)
+          | map({
+              name: .[0].name,
+              count: (map(.count) | median),
+              median_total_ms: (map(.total_ms) | median),
+              avg_ms: (map(.avg_ms) | median),
+              p50_ms: (map(.p50_ms) | median),
+              p90_ms: (map(.p90_ms) | median),
+              p99_ms: (map(.p99_ms) | median),
+              max_ms: (map(.max_ms) | median),
+              errors: (map(.errors) | add)
+            })
+          | sort_by(-.median_total_ms))
+      })
+  | map(. + {
+      mib_per_s: (if .median_ms > 0 then ((.bytes / 1048576) / (.median_ms / 1000) | round2) else 0 end),
+      files_per_s: (if .median_ms > 0 then (.files / (.median_ms / 1000) | round2) else 0 end)
+    })
+  | sort_by([.link_profile, .scenario, .label, .connections, .concurrency, .request_concurrency])
+" "$runs_file" >"$cells_file"
+
+# The delete sweeps, one row per cell coordinate, sweeps that found an empty
+# directory dropped (the first cell of a build and scenario is one) and a
+# coordinate left with none dropped with them. Kept apart from cells[]: a delete
+# sweep and an upload at the same coordinates are two different measurements.
+deletes_agg_file="$LOG_DIR/deletes.json"
+jq -s "
+  $JQ_STATS
+  $JQ_DELETE
+  group_by([.link_profile, .label, .scenario, .connections, .concurrency, .request_concurrency])
+  | map({
+      scenario: .[0].scenario, label: .[0].label, link_profile: .[0].link_profile,
+      connections: .[0].connections, concurrency: .[0].concurrency,
+      request_concurrency: .[0].request_concurrency
+    } + delete_agg)
+  | map(select(.sweeps > 0))
+  | sort_by([.link_profile, .scenario, .label, .connections, .concurrency, .request_concurrency])
+" "$deletes_file" >"$deletes_agg_file"
+
+# The auto runs, one row per (profile, scenario). "chosen" is read out of the
+# run's own counters, so it says what easySFTP did rather than what this script
+# expects it to do; the regret against the grid is added further down, where the
+# cells are in scope.
+auto_agg_file="$LOG_DIR/auto.json"
+jq -s "
+  $JQ_STATS
+  group_by([.link_profile, .scenario])
+  | map(
+      (map(select(.metrics != null)) | map(.metrics)) as \$m
+      | {
+        scenario: .[0].scenario,
+        label: \"auto\",
+        ref: .[0].ref,
+        link_profile: .[0].link_profile,
+        repeats: length,
+        failed_runs: (map(select(.exit_code != 0)) | length),
+        files: (map(.files) | max),
+        bytes: (map(.bytes) | max),
+        durations_ms: map(.duration_ms),
+        median_ms: (map(.duration_ms) | median),
+        min_ms: (map(.duration_ms) | min),
+        max_ms: (map(.duration_ms) | max),
+        mad_ms: (map(.duration_ms) | mad),
+        chosen: {
+          connections: (\$m | map(.counters.config_connections) | median),
+          concurrency: (\$m | map(.counters.config_concurrency) | median),
+          request_concurrency: (\$m | map(.counters.config_request_concurrency) | median)
+        }
+      })
+  | map(. + {
+      mib_per_s: (if .median_ms > 0 then ((.bytes / 1048576) / (.median_ms / 1000) | round2) else 0 end),
+      files_per_s: (if .median_ms > 0 then (.files / (.median_ms / 1000) | round2) else 0 end)
+    })
+  | sort_by([.link_profile, .scenario])
+" "$auto_file" >"$auto_agg_file"
+
+# per_scenario_axes, settings and scenario_docs were built here when this code
+# lived in the measuring script. They now come from the manifest, read at the
+# top of this file, exactly as they reach the Go command: what is under
+# comparison is the aggregation, and feeding the two sides different metadata
+# would only prove that two different inputs give two different documents.
+
+# matrix.json. "axes" declares the grid explicitly so a heatmap does not have to
+# infer it from the cells that happen to be present, "cells" is one row per
+# combination, "scaling" is the same data pre-grouped into the curve a reader
+# usually wants (per scenario and build, ordered by connections then
+# concurrency), "comparison" pairs each candidate cell with the reference
+# build's cell at the same coordinates, "canary" holds the fixed cell's three
+# measurements per profile, and "deletes" holds the pre-clean sweeps at the same
+# coordinates as the cells.
+#
+# A matrix run has no "runs[]" the way a standard result does, so a cell is the
+# finest grain there is. That is why it carries its own phases[] and
+# operations[] and not just upload_phase_ms: those are hours of measurement that
+# used to be aggregated and then dropped (issue #184, phase 2).
+#
+# "auto" is the policy measurement of phase 5: what easySFTP picked when asked
+# to pick, what the grid says was best, and the gap. "scaling[].best_at_axis_max"
+# is the other half of that: an optimum sitting on the largest value of an axis
+# was not measured, it was cut off, and a policy fitted to such a grid
+# extrapolates. Both are reported per scenario and profile, never averaged: the
+# whole point is that they differ per link.
+jq -n \
+  --slurpfile cells "$cells_file" \
+  --slurpfile auto "$auto_agg_file" \
+  --argjson per_scenario_axes "$per_scenario_axes" \
+  --arg candidate_ref "$CANDIDATE_REF" \
+  --arg baseline_ref "$BASELINE_REF" \
+  --arg reference_label "$reference_label" \
+  --argjson repeats "$REPEATS" \
+  --arg runner "$runner" \
+  --argjson environment "$(jq -c .environment "$MANIFEST")" \
+  --argjson link "$(oracle_link_json)" \
+  --argjson canary "$(jq -s '.' "$canary_file")" \
+  --slurpfile deletes "$deletes_agg_file" \
+  --arg settings "$settings" \
+  --argjson scenarios "$scenario_docs" \
+  --argjson link_axis "$(printf '%s\n' "${link_profiles[@]}" | jq -Rs 'split("\n") | map(select(. != ""))')" \
+  --argjson connections_axis "$(printf '%s\n' "${connections_axis[@]}" | jq -s '.')" \
+  --argjson concurrency_axis "$(printf '%s\n' "${concurrency_axis[@]}" | jq -s '.')" \
+  --argjson request_axis "$(printf '%s\n' "${request_axis[@]}" | jq -Rs 'split("\n") | map(select(. != "") | if . == "default" then null else tonumber end)')" \
+  "
+  $JQ_STATS
+  (\$cells[0]) as \$c
+  | {
+     schema_version: 2,
+     benchmark_kind: \"matrix\",
+     candidate_ref: \$candidate_ref,
+     baseline_ref: \$baseline_ref,
+     reference_label: \$reference_label,
+     repeats: \$repeats,
+     runner: \$runner,
+     environment: \$environment,
+     link: \$link,
+     canary: \$canary,
+     settings: \$settings,
+     scenarios: \$scenarios,
+     note: \"one cell per (link_profile, scenario, build, connections, concurrency, request_concurrency); median_ms is wall clock over the cell's repeats. Each scenario is swept over the axis values its payload can use (axes.per_scenario), so a cell absent from the declared axes was not skipped, it was the same configuration twice. auto[] is off the grid: it is the settings easySFTP picked for itself, scored against the best cell\",
+     axes: {
+       link_profiles: \$link_axis,
+       connections: \$connections_axis,
+       concurrency: \$concurrency_axis,
+       request_concurrency: \$request_axis,
+       per_scenario: \$per_scenario_axes
+     },
+     cells: \$c,
+     deletes: \$deletes[0],
+     scaling: (\$c | group_by([.link_profile, .scenario, .label])
+       | map(. as \$g
+         | (\$g | sort_by(.median_ms) | .[0]) as \$best
+         | {
+           scenario: .[0].scenario,
+           label: .[0].label,
+           link_profile: .[0].link_profile,
+           points: (sort_by([.connections, .concurrency])
+             | map({connections, concurrency, request_concurrency, request_concurrency_used,
+                    median_ms, mib_per_s, files_per_s,
+                    connections_used, connections_refused, max_rss_bytes, user_cpu_ms})),
+           best: (\$best | {connections, concurrency, request_concurrency, median_ms, mib_per_s, files_per_s}),
+           best_at_axis_max: ([
+             (if ((\$g | map(.connections) | unique | length) > 1)
+                 and \$best.connections == (\$g | map(.connections) | max)
+               then \"connections\" else empty end),
+             (if ((\$g | map(.concurrency) | unique | length) > 1)
+                 and \$best.concurrency == (\$g | map(.concurrency) | max)
+               then \"concurrency\" else empty end),
+             (if ((\$g | map(.request_concurrency) | unique | length) > 1)
+                 and \$best.request_concurrency != null
+                 and \$best.request_concurrency == (\$g | map(.request_concurrency) | max)
+               then \"request_concurrency\" else empty end)
+           ])
+         })),
+     auto: (\$auto[0] | map(. as \$a
+       | ([\$c[] | select(.label == \"candidate\" and .scenario == \$a.scenario
+            and .link_profile == \$a.link_profile)] | sort_by(.median_ms) | first) as \$best
+       | ([\$c[] | select(.label == \"candidate\" and .scenario == \$a.scenario
+            and .link_profile == \$a.link_profile
+            and .connections == \$a.chosen.connections
+            and .concurrency == \$a.chosen.concurrency
+            and .request_concurrency_used == \$a.chosen.request_concurrency)] | first) as \$at
+       | \$a + {
+           best: (if \$best == null then null
+             else (\$best | {connections, concurrency, request_concurrency, median_ms, mib_per_s, files_per_s})
+             end),
+           chosen_in_grid: (\$at != null),
+           chosen_cell_median_ms: (if \$at == null then null else \$at.median_ms end),
+           regret_ms: (if \$best == null then null else \$a.median_ms - \$best.median_ms end),
+           regret_percent: (if \$best == null then null else pct(\$a.median_ms; \$best.median_ms) end)
+         })),
+     comparison: [
+       \$c[] | select(.label != \$reference_label) as \$x
+       | (\$c[] | select(.label == \$reference_label and .scenario == \$x.scenario
+            and .link_profile == \$x.link_profile
+            and .connections == \$x.connections and .concurrency == \$x.concurrency
+            and .request_concurrency == \$x.request_concurrency)) as \$b
+       | {
+           scenario: \$x.scenario, label: \$x.label, reference_label: \$reference_label,
+           link_profile: \$x.link_profile,
+           connections: \$x.connections, concurrency: \$x.concurrency,
+           request_concurrency: \$x.request_concurrency,
+           median_ms: \$x.median_ms, reference_median_ms: \$b.median_ms,
+           delta_ms: (\$x.median_ms - \$b.median_ms),
+           delta_percent: pct(\$x.median_ms; \$b.median_ms)
+         }
+     ]
+   }" >"$OUT_DIR/matrix.json"
+
+# One flat row per cell: this is the file a heatmap or a scaling plot reads.
+#
+# link_profile, rtt_p50_ms and control_single_mib_per_s come along so a cell is
+# readable on its own. net_write_bytes is here too: cells[] has always carried
+# it, and it is the protocol-overhead number (117% of payload for "small").
+jq -r '
+  (.link.probes // []) as $probes
+  | ["scenario","build","ref","link_profile","rtt_p50_ms","control_single_mib_per_s",
+     "connections","concurrency","request_concurrency","request_concurrency_used","repeats",
+     "files","bytes","median_ms","min_ms","max_ms","mad_ms","mib_per_s","files_per_s",
+     "upload_phase_ms","net_write_bytes","user_cpu_ms","sys_cpu_ms","cpu_percent","max_rss_bytes","go_gc_count",
+     "go_peak_goroutines","connections_opened","connections_used","connections_refused",
+     "reconnects","retries","errors","failed_runs"],
+  (.cells[]
+   | . as $cell
+   | ([$probes[] | select(.profile == $cell.link_profile and .at == "start")] | first) as $p
+   | [
+    .scenario, .label, .ref, .link_profile,
+    ($p.rtt_ms.p50 // null), ($p.control.single_stream_mib_per_s // null),
+    .connections, .concurrency, .request_concurrency, .request_concurrency_used, .repeats,
+    .files, .bytes, .median_ms, .min_ms, .max_ms, .mad_ms, .mib_per_s, .files_per_s,
+    .upload_phase_ms, .net_write_bytes, .user_cpu_ms, .sys_cpu_ms, .cpu_percent, .max_rss_bytes, .go_gc_count,
+    .go_peak_goroutines, .connections_opened, .connections_used, .connections_refused,
+    .reconnects, .retries, .errors, .failed_runs
+  ])
+  | @csv
+' "$OUT_DIR/matrix.json" >"$OUT_DIR/matrix.csv"
+
+{
+  echo "## easySFTP connections/concurrency matrix"
+  echo
+  echo "| Setting | Value |"
+  echo "|---|---|"
+  echo "| Candidate | \`$CANDIDATE_REF\` |"
+  echo "| Baseline | \`${BASELINE_REF:-none}\` |"
+  echo "| Repeats per cell | $REPEATS |"
+  echo "| Runner | $runner_display |"
+  echo "| connections | $connections_display |"
+  echo "| concurrency | $concurrency_display |"
+  echo "| request_concurrency | ${request_display:-easySFTP default} |"
+  echo "| Link profiles | ${link_requested:-the real line} |"
+  echo "| Scenarios | ${scenarios[*]} |"
+  echo
+  # What each scenario is, next to the numbers: "sync" and "redeploy" are a
+  # deploy shape and not only a payload, and a MiB/s of theirs is over the few
+  # changed files rather than over the tree.
+  echo "| Scenario | Mode | Payload | connections | concurrency | request_concurrency |"
+  echo "|---|---|---|---|---|---|"
+  for scenario in "${scenarios[@]}"; do
+    read -r mode prepopulate _ <<<"$(scenario_shape "$scenario")"
+    if ((prepopulate)); then
+      mode="$mode, redeployed"
+    fi
+    echo "| \`$scenario\` | $mode | $(scenario_description "$scenario") | ${scenario_conn_axis[$scenario]} | ${scenario_conc_axis[$scenario]} | ${scenario_req_axis[$scenario]} |"
+  done
+  echo
+  echo "The last three columns are the axis values this scenario was swept over, which are not always the ones requested above. A value larger than the payload's file count is the same configuration under another name (only the per-file upload path spreads over connections and workers), and \`request_concurrency\` is a per-file setting that a payload of small files cannot use at all, so both are capped against the payload rather than measured twice."
+  echo
+  link_markdown "$OUT_DIR/matrix.json"
+  echo "Each grid below is median wall-clock milliseconds: rows are \`advanced.connections\`, columns are \`advanced.concurrency\`. Lower is better. \`connections > concurrency\` is measured, not skipped; easySFTP caps the pool at the concurrency (a connection no worker picks is a handshake for nothing), so those cells are expected to flatten out rather than improve."
+  echo
+
+  for scenario in "${scenarios[@]}"; do
+    read -r -a axis_conn <<<"${scenario_conn_axis[$scenario]}"
+    read -r -a axis_conc <<<"${scenario_conc_axis[$scenario]}"
+    read -r -a axis_req <<<"${scenario_req_axis[$scenario]}"
+    for label in "${labels[@]}"; do
+      for profile in "${link_profiles[@]}"; do
+        for request in "${axis_req[@]}"; do
+          title="\`$scenario\` / $label / $profile"
+          if [[ "$request" != default ]]; then
+            title="$title / request_concurrency $request"
+          fi
+          echo "#### $title"
+          echo
+          printf '| connections \\ concurrency |'
+          for conc in "${axis_conc[@]}"; do printf ' %s |' "$conc"; done
+          printf '\n|---|'
+          # "%s": bash's printf reads a leading "-" in the format as an option.
+          for _ in "${axis_conc[@]}"; do printf '%s' '---|'; done
+          printf '\n'
+          for conns in "${axis_conn[@]}"; do
+            printf '| %s |' "$conns"
+            for conc in "${axis_conc[@]}"; do
+              req_json=null
+              if [[ "$request" != default ]]; then req_json=$request; fi
+              cell=$(jq -r --arg s "$scenario" --arg l "$label" --arg p "$profile" \
+                --argjson conns "$conns" --argjson conc "$conc" \
+                --argjson req "$req_json" '
+              [.cells[] | select(.scenario == $s and .label == $l and .link_profile == $p
+                 and .connections == $conns
+                 and .concurrency == $conc and .request_concurrency == $req)] | first
+              | if . == null then "-"
+                else "\(.median_ms) ms<br>\(.mib_per_s) MiB/s"
+                  + (if .connections_refused > 0 then "<br>\(.connections_refused) refused" else "" end)
+                end' "$OUT_DIR/matrix.json")
+              printf ' %s |' "$cell"
+            done
+            printf '\n'
+          done
+          echo
+        done
+      done
+    done
+  done
+
+  echo "### Best cell per scenario, build and link profile"
+  echo
+  echo "| Scenario | Build | Profile | connections | concurrency | request_concurrency | Median | MiB/s | files/s | On an axis edge |"
+  echo "|---|---|---|---|---|---|---|---|---|---|"
+  jq -r '.scaling[] | "| \(.scenario) | \(.label) | \(.link_profile) | \(.best.connections) | \(.best.concurrency) | \(.best.request_concurrency // "default") | \(.best.median_ms) ms | \(.best.mib_per_s) | \(.best.files_per_s) | \(if (.best_at_axis_max | length) == 0 then "no" else (.best_at_axis_max | join(", ")) end) |"' \
+    "$OUT_DIR/matrix.json"
+  echo
+  # The check the auto-config work of issue #184 phase 5 rests on: a best cell
+  # sitting on the largest value of an axis is a cut-off, not an optimum, and
+  # anything fitted to it extrapolates. Only the upper edge is reported; the
+  # lower one is 1 and there is nothing below it to sweep.
+  boundary=$(jq -r '[.scaling[] | select((.best_at_axis_max | length) > 0)
+    | "\(.scenario)/\(.label)/\(.link_profile): \(.best_at_axis_max | join(", "))"] | join("; ")' \
+    "$OUT_DIR/matrix.json")
+  if [[ -n "$boundary" ]]; then
+    echo "**The optimum sits on the edge of the grid** for $boundary. The best value measured is the largest one swept, so the real optimum is at or beyond it and this sweep does not contain it. Extend that axis before fitting anything to these numbers."
+  else
+    echo "Every best cell is interior to its axes, so each optimum was measured rather than cut off."
+  fi
+
+  if [[ -n "$BASELINE_BIN" ]]; then
+    echo
+    echo "### Candidate against baseline, worst and best cell"
+    echo
+    echo "| Scenario | Profile | connections | concurrency | Candidate | Baseline | Delta |"
+    echo "|---|---|---|---|---|---|---|"
+    # Grouped per profile as well: the worst cell of one profile and the best of
+    # another are not two ends of one distribution.
+    jq -r '.comparison | group_by([.link_profile, .scenario])
+      | map(sort_by(.delta_percent // 0) | [.[0], .[-1]]) | flatten | unique_by([.link_profile, .scenario, .connections, .concurrency])
+      | .[] | "| \(.scenario) | \(.link_profile) | \(.connections) | \(.concurrency) | \(.median_ms) ms | \(.reference_median_ms) ms | \(if .delta_percent == null then "-" else (if .delta_percent > 0 then "+" else "" end) + (.delta_percent | tostring) + "%" end) |"' \
+      "$OUT_DIR/matrix.json"
+  fi
+
+  echo
+  echo "### What \`auto\` costs (policy regret)"
+  echo
+  echo "One run per scenario and profile with \`connections\`, \`concurrency\` and \`request_concurrency\` all set to \`auto\`, on the candidate build, measured next to the cells it is scored against. \`Picked\` is read out of the run's own counters, so it is what easySFTP did and not what this script assumes; \`Best\` is the fastest cell of the same scenario and profile. \`Regret\` is the gap between them: how much slower the policy is than the settings a sweep would have chosen. A policy within ~15% on every profile is defensible, one that only wins on the house line is not (issue #184, phase 5; the policy itself is #156)."
+  echo
+  echo "| Scenario | Profile | Picked (conn/conc/req) | auto | Best cell | Best | Regret | Same cell in grid |"
+  echo "|---|---|---|---|---|---|---|---|"
+  jq -r '
+    def cell($x): if $x == null then "-" else "\($x.connections)/\($x.concurrency)/\($x.request_concurrency // "default")" end;
+    .auto[]
+    | "| \(.scenario) | \(.link_profile) | \(.chosen.connections)/\(.chosen.concurrency)/\(.chosen.request_concurrency) "
+      + "| \(.median_ms) ms | \(cell(.best)) | \(if .best == null then "-" else "\(.best.median_ms) ms" end) "
+      + "| \(if .regret_percent == null then "-" else (if .regret_percent > 0 then "+" else "" end) + (.regret_percent | tostring) + "%" end) "
+      + "| \(if .chosen_in_grid then "\(.chosen_cell_median_ms) ms" else "not swept" end) |"
+  ' "$OUT_DIR/matrix.json"
+  echo
+  echo "The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the \`auto\` column means the two runs saw different conditions, and then the regret next to it is drift rather than policy. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all."
+
+  echo
+  echo "### Canary"
+  echo
+  echo "One fixed cell (\`$CANARY_SCENARIO\`, connections $CANARY_CONNECTIONS, concurrency $CANARY_CONCURRENCY, candidate build) measured at the start, the middle and the end of each profile's grid. Spread is the gap between the fastest and the slowest of them. A spread larger than the deltas below it means the server or the line moved during the sweep, and the whole run is a poor comparison basis."
+  echo
+  echo "| Profile | Start | Middle | End | Spread |"
+  echo "|---|---|---|---|---|"
+  jq -r '
+    def pick($a): [.[] | select(.at == $a) | .duration_ms] | first;
+    def ms: if . == null then "-" else "\(.) ms" end;
+    .canary | group_by(.link_profile)[]
+    | (map(.duration_ms)) as $d
+    | "| \(.[0].link_profile) | \(pick("start") | ms) | \(pick("mid") | ms) | \(pick("end") | ms) "
+      + "| \(if ($d | min) > 0 then ((($d | max) - ($d | min)) / ($d | min) * 100 | round | tostring) + "%" else "-" end) |"
+  ' "$OUT_DIR/matrix.json"
+
+  echo
+  echo "### Delete sweeps"
+  echo
+  echo "Every cell's pre-clean wipes the tree the cell before it left behind, at that cell's own \`connections\`/\`concurrency\`. It has always run and cost nothing extra; what is new is that it is measured (issue #184, phase 4). Cells whose pre-clean found an empty directory are not listed. Read the two columns on the right against #157: deletions are one round-trip per entry and the pool has nowhere to spread them."
+  echo
+  echo "<details><summary>Per-cell delete sweeps</summary>"
+  echo
+  echo "| Scenario | Build | Profile | conn | conc | Files deleted | Median | files/s | remote_scan | delete_sweep | sftp_remove p50 | sftp_rmdir p50 |"
+  echo "|---|---|---|---|---|---|---|---|---|---|---|---|"
+  jq -r '
+    def phase($n): [.phases[] | select(.name == $n) | .median_ms] | first;
+    def op($n): [.operations[] | select(.name == $n) | .p50_ms] | first;
+    def ms: if . == null then "-" else "\(.) ms" end;
+    .deletes[]
+    | "| \(.scenario) | \(.label) | \(.link_profile) | \(.connections) | \(.concurrency) "
+      + "| \(.files_deleted) | \(.median_ms) ms | \(.deletes_per_s) "
+      + "| \(phase("remote_scan") | ms) | \(phase("delete_sweep") | ms) "
+      + "| \(op("sftp_remove") | ms) | \(op("sftp_rmdir") | ms) |"
+  ' "$OUT_DIR/matrix.json"
+  echo
+  echo "</details>"
+
+  refused=$(jq '[.cells[].connections_refused] | add // 0' "$OUT_DIR/matrix.json")
+  if [[ "$refused" != 0 ]]; then
+    echo
+    echo "**$refused connection(s) were refused by the server** across the sweep and fell back to the run's first connection. Those cells had fewer connections than configured, which is the server's limit showing up in the data, not easySFTP's."
+  fi
+  echo
+  echo "Raw data: \`matrix.json\` (every cell with its own phases and round-trip percentiles, plus the pre-grouped \`scaling\` view, the \`auto\` policy runs, the \`canary\` runs and the \`deletes\` sweeps), \`matrix.csv\` (one flat row per cell). Data only: nothing here fails a build."
+} >"$OUT_DIR/matrix.md"
+}
+
+if [[ "$(jq -r '.kind' "$MANIFEST")" == matrix ]]; then
+  aggregate_matrix
+else
+  aggregate_standard
+fi

--- a/scripts/benchmark-lib.sh
+++ b/scripts/benchmark-lib.sh
@@ -2,8 +2,12 @@
 #
 # Shared measurement core of scripts/benchmark.sh and
 # scripts/benchmark-matrix.sh: payload generation, running one easySFTP build,
-# reading its step outputs and its metrics file, and the jq statistics both
-# scripts aggregate with.
+# reading its step outputs and its metrics file.
+#
+# The aggregation these scripts used to do here moved to cmd/easysftp-bench
+# (issue #190). What is left of it are JQ_STATS and JQ_DELETE below, which only
+# scripts/benchmark-aggregate-jq.sh still uses, as the parity oracle for that
+# move. Do not build anything new on them.
 #
 # Sourced, never executed. The caller is responsible for validating and
 # exporting the environment described in its own header; this file only reads:
@@ -507,6 +511,45 @@ JQ_DELETE='
     | . + {deletes_per_s:
         (if .median_ms > 0 then (.files_deleted / (.median_ms / 1000) | round2) else 0 end)};
 '
+
+# bench_tool: how to run cmd/easysftp-bench, which turns the JSONL both scripts
+# append to into results.json/matrix.json and their CSV and Markdown (issue
+# #190).
+#
+# BENCH_TOOL names a built binary where the workflow already built one. Without
+# it the command is run from source, which needs the Go toolchain the benchmark
+# runner has anyway (bench_environment already calls "go version").
+bench_tool() {
+  if [[ -n "${BENCH_TOOL:-}" ]]; then
+    "$BENCH_TOOL" "$@"
+  else
+    # SC2154: script_dir belongs to the sourcing script, like everything else
+    # this file documents in its header.
+    # shellcheck disable=SC2154
+    (cd "$script_dir/.." && go run ./cmd/easysftp-bench "$@")
+  fi
+}
+
+# json_array_of <value>...: the arguments as a JSON array of numbers, with the
+# token "default" mapped to null. That token is the request_concurrency pass
+# that sets nothing and leaves easySFTP its own value.
+json_array_of() {
+  if (($# == 0)); then
+    echo '[]'
+    return
+  fi
+  printf '%s\n' "$@" | jq -Rs 'split("\n") | map(select(. != "")
+    | if . == "default" then null else tonumber end)'
+}
+
+# json_strings_of <value>...: the arguments as a JSON array of strings.
+json_strings_of() {
+  if (($# == 0)); then
+    echo '[]'
+    return
+  fi
+  printf '%s\n' "$@" | jq -Rs 'split("\n") | map(select(. != ""))'
+}
 
 # bench_environment: the machine and toolchain a result was measured on, as
 # JSON. Two results are only comparable when this matches; benchmarks/README.md

--- a/scripts/benchmark-link.sh
+++ b/scripts/benchmark-link.sh
@@ -281,6 +281,38 @@ link_probe() {
     <<<"$wrapped"
 }
 
+# link_manifest_json <requested-input> <profile>...: the shaping half of the
+# link object, for the run manifest (issue #190).
+#
+# The probes are deliberately not in here: they are read from the probe file by
+# whatever assembles the result, so a run without a probe binary simply has
+# none. This carries only what the shell knows and the aggregation cannot
+# derive: which interface was shaped, whether shaping was possible, what was
+# asked for, what was applied, and the raw input string the summary prints.
+link_manifest_json() {
+  local requested=$1
+  shift
+  jq -n \
+    --arg iface "${LINK_IFACE:-}" \
+    --argjson available "$((LINK_SHAPING_AVAILABLE == 1 ? 1 : 0))" \
+    --arg reason "$LINK_SHAPING_REASON" \
+    --argjson profile_requested "$(printf '%s\n' "${LINK_REQUESTED[@]+"${LINK_REQUESTED[@]}"}" | jq -Rs 'split("\n") | map(select(. != ""))')" \
+    --argjson applied "$(printf '%s\n' "${LINK_APPLIED[@]+"${LINK_APPLIED[@]}"}" | jq -Rs 'split("\n") | map(select(. != ""))')" \
+    --argjson profiles "$(printf '%s\n' "$@" | jq -Rs 'split("\n") | map(select(. != ""))')" \
+    --arg requested "$requested" \
+    '{
+       iface: (if $iface == "" then null else $iface end),
+       shaping: {
+         available: ($available == 1),
+         reason: (if $reason == "" then null else $reason end),
+         requested: $profile_requested,
+         applied: $applied
+       },
+       profiles: $profiles,
+       requested: $requested
+     }'
+}
+
 # link_json <probes-file>: the "link" object a result stores. Always valid JSON,
 # even when nothing was probed and nothing was shaped.
 link_json() {

--- a/scripts/benchmark-matrix.sh
+++ b/scripts/benchmark-matrix.sh
@@ -44,6 +44,10 @@
 #   LINKPROBE_BIN               optional built cmd/linkprobe; without it the
 #                               result carries an empty probe list
 #   LINK_IFACE, LINK_SUDO       see scripts/benchmark-link.sh
+#   BENCH_TOOL                  optional built cmd/easysftp-bench, which turns
+#                               the JSONL measured here into matrix.json,
+#                               matrix.csv and matrix.md (issue #190). Without
+#                               it the command is run from source
 #   REPEATS                     repeats per cell (default 1)
 #
 # Cost warning: the grid is measured in full, but it is measured *per scenario*.
@@ -505,482 +509,100 @@ if [[ -n "${LINKPROBE_BIN:-}" ]]; then
     "$REMOTE_BASE/linkprobe" clean "$LOG_DIR/cleanup-linkprobe.log" "$LOG_DIR/cleanup-linkprobe.out" "" ||
     echo "::warning::cleanup of the link probe directory failed"
 fi
-
-cells_file="$LOG_DIR/cells.json"
-jq -s "
-  $JQ_STATS
-  group_by([.link_profile, .label, .scenario, .connections, .concurrency, .request_concurrency])
-  | map(
-      (map(select(.metrics != null)) | map(.metrics)) as \$m
-      | {
-        scenario: .[0].scenario,
-        label: .[0].label,
-        ref: .[0].ref,
-        link_profile: .[0].link_profile,
-        connections: .[0].connections,
-        concurrency: .[0].concurrency,
-        request_concurrency: .[0].request_concurrency,
-        repeats: length,
-        failed_runs: (map(select(.exit_code != 0)) | length),
-        files: (map(.files) | max),
-        bytes: (map(.bytes) | max),
-        durations_ms: map(.duration_ms),
-        median_ms: (map(.duration_ms) | median),
-        min_ms: (map(.duration_ms) | min),
-        max_ms: (map(.duration_ms) | max),
-        mad_ms: (map(.duration_ms) | mad),
-        retries: (map(.retries) | add),
-        errors: (map(.errors) | add),
-        user_cpu_ms: (\$m | map(.process.user_cpu_ms) | median),
-        sys_cpu_ms: (\$m | map(.process.sys_cpu_ms) | median),
-        cpu_percent: (\$m | map(.process.cpu_percent) | median),
-        max_rss_bytes: (\$m | map(.process.max_rss_bytes) | median),
-        go_gc_count: (\$m | map(.process.go_gc_count) | median),
-        go_peak_goroutines: (\$m | map(.process.go_peak_goroutines) | max),
-        net_write_bytes: (\$m | map(.process.net_write_bytes) | median),
-        connections_opened: (\$m | map(.counters.connections_opened // 0) | median),
-        connections_used: (\$m | map(.counters.connections_used // 0) | median),
-        # What the run actually ran with, not what the axis asked for: the
-        # request axis has a pass that sets nothing, and a null coordinate on
-        # its own does not say which value that was (issue #184, phase 5).
-        request_concurrency_used: (\$m | map(.counters.config_request_concurrency) | median),
-        connections_refused: (\$m | map(.counters.connections_refused // 0) | add),
-        reconnects: (\$m | map(.counters.reconnects // 0) | add),
-        upload_phase_ms: (\$m | map(.phases // []) | add // []
-          | map(select(.name == \"upload\") | .wall_ms) | median),
-        phases: (\$m | map(.phases // []) | add // []
-          | group_by(.name)
-          | map({name: .[0].name, median_ms: (map(.wall_ms) | median)})
-          | sort_by(-.median_ms)),
-        operations: (\$m | map(.operations // []) | add // []
-          | group_by(.name)
-          | map({
-              name: .[0].name,
-              count: (map(.count) | median),
-              median_total_ms: (map(.total_ms) | median),
-              avg_ms: (map(.avg_ms) | median),
-              p50_ms: (map(.p50_ms) | median),
-              p90_ms: (map(.p90_ms) | median),
-              p99_ms: (map(.p99_ms) | median),
-              max_ms: (map(.max_ms) | median),
-              errors: (map(.errors) | add)
-            })
-          | sort_by(-.median_total_ms))
-      })
-  | map(. + {
-      mib_per_s: (if .median_ms > 0 then ((.bytes / 1048576) / (.median_ms / 1000) | round2) else 0 end),
-      files_per_s: (if .median_ms > 0 then (.files / (.median_ms / 1000) | round2) else 0 end)
-    })
-  | sort_by([.link_profile, .scenario, .label, .connections, .concurrency, .request_concurrency])
-" "$runs_file" >"$cells_file"
-
-# The delete sweeps, one row per cell coordinate, sweeps that found an empty
-# directory dropped (the first cell of a build and scenario is one) and a
-# coordinate left with none dropped with them. Kept apart from cells[]: a delete
-# sweep and an upload at the same coordinates are two different measurements.
-deletes_agg_file="$LOG_DIR/deletes.json"
-jq -s "
-  $JQ_STATS
-  $JQ_DELETE
-  group_by([.link_profile, .label, .scenario, .connections, .concurrency, .request_concurrency])
-  | map({
-      scenario: .[0].scenario, label: .[0].label, link_profile: .[0].link_profile,
-      connections: .[0].connections, concurrency: .[0].concurrency,
-      request_concurrency: .[0].request_concurrency
-    } + delete_agg)
-  | map(select(.sweeps > 0))
-  | sort_by([.link_profile, .scenario, .label, .connections, .concurrency, .request_concurrency])
-" "$deletes_file" >"$deletes_agg_file"
-
-# The auto runs, one row per (profile, scenario). "chosen" is read out of the
-# run's own counters, so it says what easySFTP did rather than what this script
-# expects it to do; the regret against the grid is added further down, where the
-# cells are in scope.
-auto_agg_file="$LOG_DIR/auto.json"
-jq -s "
-  $JQ_STATS
-  group_by([.link_profile, .scenario])
-  | map(
-      (map(select(.metrics != null)) | map(.metrics)) as \$m
-      | {
-        scenario: .[0].scenario,
-        label: \"auto\",
-        ref: .[0].ref,
-        link_profile: .[0].link_profile,
-        repeats: length,
-        failed_runs: (map(select(.exit_code != 0)) | length),
-        files: (map(.files) | max),
-        bytes: (map(.bytes) | max),
-        durations_ms: map(.duration_ms),
-        median_ms: (map(.duration_ms) | median),
-        min_ms: (map(.duration_ms) | min),
-        max_ms: (map(.duration_ms) | max),
-        mad_ms: (map(.duration_ms) | mad),
-        chosen: {
-          connections: (\$m | map(.counters.config_connections) | median),
-          concurrency: (\$m | map(.counters.config_concurrency) | median),
-          request_concurrency: (\$m | map(.counters.config_request_concurrency) | median)
-        }
-      })
-  | map(. + {
-      mib_per_s: (if .median_ms > 0 then ((.bytes / 1048576) / (.median_ms / 1000) | round2) else 0 end),
-      files_per_s: (if .median_ms > 0 then (.files / (.median_ms / 1000) | round2) else 0 end)
-    })
-  | sort_by([.link_profile, .scenario])
-" "$auto_file" >"$auto_agg_file"
-
-# The axes each scenario was actually swept over, as JSON. The declared axes are
-# what was asked for; these are what the payload allows, and a reader plotting a
-# heatmap needs the second kind (issue #184, phase 5).
-per_scenario_axes=$(for scenario in "${scenarios[@]}"; do
-  read -r -a axis_conn <<<"${scenario_conn_axis[$scenario]}"
-  read -r -a axis_conc <<<"${scenario_conc_axis[$scenario]}"
-  read -r -a axis_req <<<"${scenario_req_axis[$scenario]}"
-  jq -nc --arg k "$scenario" \
-    --argjson files "$(scenario_files "$scenario")" \
-    --argjson conn "$(printf '%s\n' "${axis_conn[@]}" | jq -s '.')" \
-    --argjson conc "$(printf '%s\n' "${axis_conc[@]}" | jq -s '.')" \
-    --argjson req "$(printf '%s\n' "${axis_req[@]}" | jq -Rs 'split("\n") | map(select(. != "") | if . == "default" then null else tonumber end)')" \
-    '{key: $k, value: {files: $files, connections: $conn, concurrency: $conc, request_concurrency: $req}}'
-done | jq -s 'from_entries')
-
+# Everything below is aggregation and reporting, and none of it happens here any
+# more: the manifest describes the sweep, cmd/easysftp-bench reads it together
+# with the JSONL above and writes matrix.json, matrix.csv and matrix.md (issue
+# #190). What stayed in this script is what needs a host: payload generation,
+# running the cells, shaping the link and probing it.
 settings="matrix sweep; every other advanced.* setting stays at easySFTP's defaults (retries 2, timeout 30s). The mode belongs to the scenario, see scenarios below: a redeploy scenario is deployed once unmeasured and then measured over itself with $SCENARIO_CHANGED_FILES file(s) changed. Each scenario is swept over the axis values its payload can use, see axes.per_scenario"
 if [[ -n "$MATRIX_LINK_PROFILES" ]]; then
   settings="$settings; swept over the link profiles ${link_profiles[*]}"
 fi
 
-scenario_docs=$(for scenario in "${scenarios[@]}"; do
-  jq -nc --arg k "$scenario" --arg v "$(scenario_description "$scenario")" '{key: $k, value: $v}'
-done | jq -s 'from_entries')
+# One entry per scenario, carrying both what it is and the axes its payload
+# allowed. The display strings are the ones the summary prints, kept verbatim so
+# a rewrite cannot reformat a stored document by accident.
+scenario_manifest=$(for scenario in "${scenarios[@]}"; do
+  read -r mode prepopulate _ <<<"$(scenario_shape "$scenario")"
+  if ((prepopulate)); then
+    mode="$mode, redeployed"
+  fi
+  read -r -a axis_conn <<<"${scenario_conn_axis[$scenario]}"
+  read -r -a axis_conc <<<"${scenario_conc_axis[$scenario]}"
+  read -r -a axis_req <<<"${scenario_req_axis[$scenario]}"
+  jq -nc \
+    --arg name "$scenario" \
+    --arg description "$(scenario_description "$scenario")" \
+    --arg mode "$mode" \
+    --argjson files "$(scenario_files "$scenario")" \
+    --arg connections_display "${scenario_conn_axis[$scenario]}" \
+    --arg concurrency_display "${scenario_conc_axis[$scenario]}" \
+    --arg request_display "${scenario_req_axis[$scenario]}" \
+    --argjson connections "$(json_array_of "${axis_conn[@]}")" \
+    --argjson concurrency "$(json_array_of "${axis_conc[@]}")" \
+    --argjson request_concurrency "$(json_array_of "${axis_req[@]}")" \
+    '$ARGS.named'
+done | jq -s '.')
 
-# matrix.json. "axes" declares the grid explicitly so a heatmap does not have to
-# infer it from the cells that happen to be present, "cells" is one row per
-# combination, "scaling" is the same data pre-grouped into the curve a reader
-# usually wants (per scenario and build, ordered by connections then
-# concurrency), "comparison" pairs each candidate cell with the reference
-# build's cell at the same coordinates, "canary" holds the fixed cell's three
-# measurements per profile, and "deletes" holds the pre-clean sweeps at the same
-# coordinates as the cells.
-#
-# A matrix run has no "runs[]" the way a standard result does, so a cell is the
-# finest grain there is. That is why it carries its own phases[] and
-# operations[] and not just upload_phase_ms: those are hours of measurement that
-# used to be aggregated and then dropped (issue #184, phase 2).
-#
-# "auto" is the policy measurement of phase 5: what easySFTP picked when asked
-# to pick, what the grid says was best, and the gap. "scaling[].best_at_axis_max"
-# is the other half of that: an optimum sitting on the largest value of an axis
-# was not measured, it was cut off, and a policy fitted to such a grid
-# extrapolates. Both are reported per scenario and profile, never averaged: the
-# whole point is that they differ per link.
+manifest="$LOG_DIR/manifest.json"
 jq -n \
-  --slurpfile cells "$cells_file" \
-  --slurpfile auto "$auto_agg_file" \
-  --argjson per_scenario_axes "$per_scenario_axes" \
   --arg candidate_ref "$CANDIDATE_REF" \
   --arg baseline_ref "$BASELINE_REF" \
   --arg reference_label "$reference_label" \
   --argjson repeats "$REPEATS" \
   --arg runner "${RUNNER_ENVIRONMENT:-local}, $(uname -sr), $(nproc) cpu" \
+  --arg runner_display "$(uname -sr), $(nproc) cpu" \
   --argjson environment "$(bench_environment)" \
-  --argjson link "$(link_json "$probes_file")" \
-  --argjson canary "$(jq -s '.' "$canary_file")" \
-  --slurpfile deletes "$deletes_agg_file" \
   --arg settings "$settings" \
-  --argjson scenarios "$scenario_docs" \
-  --argjson link_axis "$(printf '%s\n' "${link_profiles[@]}" | jq -Rs 'split("\n") | map(select(. != ""))')" \
-  --argjson connections_axis "$(printf '%s\n' "${connections_axis[@]}" | jq -s '.')" \
-  --argjson concurrency_axis "$(printf '%s\n' "${concurrency_axis[@]}" | jq -s '.')" \
-  --argjson request_axis "$(printf '%s\n' "${request_axis[@]}" | jq -Rs 'split("\n") | map(select(. != "") | if . == "default" then null else tonumber end)')" \
-  "
-  $JQ_STATS
-  (\$cells[0]) as \$c
-  | {
-     schema_version: 2,
-     benchmark_kind: \"matrix\",
-     candidate_ref: \$candidate_ref,
-     baseline_ref: \$baseline_ref,
-     reference_label: \$reference_label,
-     repeats: \$repeats,
-     runner: \$runner,
-     environment: \$environment,
-     link: \$link,
-     canary: \$canary,
-     settings: \$settings,
-     scenarios: \$scenarios,
-     note: \"one cell per (link_profile, scenario, build, connections, concurrency, request_concurrency); median_ms is wall clock over the cell's repeats. Each scenario is swept over the axis values its payload can use (axes.per_scenario), so a cell absent from the declared axes was not skipped, it was the same configuration twice. auto[] is off the grid: it is the settings easySFTP picked for itself, scored against the best cell\",
-     axes: {
-       link_profiles: \$link_axis,
-       connections: \$connections_axis,
-       concurrency: \$concurrency_axis,
-       request_concurrency: \$request_axis,
-       per_scenario: \$per_scenario_axes
+  --argjson labels "$(json_strings_of "${labels[@]}")" \
+  --argjson scenarios "$scenario_manifest" \
+  --argjson link "$(link_manifest_json "$MATRIX_LINK_PROFILES" "${link_profiles[@]}")" \
+  --argjson connections_axis "$(json_array_of "${connections_axis[@]}")" \
+  --argjson concurrency_axis "$(json_array_of "${concurrency_axis[@]}")" \
+  --argjson request_axis "$(json_array_of "${request_axis[@]}")" \
+  --arg connections_display "$MATRIX_CONNECTIONS" \
+  --arg concurrency_display "$MATRIX_CONCURRENCY" \
+  --arg request_display "${MATRIX_REQUEST_CONCURRENCY:-}" \
+  --arg canary_scenario "$CANARY_SCENARIO" \
+  --argjson canary_connections "$CANARY_CONNECTIONS" \
+  --argjson canary_concurrency "$CANARY_CONCURRENCY" \
+  --arg runs_file "$runs_file" \
+  --arg deletes_file "$deletes_file" \
+  --arg probes_file "$probes_file" \
+  --arg canary_file "$canary_file" \
+  --arg auto_file "$auto_file" \
+  '{
+     kind: "matrix",
+     candidate_ref: $candidate_ref,
+     baseline_ref: $baseline_ref,
+     reference_label: $reference_label,
+     repeats: $repeats,
+     runner: $runner,
+     runner_display: $runner_display,
+     environment: $environment,
+     settings: $settings,
+     labels: $labels,
+     scenarios: $scenarios,
+     link: $link,
+     grid: {
+       connections: $connections_axis,
+       concurrency: $concurrency_axis,
+       request_concurrency: $request_axis,
+       connections_display: $connections_display,
+       concurrency_display: $concurrency_display,
+       request_display: $request_display,
+       canary: {
+         scenario: $canary_scenario,
+         connections: $canary_connections,
+         concurrency: $canary_concurrency
+       }
      },
-     cells: \$c,
-     deletes: \$deletes[0],
-     scaling: (\$c | group_by([.link_profile, .scenario, .label])
-       | map(. as \$g
-         | (\$g | sort_by(.median_ms) | .[0]) as \$best
-         | {
-           scenario: .[0].scenario,
-           label: .[0].label,
-           link_profile: .[0].link_profile,
-           points: (sort_by([.connections, .concurrency])
-             | map({connections, concurrency, request_concurrency, request_concurrency_used,
-                    median_ms, mib_per_s, files_per_s,
-                    connections_used, connections_refused, max_rss_bytes, user_cpu_ms})),
-           best: (\$best | {connections, concurrency, request_concurrency, median_ms, mib_per_s, files_per_s}),
-           best_at_axis_max: ([
-             (if ((\$g | map(.connections) | unique | length) > 1)
-                 and \$best.connections == (\$g | map(.connections) | max)
-               then \"connections\" else empty end),
-             (if ((\$g | map(.concurrency) | unique | length) > 1)
-                 and \$best.concurrency == (\$g | map(.concurrency) | max)
-               then \"concurrency\" else empty end),
-             (if ((\$g | map(.request_concurrency) | unique | length) > 1)
-                 and \$best.request_concurrency != null
-                 and \$best.request_concurrency == (\$g | map(.request_concurrency) | max)
-               then \"request_concurrency\" else empty end)
-           ])
-         })),
-     auto: (\$auto[0] | map(. as \$a
-       | ([\$c[] | select(.label == \"candidate\" and .scenario == \$a.scenario
-            and .link_profile == \$a.link_profile)] | sort_by(.median_ms) | first) as \$best
-       | ([\$c[] | select(.label == \"candidate\" and .scenario == \$a.scenario
-            and .link_profile == \$a.link_profile
-            and .connections == \$a.chosen.connections
-            and .concurrency == \$a.chosen.concurrency
-            and .request_concurrency_used == \$a.chosen.request_concurrency)] | first) as \$at
-       | \$a + {
-           best: (if \$best == null then null
-             else (\$best | {connections, concurrency, request_concurrency, median_ms, mib_per_s, files_per_s})
-             end),
-           chosen_in_grid: (\$at != null),
-           chosen_cell_median_ms: (if \$at == null then null else \$at.median_ms end),
-           regret_ms: (if \$best == null then null else \$a.median_ms - \$best.median_ms end),
-           regret_percent: (if \$best == null then null else pct(\$a.median_ms; \$best.median_ms) end)
-         })),
-     comparison: [
-       \$c[] | select(.label != \$reference_label) as \$x
-       | (\$c[] | select(.label == \$reference_label and .scenario == \$x.scenario
-            and .link_profile == \$x.link_profile
-            and .connections == \$x.connections and .concurrency == \$x.concurrency
-            and .request_concurrency == \$x.request_concurrency)) as \$b
-       | {
-           scenario: \$x.scenario, label: \$x.label, reference_label: \$reference_label,
-           link_profile: \$x.link_profile,
-           connections: \$x.connections, concurrency: \$x.concurrency,
-           request_concurrency: \$x.request_concurrency,
-           median_ms: \$x.median_ms, reference_median_ms: \$b.median_ms,
-           delta_ms: (\$x.median_ms - \$b.median_ms),
-           delta_percent: pct(\$x.median_ms; \$b.median_ms)
-         }
-     ]
-   }" >"$OUT_DIR/matrix.json"
+     files: {
+       runs: $runs_file, deletes: $deletes_file, probes: $probes_file,
+       canary: $canary_file, auto: $auto_file
+     }
+   }' >"$manifest"
 
-# One flat row per cell: this is the file a heatmap or a scaling plot reads.
-#
-# link_profile, rtt_p50_ms and control_single_mib_per_s come along so a cell is
-# readable on its own. net_write_bytes is here too: cells[] has always carried
-# it, and it is the protocol-overhead number (117% of payload for "small").
-jq -r '
-  (.link.probes // []) as $probes
-  | ["scenario","build","ref","link_profile","rtt_p50_ms","control_single_mib_per_s",
-     "connections","concurrency","request_concurrency","request_concurrency_used","repeats",
-     "files","bytes","median_ms","min_ms","max_ms","mad_ms","mib_per_s","files_per_s",
-     "upload_phase_ms","net_write_bytes","user_cpu_ms","sys_cpu_ms","cpu_percent","max_rss_bytes","go_gc_count",
-     "go_peak_goroutines","connections_opened","connections_used","connections_refused",
-     "reconnects","retries","errors","failed_runs"],
-  (.cells[]
-   | . as $cell
-   | ([$probes[] | select(.profile == $cell.link_profile and .at == "start")] | first) as $p
-   | [
-    .scenario, .label, .ref, .link_profile,
-    ($p.rtt_ms.p50 // null), ($p.control.single_stream_mib_per_s // null),
-    .connections, .concurrency, .request_concurrency, .request_concurrency_used, .repeats,
-    .files, .bytes, .median_ms, .min_ms, .max_ms, .mad_ms, .mib_per_s, .files_per_s,
-    .upload_phase_ms, .net_write_bytes, .user_cpu_ms, .sys_cpu_ms, .cpu_percent, .max_rss_bytes, .go_gc_count,
-    .go_peak_goroutines, .connections_opened, .connections_used, .connections_refused,
-    .reconnects, .retries, .errors, .failed_runs
-  ])
-  | @csv
-' "$OUT_DIR/matrix.json" >"$OUT_DIR/matrix.csv"
-
-{
-  echo "## easySFTP connections/concurrency matrix"
-  echo
-  echo "| Setting | Value |"
-  echo "|---|---|"
-  echo "| Candidate | \`$CANDIDATE_REF\` |"
-  echo "| Baseline | \`${BASELINE_REF:-none}\` |"
-  echo "| Repeats per cell | $REPEATS |"
-  echo "| Runner | $(uname -sr), $(nproc) cpu |"
-  echo "| connections | $MATRIX_CONNECTIONS |"
-  echo "| concurrency | $MATRIX_CONCURRENCY |"
-  echo "| request_concurrency | ${MATRIX_REQUEST_CONCURRENCY:-easySFTP default} |"
-  echo "| Link profiles | ${MATRIX_LINK_PROFILES:-the real line} |"
-  echo "| Scenarios | ${scenarios[*]} |"
-  echo
-  # What each scenario is, next to the numbers: "sync" and "redeploy" are a
-  # deploy shape and not only a payload, and a MiB/s of theirs is over the few
-  # changed files rather than over the tree.
-  echo "| Scenario | Mode | Payload | connections | concurrency | request_concurrency |"
-  echo "|---|---|---|---|---|---|"
-  for scenario in "${scenarios[@]}"; do
-    read -r mode prepopulate _ <<<"$(scenario_shape "$scenario")"
-    if ((prepopulate)); then
-      mode="$mode, redeployed"
-    fi
-    echo "| \`$scenario\` | $mode | $(scenario_description "$scenario") | ${scenario_conn_axis[$scenario]} | ${scenario_conc_axis[$scenario]} | ${scenario_req_axis[$scenario]} |"
-  done
-  echo
-  echo "The last three columns are the axis values this scenario was swept over, which are not always the ones requested above. A value larger than the payload's file count is the same configuration under another name (only the per-file upload path spreads over connections and workers), and \`request_concurrency\` is a per-file setting that a payload of small files cannot use at all, so both are capped against the payload rather than measured twice."
-  echo
-  link_markdown "$OUT_DIR/matrix.json"
-  echo "Each grid below is median wall-clock milliseconds: rows are \`advanced.connections\`, columns are \`advanced.concurrency\`. Lower is better. \`connections > concurrency\` is measured, not skipped; easySFTP caps the pool at the concurrency (a connection no worker picks is a handshake for nothing), so those cells are expected to flatten out rather than improve."
-  echo
-
-  for scenario in "${scenarios[@]}"; do
-    read -r -a axis_conn <<<"${scenario_conn_axis[$scenario]}"
-    read -r -a axis_conc <<<"${scenario_conc_axis[$scenario]}"
-    read -r -a axis_req <<<"${scenario_req_axis[$scenario]}"
-    for label in "${labels[@]}"; do
-      for profile in "${link_profiles[@]}"; do
-        for request in "${axis_req[@]}"; do
-          title="\`$scenario\` / $label / $profile"
-          if [[ "$request" != default ]]; then
-            title="$title / request_concurrency $request"
-          fi
-          echo "#### $title"
-          echo
-          printf '| connections \\ concurrency |'
-          for conc in "${axis_conc[@]}"; do printf ' %s |' "$conc"; done
-          printf '\n|---|'
-          # "%s": bash's printf reads a leading "-" in the format as an option.
-          for _ in "${axis_conc[@]}"; do printf '%s' '---|'; done
-          printf '\n'
-          for conns in "${axis_conn[@]}"; do
-            printf '| %s |' "$conns"
-            for conc in "${axis_conc[@]}"; do
-              req_json=null
-              if [[ "$request" != default ]]; then req_json=$request; fi
-              cell=$(jq -r --arg s "$scenario" --arg l "$label" --arg p "$profile" \
-                --argjson conns "$conns" --argjson conc "$conc" \
-                --argjson req "$req_json" '
-              [.cells[] | select(.scenario == $s and .label == $l and .link_profile == $p
-                 and .connections == $conns
-                 and .concurrency == $conc and .request_concurrency == $req)] | first
-              | if . == null then "-"
-                else "\(.median_ms) ms<br>\(.mib_per_s) MiB/s"
-                  + (if .connections_refused > 0 then "<br>\(.connections_refused) refused" else "" end)
-                end' "$OUT_DIR/matrix.json")
-              printf ' %s |' "$cell"
-            done
-            printf '\n'
-          done
-          echo
-        done
-      done
-    done
-  done
-
-  echo "### Best cell per scenario, build and link profile"
-  echo
-  echo "| Scenario | Build | Profile | connections | concurrency | request_concurrency | Median | MiB/s | files/s | On an axis edge |"
-  echo "|---|---|---|---|---|---|---|---|---|---|"
-  jq -r '.scaling[] | "| \(.scenario) | \(.label) | \(.link_profile) | \(.best.connections) | \(.best.concurrency) | \(.best.request_concurrency // "default") | \(.best.median_ms) ms | \(.best.mib_per_s) | \(.best.files_per_s) | \(if (.best_at_axis_max | length) == 0 then "no" else (.best_at_axis_max | join(", ")) end) |"' \
-    "$OUT_DIR/matrix.json"
-  echo
-  # The check the auto-config work of issue #184 phase 5 rests on: a best cell
-  # sitting on the largest value of an axis is a cut-off, not an optimum, and
-  # anything fitted to it extrapolates. Only the upper edge is reported; the
-  # lower one is 1 and there is nothing below it to sweep.
-  boundary=$(jq -r '[.scaling[] | select((.best_at_axis_max | length) > 0)
-    | "\(.scenario)/\(.label)/\(.link_profile): \(.best_at_axis_max | join(", "))"] | join("; ")' \
-    "$OUT_DIR/matrix.json")
-  if [[ -n "$boundary" ]]; then
-    echo "**The optimum sits on the edge of the grid** for $boundary. The best value measured is the largest one swept, so the real optimum is at or beyond it and this sweep does not contain it. Extend that axis before fitting anything to these numbers."
-  else
-    echo "Every best cell is interior to its axes, so each optimum was measured rather than cut off."
-  fi
-
-  if [[ -n "$BASELINE_BIN" ]]; then
-    echo
-    echo "### Candidate against baseline, worst and best cell"
-    echo
-    echo "| Scenario | Profile | connections | concurrency | Candidate | Baseline | Delta |"
-    echo "|---|---|---|---|---|---|---|"
-    # Grouped per profile as well: the worst cell of one profile and the best of
-    # another are not two ends of one distribution.
-    jq -r '.comparison | group_by([.link_profile, .scenario])
-      | map(sort_by(.delta_percent // 0) | [.[0], .[-1]]) | flatten | unique_by([.link_profile, .scenario, .connections, .concurrency])
-      | .[] | "| \(.scenario) | \(.link_profile) | \(.connections) | \(.concurrency) | \(.median_ms) ms | \(.reference_median_ms) ms | \(if .delta_percent == null then "-" else (if .delta_percent > 0 then "+" else "" end) + (.delta_percent | tostring) + "%" end) |"' \
-      "$OUT_DIR/matrix.json"
-  fi
-
-  echo
-  echo "### What \`auto\` costs (policy regret)"
-  echo
-  echo "One run per scenario and profile with \`connections\`, \`concurrency\` and \`request_concurrency\` all set to \`auto\`, on the candidate build, measured next to the cells it is scored against. \`Picked\` is read out of the run's own counters, so it is what easySFTP did and not what this script assumes; \`Best\` is the fastest cell of the same scenario and profile. \`Regret\` is the gap between them: how much slower the policy is than the settings a sweep would have chosen. A policy within ~15% on every profile is defensible, one that only wins on the house line is not (issue #184, phase 5; the policy itself is #156)."
-  echo
-  echo "| Scenario | Profile | Picked (conn/conc/req) | auto | Best cell | Best | Regret | Same cell in grid |"
-  echo "|---|---|---|---|---|---|---|---|"
-  jq -r '
-    def cell($x): if $x == null then "-" else "\($x.connections)/\($x.concurrency)/\($x.request_concurrency // "default")" end;
-    .auto[]
-    | "| \(.scenario) | \(.link_profile) | \(.chosen.connections)/\(.chosen.concurrency)/\(.chosen.request_concurrency) "
-      + "| \(.median_ms) ms | \(cell(.best)) | \(if .best == null then "-" else "\(.best.median_ms) ms" end) "
-      + "| \(if .regret_percent == null then "-" else (if .regret_percent > 0 then "+" else "" end) + (.regret_percent | tostring) + "%" end) "
-      + "| \(if .chosen_in_grid then "\(.chosen_cell_median_ms) ms" else "not swept" end) |"
-  ' "$OUT_DIR/matrix.json"
-  echo
-  echo "The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the \`auto\` column means the two runs saw different conditions, and then the regret next to it is drift rather than policy. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all."
-
-  echo
-  echo "### Canary"
-  echo
-  echo "One fixed cell (\`$CANARY_SCENARIO\`, connections $CANARY_CONNECTIONS, concurrency $CANARY_CONCURRENCY, candidate build) measured at the start, the middle and the end of each profile's grid. Spread is the gap between the fastest and the slowest of them. A spread larger than the deltas below it means the server or the line moved during the sweep, and the whole run is a poor comparison basis."
-  echo
-  echo "| Profile | Start | Middle | End | Spread |"
-  echo "|---|---|---|---|---|"
-  jq -r '
-    def pick($a): [.[] | select(.at == $a) | .duration_ms] | first;
-    def ms: if . == null then "-" else "\(.) ms" end;
-    .canary | group_by(.link_profile)[]
-    | (map(.duration_ms)) as $d
-    | "| \(.[0].link_profile) | \(pick("start") | ms) | \(pick("mid") | ms) | \(pick("end") | ms) "
-      + "| \(if ($d | min) > 0 then ((($d | max) - ($d | min)) / ($d | min) * 100 | round | tostring) + "%" else "-" end) |"
-  ' "$OUT_DIR/matrix.json"
-
-  echo
-  echo "### Delete sweeps"
-  echo
-  echo "Every cell's pre-clean wipes the tree the cell before it left behind, at that cell's own \`connections\`/\`concurrency\`. It has always run and cost nothing extra; what is new is that it is measured (issue #184, phase 4). Cells whose pre-clean found an empty directory are not listed. Read the two columns on the right against #157: deletions are one round-trip per entry and the pool has nowhere to spread them."
-  echo
-  echo "<details><summary>Per-cell delete sweeps</summary>"
-  echo
-  echo "| Scenario | Build | Profile | conn | conc | Files deleted | Median | files/s | remote_scan | delete_sweep | sftp_remove p50 | sftp_rmdir p50 |"
-  echo "|---|---|---|---|---|---|---|---|---|---|---|---|"
-  jq -r '
-    def phase($n): [.phases[] | select(.name == $n) | .median_ms] | first;
-    def op($n): [.operations[] | select(.name == $n) | .p50_ms] | first;
-    def ms: if . == null then "-" else "\(.) ms" end;
-    .deletes[]
-    | "| \(.scenario) | \(.label) | \(.link_profile) | \(.connections) | \(.concurrency) "
-      + "| \(.files_deleted) | \(.median_ms) ms | \(.deletes_per_s) "
-      + "| \(phase("remote_scan") | ms) | \(phase("delete_sweep") | ms) "
-      + "| \(op("sftp_remove") | ms) | \(op("sftp_rmdir") | ms) |"
-  ' "$OUT_DIR/matrix.json"
-  echo
-  echo "</details>"
-
-  refused=$(jq '[.cells[].connections_refused] | add // 0' "$OUT_DIR/matrix.json")
-  if [[ "$refused" != 0 ]]; then
-    echo
-    echo "**$refused connection(s) were refused by the server** across the sweep and fell back to the run's first connection. Those cells had fewer connections than configured, which is the server's limit showing up in the data, not easySFTP's."
-  fi
-  echo
-  echo "Raw data: \`matrix.json\` (every cell with its own phases and round-trip percentiles, plus the pre-grouped \`scaling\` view, the \`auto\` policy runs, the \`canary\` runs and the \`deletes\` sweeps), \`matrix.csv\` (one flat row per cell). Data only: nothing here fails a build."
-} >"$OUT_DIR/matrix.md"
+bench_tool aggregate --manifest "$manifest" --out "$OUT_DIR"
 
 cat "$OUT_DIR/matrix.md"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -28,6 +28,10 @@
 #   LINKPROBE_BIN                 optional built cmd/linkprobe; without it the
 #                                 result carries an empty probe list
 #   LINK_IFACE, LINK_SUDO         see scripts/benchmark-link.sh
+#   BENCH_TOOL                    optional built cmd/easysftp-bench, which turns
+#                                 the JSONL measured here into results.json,
+#                                 results.csv and summary.md (issue #190).
+#                                 Without it the command is run from source
 #   REPEATS                       measured repeats per scenario (default 3)
 #   REMOTE_BASE                   remote directory this benchmark owns
 #   OUT_DIR                       results.json and summary.md land here
@@ -84,7 +88,6 @@ mkdir -p "$OUT_DIR" "$DATASET_DIR" "$LOG_DIR"
 check_log_dir
 
 runs_file="$LOG_DIR/runs.jsonl"
-aggregate_file="$LOG_DIR/aggregate.json"
 probes_file="$LOG_DIR/link-probes.jsonl"
 deletes_file="$LOG_DIR/deletes.jsonl"
 : >"$runs_file"
@@ -226,92 +229,22 @@ if [[ -n "${LINKPROBE_BIN:-}" ]]; then
     echo "::warning::cleanup of the link probe directory failed"
 fi
 
-# One aggregate row per (link profile, build, scenario). The timing fields at the
-# top level are exactly the ones results.json v1 had, so anything already reading
-# a stored benchmark keeps working; everything new sits in its own sub-object.
-# With no profiles requested there is exactly one profile, "baseline", and the
-# row count is what it always was.
+# Everything below is aggregation and reporting, and none of it happens here any
+# more: the manifest describes the run, cmd/easysftp-bench reads it together with
+# the JSONL above and writes results.json, results.csv and summary.md (issue
+# #190). What stayed in this script is what needs a host: payload generation,
+# running the builds, shaping the link and probing it.
 #
-# duration_ms.* is wall clock. process.* is what the run cost the machine.
-# phases[] is wall clock per phase and adds up to roughly the duration.
-# operations[] is cumulative across parallel workers and does not: see the
-# "note" field the metrics file carries.
-jq -s "
-  $JQ_STATS
-  group_by([.link_profile, .label, .scenario])
-  | map(
-      (map(select(.metrics != null)) | map(.metrics)) as \$m
-      | {
-        label: .[0].label,
-        ref: .[0].ref,
-        scenario: .[0].scenario,
-        link_profile: .[0].link_profile,
-        repeats: length,
-        failed_runs: (map(select(.exit_code != 0)) | length),
-        files: (map(.files) | max),
-        bytes: (map(.bytes) | max),
-        durations_ms: map(.duration_ms),
-        median_ms: (map(.duration_ms) | median),
-        min_ms: (map(.duration_ms) | min),
-        max_ms: (map(.duration_ms) | max),
-        mad_ms: (map(.duration_ms) | mad),
-        duration_ms: (map(.duration_ms) | stats),
-        retries: (map(.retries) | add),
-        errors: (map(.errors) | add),
-        refused_connections: (map(.refused) | add),
-        process: {
-          user_cpu_ms: (\$m | map(.process.user_cpu_ms) | median),
-          sys_cpu_ms: (\$m | map(.process.sys_cpu_ms) | median),
-          cpu_percent: (\$m | map(.process.cpu_percent) | median),
-          max_rss_bytes: (\$m | map(.process.max_rss_bytes) | median),
-          go_total_alloc_bytes: (\$m | map(.process.go_total_alloc_bytes) | median),
-          go_mallocs: (\$m | map(.process.go_mallocs) | median),
-          go_gc_count: (\$m | map(.process.go_gc_count) | median),
-          go_gc_pause_total_ms: (\$m | map(.process.go_gc_pause_total_ms) | median),
-          go_peak_goroutines: (\$m | map(.process.go_peak_goroutines) | max),
-          disk_read_bytes: (\$m | map(.process.disk_read_bytes) | median),
-          net_read_bytes: (\$m | map(.process.net_read_bytes) | median),
-          net_write_bytes: (\$m | map(.process.net_write_bytes) | median)
-        },
-        counters: (\$m | map(.counters // {}) | map(to_entries) | add // []
-          | group_by(.key)
-          | map({key: .[0].key, value: (map(.value) | median)}) | from_entries),
-        phases: (\$m | map(.phases // []) | add // []
-          | group_by(.name)
-          | map({name: .[0].name, median_ms: (map(.wall_ms) | median)})
-          | sort_by(-.median_ms)),
-        operations: (\$m | map(.operations // []) | add // []
-          | group_by(.name)
-          | map({
-              name: .[0].name,
-              count: (map(.count) | median),
-              median_total_ms: (map(.total_ms) | median),
-              avg_ms: (map(.avg_ms) | median),
-              p50_ms: (map(.p50_ms) | median),
-              p90_ms: (map(.p90_ms) | median),
-              p99_ms: (map(.p99_ms) | median),
-              max_ms: (map(.max_ms) | median),
-              errors: (map(.errors) | add)
-            })
-          | sort_by(-.median_total_ms))
-      })
-  | map(. + {
-      mib_per_s: (if .median_ms > 0 then ((.bytes / 1048576) / (.median_ms / 1000) | round2) else 0 end),
-      files_per_s: (if .median_ms > 0 then (.files / (.median_ms / 1000) | round2) else 0 end)
-    })
-" "$runs_file" >"$aggregate_file"
-
-# The delete sweeps, aggregated the same way and kept strictly apart: one row per
-# (link profile, build, scenario), sweeps that deleted nothing dropped, and a
-# group left with none dropped entirely rather than stored as a row of zeroes.
-delete_file="$LOG_DIR/delete.json"
-jq -s "
-  $JQ_STATS
-  $JQ_DELETE
-  group_by([.link_profile, .label, .scenario])
-  | map({label: .[0].label, scenario: .[0].scenario, link_profile: .[0].link_profile} + delete_agg)
-  | map(select(.sweeps > 0))
-" "$deletes_file" >"$delete_file"
+# The display strings travel verbatim rather than being rebuilt on the other
+# side. This script already has them, and a summary table that reformats itself
+# during a rewrite is a change to a stored document made by accident.
+settings="easySFTP defaults (no advanced.* overrides): concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay"
+if [[ -n "$BENCH_CONNECTIONS" ]]; then
+  settings="$settings; the pool$BENCH_CONNECTIONS build is the same binary with advanced.connections: $BENCH_CONNECTIONS"
+fi
+if [[ -n "${BENCH_LINK_PROFILES:-}" ]]; then
+  settings="$settings; measured over the link profiles ${link_profiles[*]}"
+fi
 
 # The reference build every delta is measured against: the baseline when one
 # was measured, otherwise the candidate, so a pool run without a baseline is
@@ -321,228 +254,42 @@ if [[ -n "$BASELINE_BIN" ]]; then
   reference_label=baseline
 fi
 
-settings="easySFTP defaults (no advanced.* overrides): concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay"
-if [[ -n "$BENCH_CONNECTIONS" ]]; then
-  settings="$settings; the pool$BENCH_CONNECTIONS build is the same binary with advanced.connections: $BENCH_CONNECTIONS"
-fi
-if [[ -n "${BENCH_LINK_PROFILES:-}" ]]; then
-  settings="$settings; measured over the link profiles ${link_profiles[*]}"
-fi
+scenario_manifest=$(for scenario in "${SCENARIOS[@]}"; do
+  jq -nc --arg name "$scenario" --arg description "$(scenario_description "$scenario")"     '$ARGS.named'
+done | jq -s '.')
 
-scenario_docs=$(for scenario in "${SCENARIOS[@]}"; do
-  jq -nc --arg k "$scenario" --arg v "$(scenario_description "$scenario")" '{key: $k, value: $v}'
-done | jq -s 'from_entries')
-
-# results.json, schema_version 2. Layers, in the order a reader needs them:
-#   metadata (candidate_ref, baseline_ref, repeats, runner, settings, env)
-#   results   aggregated per build and scenario, incl. process/phases/operations
-#   comparison  candidate (and pool) against the reference build
-#   deletes   the pre-clean sweeps, aggregated apart from everything above
-#   runs      every individual repeat, verbatim, metrics included
-# v1's top-level keys all still exist and mean the same thing.
-# Through a file, not a process substitution: jq's --slurpfile wants a real
-# path, and /dev/fd is not one everywhere this may be run.
-runs_array="$LOG_DIR/runs.json"
-jq -s '.' "$runs_file" >"$runs_array"
-
+manifest="$LOG_DIR/manifest.json"
 jq -n \
-  --slurpfile results "$aggregate_file" \
-  --slurpfile runs "$runs_array" \
-  --slurpfile deletes "$delete_file" \
   --arg candidate_ref "$CANDIDATE_REF" \
   --arg baseline_ref "$BASELINE_REF" \
   --arg reference_label "$reference_label" \
   --argjson repeats "$REPEATS" \
   --arg runner "${RUNNER_ENVIRONMENT:-local}, $(uname -sr), $(nproc) cpu" \
+  --arg runner_display "$(uname -sr), $(nproc) cpu" \
   --argjson environment "$(bench_environment)" \
-  --argjson link "$(link_json "$probes_file")" \
   --arg settings "$settings" \
-  --argjson scenarios "$scenario_docs" \
-  "
-  $JQ_STATS
-  (\$results[0]) as \$r
-  | {
-     schema_version: 2,
-     benchmark_kind: \"standard\",
-     candidate_ref: \$candidate_ref,
-     baseline_ref: \$baseline_ref,
-     repeats: \$repeats,
-     runner: \$runner,
-     environment: \$environment,
-     link: \$link,
-     settings: \$settings,
-     reference_label: \$reference_label,
-     scenarios: \$scenarios,
-     note: \"phases are wall clock and add up to the duration; operations are cumulative across parallel workers and do not\",
-     results: \$r,
-     deletes: \$deletes[0],
-     comparison: [
-       \$r[] | select(.label != \$reference_label) as \$c
-       | (\$r[] | select(.label == \$reference_label and .scenario == \$c.scenario
-            and .link_profile == \$c.link_profile)) as \$b
-       | {
-           scenario: \$c.scenario,
-           label: \$c.label,
-           link_profile: \$c.link_profile,
-           reference_label: \$reference_label,
-           median_ms: \$c.median_ms,
-           reference_median_ms: \$b.median_ms,
-           delta_ms: (\$c.median_ms - \$b.median_ms),
-           delta_percent: pct(\$c.median_ms; \$b.median_ms),
-           reference_mad_ms: \$b.mad_ms,
-           within_noise: (if (\$b.mad_ms // 0) == 0 then null
-             else ((if \$c.median_ms - \$b.median_ms < 0 then \$b.median_ms - \$c.median_ms else \$c.median_ms - \$b.median_ms end) <= \$b.mad_ms) end)
-         }
-     ],
-     runs: \$runs[0]
-   }" >"$OUT_DIR/results.json"
+  --argjson labels "$(json_strings_of "${labels[@]}")" \
+  --argjson scenarios "$scenario_manifest" \
+  --argjson link "$(link_manifest_json "${BENCH_LINK_PROFILES:-}" "${link_profiles[@]}")" \
+  --arg runs_file "$runs_file" \
+  --arg deletes_file "$deletes_file" \
+  --arg probes_file "$probes_file" \
+  '{
+     kind: "standard",
+     candidate_ref: $candidate_ref,
+     baseline_ref: $baseline_ref,
+     reference_label: $reference_label,
+     repeats: $repeats,
+     runner: $runner,
+     runner_display: $runner_display,
+     environment: $environment,
+     settings: $settings,
+     labels: $labels,
+     scenarios: $scenarios,
+     link: $link,
+     files: {runs: $runs_file, deletes: $deletes_file, probes: $probes_file}
+   }' >"$manifest"
 
-# CSV alongside the JSON: one row per (build, scenario), so a spreadsheet or a
-# plot can read a stored result without a JSON parser. Deliberately flat and
-# aggregate-only; the raw repeats stay in results.json.
-#
-# link_profile, rtt_p50_ms and control_single_mib_per_s make a row readable on
-# its own: without them a throughput number cannot be told apart from the line
-# it was measured on. The two link numbers come from the profile's own start
-# probe, which is the one taken right before these runs.
-jq -r '
-  (.link.probes // []) as $probes
-  | ["scenario","build","ref","link_profile","rtt_p50_ms","control_single_mib_per_s",
-     "repeats","files","bytes","median_ms","min_ms","max_ms","mad_ms",
-     "mib_per_s","files_per_s","user_cpu_ms","sys_cpu_ms","cpu_percent","max_rss_bytes",
-     "go_gc_count","go_peak_goroutines","net_write_bytes","connections_opened","connections_refused",
-     "retries","errors","failed_runs"],
-  (.results[]
-   | . as $row
-   | ([$probes[] | select(.profile == $row.link_profile and .at == "start")] | first) as $p
-   | [
-    .scenario, .label, .ref, .link_profile,
-    ($p.rtt_ms.p50 // null), ($p.control.single_stream_mib_per_s // null),
-    .repeats, .files, .bytes, .median_ms, .min_ms, .max_ms, .mad_ms,
-    .mib_per_s, .files_per_s, .process.user_cpu_ms, .process.sys_cpu_ms, .process.cpu_percent,
-    .process.max_rss_bytes, .process.go_gc_count, .process.go_peak_goroutines, .process.net_write_bytes,
-    (.counters.connections_opened // 0), (.counters.connections_refused // 0),
-    .retries, .errors, .failed_runs
-  ])
-  | @csv
-' "$OUT_DIR/results.json" >"$OUT_DIR/results.csv"
-
-# summary.md carries the same numbers, readable. The delta column compares
-# every build's median against the reference build's; negative means faster.
-{
-  echo "## easySFTP benchmark"
-  echo
-  echo "| Setting | Value |"
-  echo "|---|---|"
-  echo "| Candidate | \`$CANDIDATE_REF\` |"
-  echo "| Baseline | \`${BASELINE_REF:-none}\` |"
-  echo "| Repeats per scenario | $REPEATS |"
-  echo "| Runner | $(uname -sr), $(nproc) cpu |"
-  echo "| Link profiles | ${BENCH_LINK_PROFILES:-the real line} |"
-  echo "| Settings | $settings |"
-  echo
-  link_markdown "$OUT_DIR/results.json"
-  echo "### Throughput"
-  echo
-  echo "| Scenario | Build | Profile | Files | Size | Median | Min | Max | MAD | MiB/s | files/s | Retries | Errors | Failed runs | Delta |"
-  echo "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|"
-  for scenario in "${SCENARIOS[@]}"; do
-    for label in "${labels[@]}"; do
-      for profile in "${link_profiles[@]}"; do
-        jq -r --arg s "$scenario" --arg l "$label" --arg p "$profile" '
-        (.results[] | select(.scenario == $s and .label == $l and .link_profile == $p)) as $row
-        # Through a list: the reference build has no comparison entry, and a
-        # bare "as" over an empty generator would drop its whole row.
-        | ([.comparison[] | select(.scenario == $s and .label == $l and .link_profile == $p) | .delta_percent] | first) as $delta
-        | "| \($s) | \($l) | \($p) | \($row.files) | \((($row.bytes / 1048576) * 10 | round / 10)) MiB "
-          + "| \($row.median_ms) ms | \($row.min_ms) ms | \($row.max_ms) ms | \(if $row.mad_ms == null then "-" else "\($row.mad_ms) ms" end) "
-          + "| \($row.mib_per_s) | \($row.files_per_s) | \($row.retries) | \($row.errors) | \($row.failed_runs) "
-          + "| \(if $delta == null then "-" else (if $delta > 0 then "+" else "" end) + ($delta | tostring) + "%" end) |"
-        ' "$OUT_DIR/results.json"
-      done
-    done
-  done
-  echo
-  echo "Delta compares each build's median against the \`$reference_label\` build **on the same link profile**; negative is faster. MAD is the median absolute deviation of the repeats: a delta smaller than it is inside this host's own noise."
-
-  echo
-  echo "### Resources (median per run)"
-  echo
-  echo "| Scenario | Build | Profile | User CPU | Sys CPU | CPU % | Peak RSS | Go allocs | GCs | GC pause | Peak goroutines | Net sent |"
-  echo "|---|---|---|---|---|---|---|---|---|---|---|---|"
-  # Looped rather than one jq pass over .results, so the rows come out in
-  # scenario order like the throughput table above instead of in jq's
-  # group_by order.
-  for scenario in "${SCENARIOS[@]}"; do
-    for label in "${labels[@]}"; do
-      for profile in "${link_profiles[@]}"; do
-        jq -r --arg s "$scenario" --arg l "$label" --arg p "$profile" \
-          '.results[] | select(.scenario == $s and .label == $l and .link_profile == $p)
-        | "| \(.scenario) | \(.label) | \(.link_profile) | \(.process.user_cpu_ms) ms | \(.process.sys_cpu_ms) ms | \(.process.cpu_percent)% "
-          + "| \(((.process.max_rss_bytes / 1048576) * 10 | round / 10)) MiB "
-          + "| \(((.process.go_total_alloc_bytes / 1048576) * 10 | round / 10)) MiB | \(.process.go_gc_count) "
-          + "| \(.process.go_gc_pause_total_ms) ms | \(.process.go_peak_goroutines) "
-          + "| \(((.process.net_write_bytes / 1048576) * 10 | round / 10)) MiB |"
-        ' "$OUT_DIR/results.json"
-      done
-    done
-  done
-
-  echo
-  echo "### Where the time goes"
-  echo
-  echo "Phases are wall clock and add up to roughly the run's duration. Operation totals are **cumulative across parallel workers** and are normally larger than the phase they belong to; read them for their share and their per-call cost, never as wall clock."
-  echo
-  for scenario in "${SCENARIOS[@]}"; do
-    echo "<details><summary><code>$scenario</code> phases and round-trips</summary>"
-    echo
-    echo "| Build | Profile | Phase | Wall |"
-    echo "|---|---|---|---|"
-    jq -r --arg s "$scenario" '.results[] | select(.scenario == $s) as $row
-      | $row.phases[] | select(.median_ms > 0)
-      | "| \($row.label) | \($row.link_profile) | \(.name) | \(.median_ms) ms |"' "$OUT_DIR/results.json"
-    echo
-    echo "| Build | Profile | Operation | Count | Cumulative | Avg | p50 | p90 | p99 | Max |"
-    echo "|---|---|---|---|---|---|---|---|---|---|"
-    jq -r --arg s "$scenario" '.results[] | select(.scenario == $s) as $row
-      | $row.operations[] | select(.count > 0)
-      | "| \($row.label) | \($row.link_profile) | \(.name) | \(.count) | \(.median_total_ms) ms | \(.avg_ms) ms | \(.p50_ms) ms | \(.p90_ms) ms | \(.p99_ms) ms | \(.max_ms) ms |"' "$OUT_DIR/results.json"
-    echo
-    echo "</details>"
-    echo
-  done
-
-  echo "### Delete sweeps"
-  echo
-  echo "The pre-clean before every measured run wipes the tree the previous repeat left behind, which makes it a pure delete sweep. It costs no extra time (it has always run) and its numbers never enter the upload tables above. Sweeps that found an empty directory are not counted."
-  echo
-  echo "| Scenario | Build | Profile | Sweeps | Files deleted | Median | files/s | remote_scan | delete_sweep |"
-  echo "|---|---|---|---|---|---|---|---|---|"
-  jq -r '
-    def phase($n): [.phases[] | select(.name == $n) | .median_ms] | first;
-    def ms: if . == null then "-" else "\(.) ms" end;
-    .deletes[]
-    | "| \(.scenario) | \(.label) | \(.link_profile) | \(.sweeps) | \(.files_deleted) | \(.median_ms) ms "
-      + "| \(.deletes_per_s) | \(phase("remote_scan") | ms) | \(phase("delete_sweep") | ms) |"
-  ' "$OUT_DIR/results.json"
-  echo
-  echo "| Scenario | Build | Profile | Operation | Count | Cumulative | p50 | p90 | p99 | Max |"
-  echo "|---|---|---|---|---|---|---|---|---|---|"
-  # sftp_remove and sftp_rmdir are the numbers issue #157 is about: one
-  # round-trip per entry, strictly sequential, no concurrency anywhere near them.
-  jq -r '.deletes[] as $d | $d.operations[] | select(.count > 0)
-    | "| \($d.scenario) | \($d.label) | \($d.link_profile) | \(.name) | \(.count) | \(.median_total_ms) ms "
-      + "| \(.p50_ms) ms | \(.p90_ms) ms | \(.p99_ms) ms | \(.max_ms) ms |"' "$OUT_DIR/results.json"
-  echo
-
-  # Without this line a pool run whose extra connections the server refused
-  # reads as "the pool did nothing", which is the wrong conclusion entirely.
-  refused=$(jq '[.results[].refused_connections] | add // 0' "$OUT_DIR/results.json")
-  if [[ "$refused" != 0 ]]; then
-    echo "**$refused connection(s) were refused by the server** and fell back to the run's first connection, so a pool build measured here had fewer connections than configured."
-    echo
-  fi
-  echo "Data only: these numbers set no threshold and fail no build. Collected to evaluate the single-connection ceiling discussed in issue #158 and to show where a run spends its time."
-} >"$OUT_DIR/summary.md"
+bench_tool aggregate --manifest "$manifest" --out "$OUT_DIR"
 
 cat "$OUT_DIR/summary.md"

--- a/scripts/test-benchmark.sh
+++ b/scripts/test-benchmark.sh
@@ -45,6 +45,56 @@ expect_nonempty() {
 # must not fail against "      10" just because the check ran on a Mac.
 line_count() { echo $(($(wc -l <"$1"))); }
 
+# parity <label> <prefix>: the same measurement aggregated twice, once by
+# cmd/easysftp-bench and once by the jq implementation it replaced (issue #190).
+#
+# scripts/benchmark-aggregate-jq.sh reads the same manifest the Go command
+# reads, so both get identical inputs by construction and a difference can only
+# come from the aggregation itself. That is the check that makes "a behavioural
+# rewrite" something other than a claim, and it runs against the live scripts
+# rather than against a fixture captured once.
+#
+# The JSON is compared as values, because object key order is not data. The CSV
+# and the Markdown are compared byte for byte, because there the layout *is* the
+# document.
+parity() {
+  local label=$1 prefix=$2
+  local oracle="$work/$label-oracle"
+  local manifest="$LOG_DIR/manifest.json"
+  local summary=summary.md
+  if [[ "$prefix" == matrix ]]; then
+    summary=matrix.md
+  fi
+
+  if [[ ! -f "$manifest" ]]; then
+    fail "$label: the run wrote no manifest"
+    return
+  fi
+  mkdir -p "$oracle"
+  if ! MANIFEST="$manifest" OUT_DIR="$oracle" bash "$repo_root/scripts/benchmark-aggregate-jq.sh" \
+    >"$work/$label-oracle.log" 2>&1; then
+    fail "$label: the jq oracle exited non-zero (see $work/$label-oracle.log)"
+    return
+  fi
+
+  if diff <(jq -S . "$OUT_DIR/$prefix.json") <(jq -S . "$oracle/$prefix.json") >"$work/$label-json.diff"; then
+    pass "$label: Go and jq produce the same $prefix.json"
+  else
+    fail "$label: Go and jq disagree on $prefix.json (see $work/$label-json.diff)"
+  fi
+  if diff "$OUT_DIR/$prefix.csv" "$oracle/$prefix.csv" >"$work/$label-csv.diff"; then
+    pass "$label: Go and jq produce the same $prefix.csv"
+  else
+    fail "$label: Go and jq disagree on $prefix.csv (see $work/$label-csv.diff)"
+  fi
+  if diff "$OUT_DIR/$summary" "$oracle/$summary" >"$work/$label-md.diff"; then
+    pass "$label: Go and jq produce the same $summary"
+  else
+    fail "$label: Go and jq disagree on $summary (see $work/$label-md.diff)"
+  fi
+}
+
+
 # The stub. It reads the two settings the scripts vary (the source tree and,
 # from the generated config file, advanced.*), reports a duration derived from
 # them, and writes a metrics file in the real schema. The duration is
@@ -228,6 +278,7 @@ echo "== scripts/benchmark.sh =="
 export OUT_DIR="$work/out" LOG_DIR="$work/logs" REPEATS=3 BENCH_CONNECTIONS=2
 bash "$repo_root/scripts/benchmark.sh" >"$work/benchmark.stdout" 2>&1 ||
   fail "benchmark.sh exited non-zero (see $work/benchmark.stdout)"
+parity standard results
 
 results="$OUT_DIR/results.json"
 if [[ ! -f $results ]]; then
@@ -336,6 +387,7 @@ export BENCH_LINK_PROFILES="baseline +50ms/5mbit" LINKPROBE_BIN="$probe_stub"
 unset BENCH_CONNECTIONS
 bash "$repo_root/scripts/benchmark.sh" >"$work/link.stdout" 2>&1 ||
   fail "benchmark.sh over link profiles exited non-zero (see $work/link.stdout)"
+parity standard-link results
 
 link_results="$OUT_DIR/results.json"
 if [[ ! -f $link_results ]]; then
@@ -390,6 +442,7 @@ export MATRIX_CONNECTIONS="1 2" MATRIX_CONCURRENCY="1 4" MATRIX_SCENARIOS="small
 unset BENCH_CONNECTIONS
 bash "$repo_root/scripts/benchmark-matrix.sh" >"$work/matrix.stdout" 2>&1 ||
   fail "benchmark-matrix.sh exited non-zero (see $work/matrix.stdout)"
+parity matrix matrix
 
 matrix="$OUT_DIR/matrix.json"
 if [[ ! -f $matrix ]]; then
@@ -552,6 +605,7 @@ export MATRIX_CONNECTIONS="1" MATRIX_CONCURRENCY="1" MATRIX_SCENARIOS="small"
 export MATRIX_LINK_PROFILES="baseline +150ms" LINKPROBE_BIN="$probe_stub"
 bash "$repo_root/scripts/benchmark-matrix.sh" >"$work/matrix-link.stdout" 2>&1 ||
   fail "benchmark-matrix.sh over link profiles exited non-zero (see $work/matrix-link.stdout)"
+parity matrix-link matrix
 
 matrix_link="$OUT_DIR/matrix.json"
 if [[ ! -f $matrix_link ]]; then
@@ -647,6 +701,7 @@ export MATRIX_SCENARIOS="redeploy sync calib-10x64k"
 unset MATRIX_LINK_PROFILES LINKPROBE_BIN BASELINE_BIN BASELINE_REF
 bash "$repo_root/scripts/benchmark-matrix.sh" >"$work/matrix-shapes.stdout" 2>&1 ||
   fail "benchmark-matrix.sh over the deploy shapes exited non-zero (see $work/matrix-shapes.stdout)"
+parity matrix-shapes matrix
 
 shape_matrix="$OUT_DIR/matrix.json"
 if [[ ! -f $shape_matrix ]]; then
@@ -690,6 +745,7 @@ export MATRIX_CONNECTIONS="1" MATRIX_CONCURRENCY="1" MATRIX_SCENARIOS="single"
 export MATRIX_REQUEST_CONCURRENCY="default"
 bash "$repo_root/scripts/benchmark-matrix.sh" >"$work/matrix-req.stdout" 2>&1 ||
   fail "benchmark-matrix.sh with the request axis off exited non-zero (see $work/matrix-req.stdout)"
+parity matrix-req matrix
 
 req_matrix="$OUT_DIR/matrix.json"
 if [[ ! -f $req_matrix ]]; then


### PR DESCRIPTION
Steps 1 and 2 of the migration issue #190 describes, now that #184 is complete and its final shell version is the behavioural reference.

## What moves

**Shell measures, Go aggregates.** `benchmark.sh` and `benchmark-matrix.sh` keep payload generation, running the builds, `tc` shaping and probing, because those need a host and privileges. They now also write a `manifest.json` describing the run, and everything downstream of the JSONL they already appended to happens in `cmd/easysftp-bench`.

The manifest is the seam, and it carries the display strings the summaries print (axis lists, the runner line, the settings sentence) verbatim rather than having Go rebuild them: a summary table that reformats itself would be a change to a stored document made by accident.

| Package | What it is |
|---|---|
| `internal/benchmark/schema` | step 1: what is on disk. Its fixture test decodes every result committed under `benchmarks/` **strictly**, so a type that does not cover a stored field fails the build instead of dropping it on the next rewrite. `easysftp-bench validate` is the same check on the command line. |
| `internal/benchmark/stats` | the old `JQ_STATS` block, edge cases included: the lower middle median, `mad` null below two samples, and null sorting below every number while being the identity of addition. |
| `internal/benchmark/report` | the CSV and the Markdown, transcribed rather than improved. |

## Parity is checked, not asserted

`scripts/benchmark-aggregate-jq.sh` is the jq implementation, moved out of the two scripts and kept as an oracle. It reads the *same manifest* the Go command reads, so both sides get identical inputs by construction. `scripts/test-benchmark.sh` aggregates each of its six stub-driven runs twice and diffs the JSON (as values, since key order is not data), the CSV and the Markdown (byte for byte).

All 18 comparisons match. It is scaffolding with an end date: step 6 of #190 deletes it together with the last shell path it checks.

The check earned its keep immediately. It found four real defects in the Go side that review would not have:

- null `mad_ms` and `within_noise` were dropped where jq emits them
- a literal per cent sign in a table header came out as `%%`
- probe documents were re-encoded rather than stored whole, turning a measured host load of `1.0` into `1`
- Go's default HTML escaping would have rewritten `<`, `>` and `&` in any ref or label

Probes are now passed through verbatim, which is what "a probe document is kept whole" should have meant all along.

## Not in scope

No scenario, formula, default or measurement policy changes. The stored documents are the same documents, which is the whole point of a behavioural rewrite. Steps 3 to 6 (scenario generation, process orchestration, the result store, then removing the oracle) are separate PRs.

## Verification

- `scripts/test-benchmark.sh`: 154 checks pass, including the 18 parity diffs
- `scripts/test-benchmark-store.sh`: passes
- `go test ./...`, `go vet ./...`, `gofmt`, `shellcheck scripts/*.sh`: clean
- `easysftp-bench validate` accepts every stored result, `schema_version` 1 included

`go test -race` could not run here: this machine has no C toolchain and it fails with "-race requires cgo". CI covers the race pass. The parity diffs were run against jq 1.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)