### PR TITLE
feat(benchmark): measure, sweep and store in Go (#190)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,58 +171,79 @@ granularity is a separate, later decision; don't build it speculatively.
 
 ## Benchmarks
 
-The harness is split in two, and the split is the thing to keep straight
-(issue #190). **Shell measures, Go aggregates.** `scripts/benchmark.sh`
-measures throughput at the default settings, `scripts/benchmark-matrix.sh`
-sweeps `advanced.connections` against `advanced.concurrency`, both on top of the
-shared `scripts/benchmark-lib.sh` (payload generation, running a build, reading
-its outputs) and `scripts/benchmark-link.sh` (the probed link profile and `tc`
-shaping). Each appends one JSON document per run to its JSONL files, writes a
-`manifest.json` describing the run, and then calls `cmd/easysftp-bench`, which
-reads both and writes `results.json`/`matrix.json` plus their CSV and Markdown.
+The harness is being moved off the shell in the six steps of issue #190, and
+where a given step has got to is the thing to keep straight. Steps 1 to 4 are
+done: **`cmd/easysftp-bench` measures, aggregates and stores**, and the shell
+scripts of the same names survive only as the behavioural reference the parity
+check of step 5 diffs against, before step 6 deletes them. Do not add to the
+shell; add to the Go and let the parity check argue about it.
 
-That means a change to *what is measured* is a shell change and a change to
-*what is reported* is a Go change, and the manifest is the seam. The manifest
-carries the display strings the summaries print (axis lists, the runner line,
-the settings sentence) verbatim rather than rebuilding them in Go: a summary
-table that reformats itself is a change to a stored document made by accident.
+The Go commands are `standard` (throughput at the default settings), `matrix`
+(sweeps `advanced.connections` against `advanced.concurrency`), `store` (files a
+result set under `benchmarks/`), plus `aggregate` and `validate`. The first
+three read their configuration from the environment, exactly the variables the
+scripts read, so the workflows keep passing the same things.
 
-Inside `internal/benchmark`: `schema` is what is on disk and must keep reading
-every result already committed (its fixture test decodes every file under
-`benchmarks/` strictly, so a type that does not cover a stored field fails);
-`stats` is the old `JQ_STATS` block, and its edge cases are load-bearing (lower
-middle median, `mad` null below two samples, null sorting below every number and
-being the identity of addition); `report` renders the CSV and the Markdown.
+The seam between measuring and reporting is still `manifest.json`: the measuring
+half appends one JSON document per run to its JSONL files, writes a manifest
+describing the run, and the aggregation reads both. That is what lets
+`scripts/test-benchmark.sh` hand the jq oracle the same manifest the Go
+aggregation got. The manifest carries the display strings the summaries print
+(axis lists, the runner line, the settings sentence) verbatim rather than
+rebuilding them: a summary table that reformats itself is a change to a stored
+document made by accident.
+
+Inside `internal/benchmark`:
+
+- `schema` is what is on disk and must keep reading every result already
+  committed (its fixture test decodes every file under `benchmarks/` strictly,
+  so a type that does not cover a stored field fails). Anything nullable in a
+  stored document is a pointer here, and `Ordered` exists because a Go map
+  re-encodes its keys sorted: `index.json` is committed, and rewriting an
+  object's key order on the next store is a change nobody made.
+- `stats` is the old `JQ_STATS` block, and its edge cases are load-bearing
+  (lower middle median, `mad` null below two samples, null sorting below every
+  number and being the identity of addition); `report` renders the CSV and the
+  Markdown.
+- `scenario` is the payload tables (spec, description, shape, the per-scenario
+  axis caps), `runner` starts one build and reads its step outputs back,
+  `link` parses profiles and drives `tc` and `cmd/linkprobe`, `driver` is the
+  two measuring loops, and `store` is the result directory.
+- `driver`'s own tests build the stub in `driver/testdata/stub` and assert on
+  what comes out, which is the Go form of what `scripts/test-benchmark.sh` does
+  to the shell. `store`'s tests are the Go form of
+  `scripts/test-benchmark-store.sh`.
 
 `scripts/benchmark-aggregate-jq.sh` is the jq implementation the Go one
 replaced, kept only as the parity oracle `scripts/test-benchmark.sh` diffs
 against. It is scaffolding, not a second implementation: do not tidy it, and do
 not add to it. Step 6 of #190 deletes it.
-A scenario there carries a *shape* as well as a payload (`scenario_shape`: mode,
+A scenario carries a *shape* as well as a payload (`scenario.ShapeOf`: mode,
 whether the measured run redeploys over an unmeasured one, flat or deep
 layout). The deploy-shape scenarios (`redeploy`, `sync`, `deep`, `bulk`,
-`calib-*`) are matrix-only: `benchmark.sh`'s set is fixed, because adding to it
-makes every stored release result incomparable.
-`scripts/benchmark-store.sh` files a result under `benchmarks/`;
-`benchmarks/README.md` documents the layout and the JSON schema and is the page
-to keep in sync when any of those change. Read `benchmarks/index.json` before
-opening single files.
+`calib-*`) are matrix-only: `driver.StandardScenarios` is fixed, because adding
+to it makes every stored release result incomparable.
+`benchmarks/README.md` documents the store layout and the JSON schema and is the
+page to keep in sync when any of those change. Read `benchmarks/index.json`
+before opening single files.
 
 Results are filed by kind: `benchmarks/releases/`, `manual/`, `matrix/`, plus
 `archive/<kind>/`. Only `latest.{json,md}` and `index.json` sit at the top
-level, because those links must not move. `KIND=reindex bash
-scripts/benchmark-store.sh` rebuilds both from what is on disk (that is how the
+level, because those links must not move. `KIND=reindex go run
+./cmd/easysftp-bench store` rebuilds them from what is on disk (that is how the
 migration into this layout was done).
 
 Three invariants the whole thing rests on: a stored result is never rewritten
 (storing an existing name fails), `latest.*` is only ever a copy of a
-`kind: "release"` entry, and a matrix run is never official. Two CI-run
-self-checks pin them (both need `jq`): `scripts/test-benchmark-store.sh` for
-the retention window, archiving and the invariants, and
-`scripts/test-benchmark.sh`, which drives both measuring scripts end to end
-against a stub binary so the jq aggregation, schema and CSV columns are checked
-without an SFTP server. The other half (that a *real* run produces the metrics
-those scripts aggregate) is asserted by the container self-test in `ci.yml`.
+`kind: "release"` entry, and a matrix run is never official.
+`internal/benchmark/store`'s tests pin them, and so do the two jq-dependent
+shell self-checks CI still runs against the reference implementation:
+`scripts/test-benchmark-store.sh` for the retention window, archiving and the
+invariants, and `scripts/test-benchmark.sh`, which drives both measuring scripts
+end to end against a stub binary. The Go equivalents are
+`internal/benchmark/driver`'s tests. The other half (that a *real* run produces
+the metrics all of this aggregates) is asserted by the container self-test in
+`ci.yml`.
 
 The link a result was measured over is recorded in a top-level `link` object
 (issue #184, phase 1) by `cmd/linkprobe`, a separate binary that imports nothing
@@ -231,13 +252,14 @@ would not be a control. Three things to keep true when touching it: `environment
 stays the comparability key and `link` stays a measurement (so it must not move
 into `environment`), the probe report never names the host or the user (it lands
 in `results.json`, which is an artifact and is committed), and `tc` shaping is
-applied only behind the EXIT/INT/TERM trap in `benchmark-link.sh`, because a
-runner left shaped makes every later measurement on it quietly wrong. Shaping
-that is unavailable is recorded, never fatal.
+applied only behind something that survives an interrupt (`link.Shaper.Guard`
+plus a deferred `Clear`, and the EXIT/INT/TERM trap in `benchmark-link.sh`),
+because a runner left shaped makes every later measurement on it quietly wrong.
+Shaping that is unavailable is recorded, never fatal.
 
-The matrix grid is **per scenario** (issue #184, phase 5). `axis_for_scenario`
+The matrix grid is **per scenario** (issue #184, phase 5). `scenario.AxisFor`
 caps and deduplicates both axes at the scenario's file count, and
-`scenario_sweeps_requests` only lets the `request_concurrency` axis through for
+`scenario.SweepsRequests` only lets the `request_concurrency` axis through for
 payloads with files of at least 1 MiB, because that setting is
 `MaxConcurrentRequestsPerFile`. Both rules are properties of the payload, not
 opinions about the code: a value above the file count measures the same

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,18 +1,21 @@
 # Benchmarks
 
-Upload performance of easySFTP against a real SFTP server, measured by
-[`scripts/benchmark.sh`](../scripts/benchmark.sh) (throughput at the default
-settings) and [`scripts/benchmark-matrix.sh`](../scripts/benchmark-matrix.sh)
-(a connections/concurrency sweep), aggregated into the documents below by
-[`cmd/easysftp-bench`](../cmd/easysftp-bench), and filed here by
-[`scripts/benchmark-store.sh`](../scripts/benchmark-store.sh).
+Upload performance of easySFTP against a real SFTP server, measured, aggregated
+and filed here by [`cmd/easysftp-bench`](../cmd/easysftp-bench):
 
-The split is deliberate (issue #190): the scripts measure, because that needs a
-host, a payload and privileges; everything downstream of the measurement is Go,
-because it is where the schemas, the statistics and the reports live. The
-documents themselves did not change with that move, which is what
-`scripts/test-benchmark.sh` checks by aggregating the same measurement twice and
-diffing the two.
+| Command | What it does |
+|---|---|
+| `easysftp-bench standard` | throughput at the default settings |
+| `easysftp-bench matrix` | a connections/concurrency sweep |
+| `easysftp-bench aggregate` | one measured run into the documents below |
+| `easysftp-bench store` | files a result set in this directory |
+
+Issue #190 moved that work off the shell in steps, and the shell scripts of the
+same names are still in `scripts/` as the behavioural reference the Go
+implementation is checked against, until the parity check of step 5 and the
+switch of step 6. The documents themselves did not change with the move, which
+is what `scripts/test-benchmark.sh` checks by aggregating the same measurement
+twice and diffing the two.
 
 These numbers set no threshold and fail no build. They exist to see where the
 time goes (issues #158 and #169), so read them as one host's behaviour on
@@ -458,9 +461,9 @@ they are older than the oldest kept release. Nothing is ever deleted or
 rewritten: storing a name that already exists fails on purpose, so a number
 that was once published stays exactly as it was published.
 
-If results are ever moved by hand, `KIND=reindex bash scripts/benchmark-store.sh`
-rebuilds `index.json` and `latest.*` from whatever is on disk without storing
-anything new.
+If results are ever moved by hand, `KIND=reindex go run ./cmd/easysftp-bench store`
+rebuilds `index.json`, `trend.csv` and `latest.*` from whatever is on disk
+without storing anything new.
 
 ## Running a benchmark
 

--- a/cmd/easysftp-bench/env.go
+++ b/cmd/easysftp-bench/env.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// The measuring commands are configured through the environment, the way the
+// shell scripts they replace were, so .github/workflows/benchmark.yml keeps
+// passing the same variables and a maintainer keeps invoking them the same way.
+// Everything here is reading and validating; nothing below this file touches
+// os.Getenv.
+
+// requireEnv fails on the first empty variable, listing all of them, because a
+// benchmark that dies on the second missing secret after minutes of measuring
+// is a worse error message than one that dies on all of them at once.
+func requireEnv(names ...string) error {
+	var missing []string
+	for _, name := range names {
+		if os.Getenv(name) == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	for _, name := range missing {
+		fmt.Fprintf(os.Stderr, "::error::%s is required but empty\n", name)
+	}
+	return fmt.Errorf("see the secret list in .github/workflows/benchmark.yml")
+}
+
+func envOr(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}
+
+// envPositive reads a variable that must be a positive integer, or its default
+// when unset.
+func envPositive(name string, fallback int) (int, error) {
+	text := os.Getenv(name)
+	if text == "" {
+		return fallback, nil
+	}
+	value, err := positiveInt(text)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a positive integer, got '%s'", name, text)
+	}
+	return value, nil
+}
+
+// envAxis reads a whitespace-separated list of positive integers.
+func envAxis(name, fallback string) ([]int, string, error) {
+	raw := envOr(name, fallback)
+	var out []int
+	for _, field := range strings.Fields(raw) {
+		value, err := positiveInt(field)
+		if err != nil {
+			return nil, "", fmt.Errorf("matrix axis values must be positive integers, got '%s'", field)
+		}
+		out = append(out, value)
+	}
+	return out, raw, nil
+}
+
+// envRequestAxis reads the third matrix axis, which carries the literal token
+// "default" for "set nothing and let easySFTP pick". That keeps a
+// two-dimensional grid expressible now that the axis has a real default, and it
+// is stored as a null coordinate.
+func envRequestAxis(name, fallback string) ([]*int, string, error) {
+	raw := os.Getenv(name)
+	fields := strings.Fields(envOr(name, fallback))
+	if len(fields) == 0 {
+		fields = []string{"default"}
+	}
+	out := make([]*int, 0, len(fields))
+	for _, field := range fields {
+		if field == "default" {
+			out = append(out, nil)
+			continue
+		}
+		value, err := positiveInt(field)
+		if err != nil {
+			return nil, "", fmt.Errorf(
+				"request_concurrency axis values must be positive integers or the token 'default', got '%s'", field)
+		}
+		out = append(out, &value)
+	}
+	return out, raw, nil
+}
+
+// positiveInt accepts what the shell's ^[1-9][0-9]*$ accepted, and nothing
+// else: no sign, no leading zero, no whitespace.
+func positiveInt(text string) (int, error) {
+	if text == "" || text[0] == '0' {
+		return 0, fmt.Errorf("not a positive integer: %q", text)
+	}
+	for i := 0; i < len(text); i++ {
+		if text[i] < '0' || text[i] > '9' {
+			return 0, fmt.Errorf("not a positive integer: %q", text)
+		}
+	}
+	return strconv.Atoi(text)
+}

--- a/cmd/easysftp-bench/main.go
+++ b/cmd/easysftp-bench/main.go
@@ -1,32 +1,33 @@
-// Command easysftp-bench aggregates a benchmark run into the documents it
-// stores.
+// Command easysftp-bench measures a benchmark run and turns it into the
+// documents it stores.
 //
-// It is the Go half of the split issue #190 describes. The measuring scripts
-// keep generating payloads, running easySFTP and shaping the link; they hand
-// this command one manifest describing the run plus the JSONL they appended to,
-// and it writes results.json/results.csv/summary.md or
-// matrix.json/matrix.csv/matrix.md.
+// It is the Go half of the split issue #190 describes, and by steps 3 and 4 it
+// is most of both halves: "standard" and "matrix" generate the payloads, run
+// the builds, shape and probe the link and aggregate what came out, "store"
+// files a result set under benchmarks/, and "aggregate" is the seam between the
+// two, still callable on its own so the jq oracle can be handed the same
+// manifest.
 //
-// It performs no measurement, opens no connection and reads no environment
-// variable. Given the same inputs it writes the same bytes, which is what makes
-// it comparable against the jq implementation it replaces.
+// The subcommands that measure read their configuration from the environment,
+// exactly as the shell scripts they replace did; "aggregate" and "validate"
+// read none, so given the same inputs they write the same bytes, which is what
+// makes the parity check against jq meaningful at all.
 //
 // Usage:
 //
+//	easysftp-bench standard                              measure at the default settings
+//	easysftp-bench matrix                                sweep connections against concurrency
+//	easysftp-bench store                                 file a result set under benchmarks/
 //	easysftp-bench aggregate --manifest <path> --out <dir>
 //	easysftp-bench validate <stored-result.json>...
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/eiserv/easySFTP/internal/benchmark"
-	"github.com/eiserv/easySFTP/internal/benchmark/report"
 	"github.com/eiserv/easySFTP/internal/benchmark/schema"
 )
 
@@ -37,6 +38,12 @@ func main() {
 	}
 	var err error
 	switch os.Args[1] {
+	case "standard":
+		err = runStandard()
+	case "matrix":
+		err = runMatrix()
+	case "store":
+		err = runStore()
 	case "aggregate":
 		err = aggregate(os.Args[2:])
 	case "validate":
@@ -57,10 +64,16 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprint(os.Stderr, `easysftp-bench aggregates a benchmark run into its stored documents.
+	fmt.Fprint(os.Stderr, `easysftp-bench measures a benchmark run and stores what it measured.
 
+  standard                                  measure one or two builds at the default settings
+  matrix                                    sweep connections against concurrency
+  store                                     file a measured result set under benchmarks/
   aggregate --manifest <path> --out <dir>   write the result, the CSV and the summary
   validate <file>...                        check stored results against the schema
+
+The first three read their configuration from the environment; see
+docs/benchmarking.md and .github/workflows/benchmark.yml.
 `)
 }
 
@@ -84,92 +97,8 @@ func aggregate(args []string) error {
 		return err
 	}
 
-	switch manifest.Kind {
-	case schema.BenchmarkMatrix:
-		return writeMatrix(manifest, inputs, *outDir)
-	default:
-		return writeStandard(manifest, inputs, *outDir)
-	}
-}
-
-func writeStandard(m *benchmark.Manifest, in *benchmark.Inputs, outDir string) error {
-	result := benchmark.BuildStandard(m, in)
-	summary := report.Standard{
-		Result:        result,
-		CandidateRef:  m.CandidateRef,
-		BaselineRef:   m.BaselineRef,
-		Repeats:       m.Repeats,
-		RunnerDisplay: m.RunnerDisplay,
-		LinkRequested: m.Link.Requested,
-		Settings:      m.Settings,
-		Labels:        m.Labels,
-		Scenarios:     scenarioNames(m),
-		LinkProfiles:  m.Link.Profiles,
-	}
-	if err := writeJSON(filepath.Join(outDir, "results.json"), result); err != nil {
-		return err
-	}
-	if err := writeFile(filepath.Join(outDir, "results.csv"), summary.CSV()); err != nil {
-		return err
-	}
-	return writeFile(filepath.Join(outDir, "summary.md"), summary.Markdown())
-}
-
-func writeMatrix(m *benchmark.Manifest, in *benchmark.Inputs, outDir string) error {
-	result := benchmark.BuildMatrix(m, in)
-	summary := report.Matrix{
-		Result:             result,
-		CandidateRef:       m.CandidateRef,
-		BaselineRef:        m.BaselineRef,
-		Repeats:            m.Repeats,
-		RunnerDisplay:      m.RunnerDisplay,
-		LinkRequested:      m.Link.Requested,
-		ConnectionsDisplay: m.Grid.ConnectionsDisplay,
-		ConcurrencyDisplay: m.Grid.ConcurrencyDisplay,
-		RequestDisplay:     m.Grid.RequestDisplay,
-		Labels:             m.Labels,
-		LinkProfiles:       m.Link.Profiles,
-		Scenarios:          matrixScenarios(m),
-		Canary: schema.Canary{
-			Scenario:    m.Grid.Canary.Scenario,
-			Connections: m.Grid.Canary.Connections,
-			Concurrency: m.Grid.Canary.Concurrency,
-		},
-		HasBaseline: m.BaselineRef != "",
-	}
-	if err := writeJSON(filepath.Join(outDir, "matrix.json"), result); err != nil {
-		return err
-	}
-	if err := writeFile(filepath.Join(outDir, "matrix.csv"), summary.CSV()); err != nil {
-		return err
-	}
-	return writeFile(filepath.Join(outDir, "matrix.md"), summary.Markdown())
-}
-
-func scenarioNames(m *benchmark.Manifest) []string {
-	names := make([]string, 0, len(m.Scenarios))
-	for _, s := range m.Scenarios {
-		names = append(names, s.Name)
-	}
-	return names
-}
-
-func matrixScenarios(m *benchmark.Manifest) []report.MatrixScenario {
-	out := make([]report.MatrixScenario, 0, len(m.Scenarios))
-	for _, s := range m.Scenarios {
-		out = append(out, report.MatrixScenario{
-			Name:               s.Name,
-			Description:        s.Description,
-			Mode:               s.Mode,
-			ConnectionsDisplay: s.ConnectionsDisplay,
-			ConcurrencyDisplay: s.ConcurrencyDisplay,
-			RequestDisplay:     s.RequestDisplay,
-			Connections:        s.Connections,
-			Concurrency:        s.Concurrency,
-			RequestConcurrency: s.RequestConcurrency,
-		})
-	}
-	return out
+	_, err = benchmark.Write(manifest, inputs, *outDir)
+	return err
 }
 
 // validate checks stored results against the schema. It is what keeps "current
@@ -203,31 +132,4 @@ func validate(paths []string) error {
 		return fmt.Errorf("%d of %d stored result(s) did not validate", failures, len(paths))
 	}
 	return nil
-}
-
-// writeJSON writes a document the way jq does: two-space indentation, a
-// trailing newline, and no HTML escaping.
-//
-// That last part is the reason this does not use json.MarshalIndent, which
-// rewrites the three HTML-significant characters as unicode escapes. jq leaves
-// them alone, and a ref or a label carrying one of them would otherwise make a
-// Go-written result differ from the jq-written results already stored, for no
-// reason a reader could make sense of.
-func writeJSON(path string, value any) error {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(value); err != nil {
-		return err
-	}
-	// Encode already ends the document with a newline.
-	return writeFile(path, buf.String())
-}
-
-func writeFile(path, content string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte(content), 0o644)
 }

--- a/cmd/easysftp-bench/run.go
+++ b/cmd/easysftp-bench/run.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/driver"
+	"github.com/eiserv/easySFTP/internal/benchmark/link"
+	"github.com/eiserv/easySFTP/internal/benchmark/runner"
+	"github.com/eiserv/easySFTP/internal/benchmark/scenario"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/store"
+)
+
+// runStandard measures one or two builds at the default settings.
+func runStandard() error {
+	opts, err := commonOptions()
+	if err != nil {
+		return err
+	}
+	if opts.Repeats, err = envPositive("REPEATS", 3); err != nil {
+		return err
+	}
+	if opts.Connections, err = envPositive("BENCH_CONNECTIONS", 0); err != nil {
+		return err
+	}
+	// Parsed before anything is measured: a typo in a profile must not surface
+	// after minutes of uploading.
+	opts.LinkProfilesRaw = os.Getenv("BENCH_LINK_PROFILES")
+	if opts.LinkProfiles, err = link.ParseProfiles(opts.LinkProfilesRaw); err != nil {
+		return err
+	}
+	return driver.Standard(opts)
+}
+
+// runMatrix sweeps advanced.connections against advanced.concurrency.
+func runMatrix() error {
+	opts, err := commonOptions()
+	if err != nil {
+		return err
+	}
+	if opts.Repeats, err = envPositive("REPEATS", 1); err != nil {
+		return err
+	}
+	if opts.ConnectionsAxis, opts.ConnectionsDisplay, err = envAxis("MATRIX_CONNECTIONS", "1 2 4 8"); err != nil {
+		return err
+	}
+	if opts.ConcurrencyAxis, opts.ConcurrencyDisplay, err = envAxis("MATRIX_CONCURRENCY", "1 2 4 8 16 32 64"); err != nil {
+		return err
+	}
+	if opts.RequestAxis, opts.RequestDisplay, err = envRequestAxis("MATRIX_REQUEST_CONCURRENCY", "1 16 64"); err != nil {
+		return err
+	}
+
+	opts.Scenarios = strings.Fields(envOr("MATRIX_SCENARIOS", "small large single"))
+	for _, name := range opts.Scenarios {
+		if _, err := scenario.Spec(name); err != nil {
+			return err
+		}
+	}
+
+	opts.LinkProfilesRaw = os.Getenv("MATRIX_LINK_PROFILES")
+	if opts.LinkProfiles, err = link.ParseProfiles(opts.LinkProfilesRaw); err != nil {
+		return err
+	}
+	return driver.Matrix(opts)
+}
+
+// commonOptions is everything both measuring commands read.
+func commonOptions() (driver.Options, error) {
+	if err := requireEnv("CANDIDATE_BIN", "CANDIDATE_REF", "OUT_DIR", "DATASET_DIR", "LOG_DIR",
+		"REMOTE_BASE", "BENCH_HOST", "BENCH_USERNAME", "BENCH_PASSWORD", "BENCH_KNOWN_HOSTS"); err != nil {
+		return driver.Options{}, err
+	}
+	port, err := envPositive("BENCH_PORT", 22)
+	if err != nil {
+		return driver.Options{}, err
+	}
+	return driver.Options{
+		CandidateBin: os.Getenv("CANDIDATE_BIN"),
+		CandidateRef: os.Getenv("CANDIDATE_REF"),
+		BaselineBin:  os.Getenv("BASELINE_BIN"),
+		BaselineRef:  os.Getenv("BASELINE_REF"),
+		RemoteBase:   os.Getenv("REMOTE_BASE"),
+		OutDir:       os.Getenv("OUT_DIR"),
+		DatasetDir:   os.Getenv("DATASET_DIR"),
+		LogDir:       os.Getenv("LOG_DIR"),
+		Server: runner.Server{
+			Host:       os.Getenv("BENCH_HOST"),
+			Port:       port,
+			Username:   os.Getenv("BENCH_USERNAME"),
+			Password:   os.Getenv("BENCH_PASSWORD"),
+			KnownHosts: os.Getenv("BENCH_KNOWN_HOSTS"),
+		},
+		LinkProbeBin:      os.Getenv("LINKPROBE_BIN"),
+		LinkIface:         os.Getenv("LINK_IFACE"),
+		LinkSudo:          os.Getenv("LINK_SUDO"),
+		RunnerEnvironment: envOr("RUNNER_ENVIRONMENT", "local"),
+		RunnerName:        os.Getenv("RUNNER_NAME"),
+	}, nil
+}
+
+// runStore files a measured result set under benchmarks/.
+func runStore() error {
+	keep, err := envPositive("KEEP_RELEASES", 5)
+	if err != nil {
+		return err
+	}
+	opts := store.Options{
+		Kind:         os.Getenv("KIND"),
+		ResultsJSON:  os.Getenv("RESULTS_JSON"),
+		SummaryMD:    os.Getenv("SUMMARY_MD"),
+		ResultsCSV:   os.Getenv("RESULTS_CSV"),
+		Version:      os.Getenv("VERSION"),
+		Label:        envOr("LABEL", "manual"),
+		RecordedAt:   envOr("RECORDED_AT", time.Now().UTC().Format("2006-01-02T15:04:05Z")),
+		Commit:       os.Getenv("COMMIT"),
+		RunURL:       os.Getenv("RUN_URL"),
+		Dir:          envOr("BENCH_DIR", "benchmarks"),
+		KeepReleases: keep,
+	}
+	if opts.Kind != store.KindReindex {
+		if opts.ResultsJSON == "" {
+			return fmt.Errorf("RESULTS_JSON is required")
+		}
+		if opts.SummaryMD == "" {
+			return fmt.Errorf("SUMMARY_MD is required")
+		}
+		for _, path := range []string{opts.ResultsJSON, opts.SummaryMD} {
+			if _, err := os.Stat(path); err != nil {
+				return fmt.Errorf("%s does not exist", path)
+			}
+		}
+		if opts.ResultsCSV != "" {
+			if _, err := os.Stat(opts.ResultsCSV); err != nil {
+				return fmt.Errorf("RESULTS_CSV ('%s') does not exist", opts.ResultsCSV)
+			}
+		}
+	}
+	// A release is filed under its version and a sweep under its label, so the
+	// two never share a name; the store refuses to reuse one either way.
+	if opts.Kind != schema.KindRelease {
+		opts.Version = ""
+	}
+	return store.Run(opts)
+}

--- a/internal/benchmark/driver/driver.go
+++ b/internal/benchmark/driver/driver.go
@@ -1,0 +1,528 @@
+// Package driver measures a benchmark run: it generates the payloads, runs the
+// builds, shapes and probes the link, and appends what each run reported to the
+// JSONL the aggregation reads back.
+//
+// It is the Go form of scripts/benchmark.sh and scripts/benchmark-matrix.sh
+// (issue #190, steps 3 and 4). What moved is the orchestration, not the
+// measurement: the same runs happen in the same order at the same settings, and
+// the manifest and the JSONL are the same documents the scripts wrote. A
+// rewrite that also changed what is measured could not be reviewed.
+//
+// Nothing here writes into Options.OutDir except the aggregated result: run
+// logs and the generated config file name the host and the user, and OutDir is
+// uploaded as a workflow artifact, where nothing is masked.
+package driver
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/eiserv/easySFTP/internal/benchmark"
+	"github.com/eiserv/easySFTP/internal/benchmark/link"
+	"github.com/eiserv/easySFTP/internal/benchmark/runner"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// Options is everything a run needs, already validated. The command that builds
+// it reads the environment; nothing below this line does.
+type Options struct {
+	CandidateBin string
+	CandidateRef string
+	BaselineBin  string
+	BaselineRef  string
+
+	// Connections turns on the standard benchmark's third build label
+	// ("poolN"), the same binary with advanced.connections set. Zero is off.
+	Connections int
+
+	Repeats    int
+	RemoteBase string
+	OutDir     string
+	DatasetDir string
+	LogDir     string
+
+	Server runner.Server
+
+	// LinkProfilesRaw is the requested profile string, verbatim, because the
+	// summary prints it. LinkProfiles is the parsed form.
+	LinkProfilesRaw string
+	LinkProfiles    []string
+	LinkProbeBin    string
+	LinkIface       string
+	LinkSudo        string
+
+	// The matrix grid, as it was asked for. Each scenario's own axes are
+	// derived from these against its payload.
+	Scenarios          []string
+	ConnectionsAxis    []int
+	ConcurrencyAxis    []int
+	RequestAxis        []*int
+	ConnectionsDisplay string
+	ConcurrencyDisplay string
+	RequestDisplay     string
+
+	// RunnerEnvironment and RunnerName are the two GitHub Actions variables
+	// that describe the machine.
+	RunnerEnvironment string
+	RunnerName        string
+}
+
+// run is the state one measuring pass carries around.
+type run struct {
+	opts   Options
+	runner *runner.Runner
+	shaper *link.Shaper
+	prober *link.Prober
+
+	// profile is the link profile every measured run below is on. Set by the
+	// profile loop; a run always carries it, so "baseline" in a stored result
+	// means "the real line" and not "unknown".
+	profile string
+
+	labels    []string
+	binaries  []string
+	refs      []string
+	advanced  []string
+	reference string
+
+	files map[string]*jsonl
+}
+
+func logf(format string, args ...any)  { fmt.Printf(format+"\n", args...) }
+func warnf(format string, args ...any) { fmt.Printf("::warning::"+format+"\n", args...) }
+
+func newRun(opts Options) (*run, error) {
+	if opts.Repeats < 1 {
+		return nil, fmt.Errorf("a run needs at least one repeat, got %d", opts.Repeats)
+	}
+	if err := checkRemoteBase(opts.RemoteBase); err != nil {
+		return nil, err
+	}
+	for _, dir := range []string{opts.OutDir, opts.DatasetDir, opts.LogDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, err
+		}
+	}
+	if err := checkLogDir(opts.OutDir, opts.LogDir); err != nil {
+		return nil, err
+	}
+
+	r := &run{
+		opts:    opts,
+		runner:  &runner.Runner{Server: opts.Server, LogDir: opts.LogDir},
+		shaper:  link.NewShaper(opts.LinkIface, opts.LinkSudo, opts.Server.Host, logf, warnf),
+		profile: "baseline",
+		files:   map[string]*jsonl{},
+	}
+	r.shaper.Requested = opts.LinkProfiles
+	r.prober = &link.Prober{
+		Binary:     opts.LinkProbeBin,
+		Host:       opts.Server.Host,
+		Port:       opts.Server.Port,
+		Username:   opts.Server.Username,
+		Password:   opts.Server.Password,
+		KnownHosts: opts.Server.KnownHosts,
+		RemotePath: opts.RemoteBase + "/linkprobe",
+		Logf:       logf,
+		Warnf:      warnf,
+	}
+	return r, nil
+}
+
+// finish hands the measurement over to the aggregation half and prints the
+// summary it wrote.
+//
+// The manifest is written out as well as passed on. It is what
+// scripts/test-benchmark.sh feeds to the jq oracle, so the parity check of
+// issue #190 compares two aggregations of one measurement rather than two
+// measurements (step 5), and it is the seam the two halves meet at.
+func (r *run) finish(m *benchmark.Manifest) error {
+	// The aggregation reads these back off disk, so everything measured has to
+	// be flushed before it does.
+	r.closeFiles()
+
+	manifest := filepath.Join(r.opts.LogDir, "manifest.json")
+	if err := benchmark.WriteJSON(manifest, m); err != nil {
+		return err
+	}
+	inputs, err := benchmark.Load(m)
+	if err != nil {
+		return err
+	}
+	summary, err := benchmark.Write(m, inputs, r.opts.OutDir)
+	if err != nil {
+		return err
+	}
+	cat(filepath.Join(r.opts.OutDir, summary))
+	return nil
+}
+
+// checkRemoteBase refuses the obvious mistakes. The benchmark wipes everything
+// below "<base>/<build>/<scenario>" before every repeat, so a too-broad path is
+// a data-loss bug, not a slow benchmark. easySFTP itself refuses "/"; this
+// refuses the rest.
+func checkRemoteBase(base string) error {
+	switch {
+	case base == "/", base == ".", base == "..", strings.HasSuffix(base, "/"):
+		return fmt.Errorf(
+			"REMOTE_BASE ('%s') must be a dedicated directory such as /easysftp-benchmark, without a trailing slash", base)
+	}
+	return nil
+}
+
+// checkLogDir keeps the run logs out of the artifact. They echo the host name
+// and the user name, both secrets here, and OutDir is uploaded unmasked.
+func checkLogDir(outDir, logDir string) error {
+	out, err := filepath.Abs(outDir)
+	if err != nil {
+		return err
+	}
+	log, err := filepath.Abs(logDir)
+	if err != nil {
+		return err
+	}
+	if log == out || strings.HasPrefix(log, out+string(filepath.Separator)) {
+		return fmt.Errorf(
+			"LOG_DIR must not be inside OUT_DIR: run logs name the host and user, and OUT_DIR is uploaded as an artifact")
+	}
+	return nil
+}
+
+// jsonl is one of the append-only files a run measures into. They are truncated
+// up front, so a re-run in the same log directory measures itself and not its
+// predecessor.
+type jsonl struct {
+	path string
+	file *os.File
+}
+
+func (r *run) open(name, filename string) (string, error) {
+	path := filepath.Join(r.opts.LogDir, filename)
+	file, err := os.Create(path)
+	if err != nil {
+		return "", err
+	}
+	r.files[name] = &jsonl{path: path, file: file}
+	return path, nil
+}
+
+// append writes one document as a line. A record that cannot be encoded is a
+// bug in this package rather than a measurement problem, so it stops the run.
+func (r *run) append(name string, record any) error {
+	line, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	f := r.files[name]
+	if _, err := f.file.Write(append(line, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *run) closeFiles() {
+	for _, f := range r.files {
+		f.file.Close()
+	}
+}
+
+func (r *run) path(name string) string {
+	if f, ok := r.files[name]; ok {
+		return f.path
+	}
+	return ""
+}
+
+// stem is the log file prefix of one measured run, with the profile as a
+// filename component: profiles contain "+" and "/", and a log called
+// "+50ms/5mbit-small-1.log" is a missing directory, not a log.
+func (r *run) stem(parts ...string) string {
+	return filepath.Join(r.opts.LogDir, strings.Join(parts, "-"))
+}
+
+// builds fills in the build labels every measured run loops over. The
+// connection pool is measured as a third build of the *same* binary, not as a
+// separate workflow run: the two numbers are only comparable when they are
+// interleaved on the same host in the same minutes.
+func (r *run) setBuilds(withPool bool) {
+	r.labels = []string{"candidate"}
+	r.binaries = []string{r.opts.CandidateBin}
+	r.refs = []string{r.opts.CandidateRef}
+	r.advanced = []string{""}
+
+	if r.opts.BaselineBin != "" {
+		ref := r.opts.BaselineRef
+		if ref == "" {
+			ref = "unknown"
+		}
+		r.labels = append(r.labels, "baseline")
+		r.binaries = append(r.binaries, r.opts.BaselineBin)
+		r.refs = append(r.refs, ref)
+		r.advanced = append(r.advanced, "")
+	}
+	if withPool && r.opts.Connections > 0 {
+		r.labels = append(r.labels, fmt.Sprintf("pool%d", r.opts.Connections))
+		r.binaries = append(r.binaries, r.opts.CandidateBin)
+		r.refs = append(r.refs, r.opts.CandidateRef)
+		r.advanced = append(r.advanced, fmt.Sprintf("connections: %d", r.opts.Connections))
+	}
+
+	// The reference build every delta is measured against: the baseline when
+	// one was measured, otherwise the candidate, so a pool run without a
+	// baseline is still compared against something.
+	r.reference = "candidate"
+	if r.opts.BaselineBin != "" {
+		r.reference = "baseline"
+	}
+}
+
+// preClean is the clean deployment that runs before every measured run. It
+// wipes the populated tree the last run left behind, so repeat 1 (uploading
+// into nothing) measures the same thing as the repeats after it.
+//
+// It is instrumented where its numbers are wanted, into its own metrics file
+// and its own aggregate (issue #184, phase 4): a clean deployment of an empty
+// directory is a pure delete sweep, and it is the only place deletions are
+// measured at all. Nothing of it ever reaches the upload numbers.
+func (r *run) preClean(binary, remote, stem, advanced string, instrument bool) (int, error) {
+	metrics := ""
+	if instrument {
+		metrics = stem + ".clean.metrics.json"
+	}
+	return r.cleanAt(binary, remote, stem+".clean", advanced, metrics)
+}
+
+// cleanAt deploys an empty directory over a remote path, writing its log and
+// step outputs next to the given stem.
+func (r *run) cleanAt(binary, remote, stem, advanced, metrics string) (int, error) {
+	return r.runner.Do(runner.Run{
+		Binary:   binary,
+		Source:   filepath.Join(r.opts.DatasetDir, "empty"),
+		Remote:   remote,
+		Mode:     "clean",
+		Log:      stem + ".log",
+		Outputs:  stem + ".out",
+		Metrics:  metrics,
+		Advanced: advanced,
+	})
+}
+
+// cat copies a failed run's log into the job log, which masks secrets. Never
+// into the artifact.
+func cat(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	os.Stdout.Write(data)
+}
+
+// deleteRecord is one pre-clean read back off disk. The coordinates are added
+// by the caller, which is what lets a standard sweep and a matrix sweep share
+// this shape (issue #184, phase 4).
+type deleteRecord struct {
+	ExitCode     int             `json:"exit_code"`
+	DurationMS   float64         `json:"duration_ms"`
+	FilesDeleted float64         `json:"files_deleted"`
+	Metrics      json.RawMessage `json:"metrics"`
+
+	Label       string `json:"label"`
+	Scenario    string `json:"scenario"`
+	LinkProfile string `json:"link_profile"`
+
+	Connections        *int `json:"connections,omitempty"`
+	Concurrency        *int `json:"concurrency,omitempty"`
+	RequestConcurrency *int `json:"request_concurrency,omitempty"`
+
+	Repeat int `json:"repeat"`
+}
+
+func readDelete(stem string, exitCode int) deleteRecord {
+	return deleteRecord{
+		ExitCode:     exitCode,
+		DurationMS:   runner.StepNumber(stem+".clean.out", "duration-ms"),
+		FilesDeleted: runner.StepNumber(stem+".clean.out", "files-deleted"),
+		Metrics:      runner.ReadMetrics(stem + ".clean.metrics.json"),
+	}
+}
+
+// runRecord is one measured run, exactly as the scripts appended it.
+type runRecord struct {
+	Label       string `json:"label"`
+	Ref         string `json:"ref"`
+	Scenario    string `json:"scenario"`
+	LinkProfile string `json:"link_profile"`
+
+	Connections        *int `json:"connections,omitempty"`
+	Concurrency        *int `json:"concurrency,omitempty"`
+	RequestConcurrency *int `json:"request_concurrency,omitempty"`
+
+	Repeat     int             `json:"repeat"`
+	ExitCode   int             `json:"exit_code"`
+	DurationMS float64         `json:"duration_ms"`
+	Files      float64         `json:"files"`
+	Bytes      float64         `json:"bytes"`
+	Retries    *float64        `json:"retries,omitempty"`
+	Errors     *float64        `json:"errors,omitempty"`
+	Refused    *float64        `json:"refused,omitempty"`
+	Metrics    json.RawMessage `json:"metrics"`
+}
+
+// environment is the machine and toolchain a result was measured on, and the
+// comparability key between two results: benchmarks/README.md says two numbers
+// may only be compared when this matches.
+//
+// The three uname fields and the CPU count come from the same commands the
+// shell used, so a runner that reports "6.8.0-51-generic" keeps reporting it.
+// Where a command is missing, Go's own view of the machine stands in rather
+// than the field being invented.
+func (r *run) environment() *schema.Environment {
+	env := &schema.Environment{
+		Runner:     r.opts.RunnerEnvironment,
+		OS:         firstLine(exec.Command("uname", "-s"), capitalized(runtime.GOOS)),
+		Kernel:     firstLine(exec.Command("uname", "-r"), ""),
+		Arch:       firstLine(exec.Command("uname", "-m"), runtime.GOARCH),
+		CPUModel:   cpuModel(),
+		CPUs:       cpuCount(),
+		GoVersion:  goVersion(),
+		RunnerName: r.opts.RunnerName,
+	}
+	return env
+}
+
+// runnerLine is the "<environment>, <kernel>, <n> cpu" string a result stores,
+// and runnerDisplay the shorter one the summary table prints. The two differ,
+// and reconstructing either from the other would be guesswork, so both travel
+// through the manifest.
+func (r *run) runnerLine() (string, string) {
+	display := fmt.Sprintf("%s %s, %d cpu",
+		firstLine(exec.Command("uname", "-s"), capitalized(runtime.GOOS)),
+		firstLine(exec.Command("uname", "-r"), ""),
+		cpuCount())
+	return r.opts.RunnerEnvironment + ", " + display, display
+}
+
+func firstLine(cmd *exec.Cmd, fallback string) string {
+	out, err := cmd.Output()
+	if err != nil {
+		return fallback
+	}
+	line, _, _ := strings.Cut(strings.TrimSpace(string(out)), "\n")
+	if line == "" {
+		return fallback
+	}
+	return line
+}
+
+func capitalized(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// cpuModel is the first "model name" of /proc/cpuinfo, which is where the shell
+// read it. Machines without that file report "unknown", as they did before.
+func cpuModel() string {
+	data, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		return "unknown"
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if name, value, found := strings.Cut(line, ": "); found && strings.HasPrefix(name, "model name") {
+			return value
+		}
+	}
+	return "unknown"
+}
+
+// cpuCount prefers nproc, which reports the CPUs this process may actually use.
+// runtime.NumCPU reports the same thing, and stands in where nproc is missing.
+func cpuCount() int {
+	if text := firstLine(exec.Command("nproc"), ""); text != "" {
+		if n, err := strconv.Atoi(text); err == nil {
+			return n
+		}
+	}
+	return runtime.NumCPU()
+}
+
+// goVersion is the toolchain on the runner, not the toolchain this binary was
+// built with: the benchmark builds easySFTP from source on the same machine.
+func goVersion() string {
+	fields := strings.Fields(firstLine(exec.Command("go", "version"), ""))
+	if len(fields) < 3 {
+		return ""
+	}
+	return fields[2]
+}
+
+// linkManifest is the shaping half of the link object.
+//
+// The probes are deliberately not in here: they are read from the probe file by
+// the aggregation, so a run without a probe binary simply has none. This
+// carries only what the measuring half knows and the aggregation cannot derive.
+func (r *run) linkManifest() benchmark.ManifestLink {
+	var iface *string
+	if r.shaper.Iface != "" {
+		value := r.shaper.Iface
+		iface = &value
+	}
+	var reason *string
+	if r.shaper.Reason != "" {
+		value := r.shaper.Reason
+		reason = &value
+	}
+	return benchmark.ManifestLink{
+		Iface: iface,
+		Shaping: schema.Shaping{
+			Available: r.shaper.Available,
+			Reason:    reason,
+			Requested: orEmpty(r.shaper.Requested),
+			Applied:   orEmpty(r.shaper.Applied),
+		},
+		Profiles:  orEmpty(r.opts.LinkProfiles),
+		Requested: r.opts.LinkProfilesRaw,
+	}
+}
+
+// orEmpty keeps a nil slice out of the stored JSON: "[]" is a run that shaped
+// nothing, "null" is a document nobody wrote on purpose.
+func orEmpty(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
+}
+
+// shapeIfNeeded probes for shaping only when a profile actually asks for it: a
+// run on the real line must not need tc, sudo or NET_ADMIN.
+func (r *run) shapeIfNeeded(what string) {
+	if !link.ShapeNeeded(r.opts.LinkProfiles) {
+		return
+	}
+	r.shaper.Probe()
+	if !r.shaper.Available {
+		warnf("link profiles were requested but shaping is unavailable (%s); every profile is %s on the real line",
+			r.shaper.Reason, what)
+	}
+}
+
+// cleanupLinkProbe removes what a probe killed mid-write left behind. The probe
+// removes its own payload, and a leftover would be counted by the next run's
+// remote scan.
+func (r *run) cleanupLinkProbe() {
+	if r.opts.LinkProbeBin == "" {
+		return
+	}
+	if _, err := r.cleanAt(r.opts.CandidateBin, r.opts.RemoteBase+"/linkprobe",
+		filepath.Join(r.opts.LogDir, "cleanup-linkprobe"), "", ""); err != nil {
+		warnf("cleanup of the link probe directory failed")
+	}
+}

--- a/internal/benchmark/driver/driver_test.go
+++ b/internal/benchmark/driver/driver_test.go
@@ -1,0 +1,458 @@
+package driver_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/driver"
+	"github.com/eiserv/easySFTP/internal/benchmark/runner"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// These tests are the Go half of scripts/test-benchmark.sh: the driver does not
+// care what the "easySFTP binary" it runs is, so a stub that writes plausible
+// step outputs and a plausible metrics file is enough to check the measurement
+// order, the deploy shapes, the delete sweeps and the documents that come out,
+// without an SFTP server, a network or a real build.
+//
+// What they deliberately do not cover is whether easySFTP itself is fast; that
+// is what the real benchmark is for.
+
+// stub is the "easySFTP build" these tests measure: this very test binary, run
+// again with stubMarker set so it takes the stub path in stub_test.go instead
+// of running the suite.
+//
+// Re-execution rather than a compiled helper, because nothing then has to be
+// built while the tests run, and the binary the driver starts is one that
+// already exists.
+var stub string
+
+func TestMain(m *testing.M) {
+	if os.Getenv(stubMarker) != "" {
+		stubMain()
+		return
+	}
+	binary, err := os.Executable()
+	if err != nil {
+		panic("locating the test binary: " + err.Error())
+	}
+	stub = binary
+	os.Exit(m.Run())
+}
+
+// options is the smallest complete configuration: one work directory per test,
+// with the log directory outside the output directory, as the driver insists.
+func options(t *testing.T) driver.Options {
+	t.Helper()
+	work := t.TempDir()
+	// The driver passes its own environment on to every build it starts, which
+	// is how the stub learns both that it is the stub and where to keep its
+	// stand-in for the remote server.
+	t.Setenv(stubMarker, "1")
+	t.Setenv("EASYSFTP_STUB_STATE", filepath.Join(work, "remote"))
+	return driver.Options{
+		CandidateBin: stub,
+		CandidateRef: "candidate-ref",
+		BaselineBin:  stub,
+		BaselineRef:  "baseline-ref",
+		RemoteBase:   "/easysftp-benchmark-test",
+		OutDir:       filepath.Join(work, "out"),
+		DatasetDir:   filepath.Join(work, "data"),
+		LogDir:       filepath.Join(work, "logs"),
+		Server: runner.Server{
+			Host: "example.invalid", Port: 22, Username: "tester",
+			Password: "secret", KnownHosts: "example.invalid ssh-ed25519 AAAA",
+		},
+		LinkProfiles:      []string{"baseline"},
+		RunnerEnvironment: "local",
+		Repeats:           1,
+	}
+}
+
+func readJSON[T any](t *testing.T, path string) T {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	value, err := schema.DecodeStrict[T](data)
+	if err != nil {
+		t.Fatalf("decoding %s: %v", path, err)
+	}
+	return *value
+}
+
+func TestStandard(t *testing.T) {
+	opts := options(t)
+	opts.Repeats = 3
+	opts.Connections = 2
+	if err := driver.Standard(opts); err != nil {
+		t.Fatalf("measuring: %v", err)
+	}
+
+	result := readJSON[schema.Standard](t, filepath.Join(opts.OutDir, "results.json"))
+	if result.SchemaVersion != schema.StandardSchemaVersion {
+		t.Errorf("schema_version = %d, want %d", result.SchemaVersion, schema.StandardSchemaVersion)
+	}
+	// Three builds (candidate, baseline, pool2) x three scenarios.
+	if len(result.Results) != 9 {
+		t.Errorf("aggregated %d rows, want 9", len(result.Results))
+	}
+	if len(result.Runs) != 27 {
+		t.Errorf("kept %d raw repeats, want 27", len(result.Runs))
+	}
+	for _, row := range result.Results {
+		if row.FailedRuns != 0 {
+			t.Errorf("%s/%s: %d failed run(s)", row.Label, row.Scenario, row.FailedRuns)
+		}
+		if row.LinkProfile != "baseline" {
+			t.Errorf("%s/%s: link profile %q, want the implicit baseline", row.Label, row.Scenario, row.LinkProfile)
+		}
+	}
+	if result.Environment == nil || result.Environment.OS == "" {
+		t.Error("the environment block is empty")
+	}
+
+	// The stub gives the pool build twice the parallelism, so it must come out
+	// ahead of the single-connection baseline. This is the check that the delta
+	// arithmetic has its sign the right way round.
+	delta := comparison(t, result, "pool2", "small")
+	if delta == nil || *delta >= 0 {
+		t.Errorf("the pool build should be faster than the baseline, got delta %v", delta)
+	}
+
+	// The pre-clean is a delete sweep and is stored as one (issue #184, phase
+	// 4). Three repeats mean two sweeps that found something: the first
+	// pre-clean of a build and scenario runs against an empty directory and is
+	// dropped.
+	if len(result.Deletes) != 9 {
+		t.Errorf("stored %d delete rows, want one per build and scenario", len(result.Deletes))
+	}
+	sweep := deleteRow(t, result, "candidate", "small")
+	if sweep.Sweeps != 2 {
+		t.Errorf("counted %d sweeps, want the two that found something", sweep.Sweeps)
+	}
+	if sweep.FilesDeleted != 300 {
+		t.Errorf("deleted %v files, want 300", sweep.FilesDeleted)
+	}
+	if got := names(sweep.Phases); got != "connect delete_sweep remote_scan" {
+		t.Errorf("the delete sweep kept phases %q", got)
+	}
+
+	// The whole point of a separate block: an upload aggregate must not have
+	// grown a delete phase, and the delete numbers must not have moved an
+	// upload median.
+	for _, row := range result.Results {
+		for _, phase := range row.Phases {
+			if phase.Name == "delete_sweep" {
+				t.Errorf("%s/%s picked up a delete phase", row.Label, row.Scenario)
+			}
+		}
+		for _, op := range row.Operations {
+			if op.Name == "sftp_remove" {
+				t.Errorf("%s/%s picked up a delete round-trip", row.Label, row.Scenario)
+			}
+		}
+	}
+
+	// Without a probe binary the result still has to carry a valid link object,
+	// with an empty probe list rather than an invented entry.
+	if result.Link == nil || len(result.Link.Probes) != 0 || result.Link.Shaping.Available {
+		t.Errorf("an unprobed run reports link %+v", result.Link)
+	}
+
+	csv := lines(t, filepath.Join(opts.OutDir, "results.csv"))
+	if len(csv) != 10 {
+		t.Errorf("the CSV has %d lines, want a header plus one row per build and scenario", len(csv))
+	}
+	summary := read(t, filepath.Join(opts.OutDir, "summary.md"))
+	for _, needle := range []string{
+		"## easySFTP benchmark", "### Throughput", "### Resources",
+		"### Where the time goes", "### Delete sweeps", "No link probe ran for this result",
+	} {
+		if !strings.Contains(summary, needle) {
+			t.Errorf("summary.md is missing %q", needle)
+		}
+	}
+}
+
+func TestMatrix(t *testing.T) {
+	opts := options(t)
+	opts.Scenarios = []string{"small", "single"}
+	opts.ConnectionsAxis = []int{1, 2}
+	opts.ConcurrencyAxis = []int{1, 4}
+	opts.RequestAxis = []*int{intp(1), intp(16), intp(64)}
+	opts.ConnectionsDisplay, opts.ConcurrencyDisplay, opts.RequestDisplay = "1 2", "1 4", "1 16 64"
+	if err := driver.Matrix(opts); err != nil {
+		t.Fatalf("sweeping: %v", err)
+	}
+
+	result := readJSON[schema.Matrix](t, filepath.Join(opts.OutDir, "matrix.json"))
+	if result.BenchmarkKind != schema.BenchmarkMatrix {
+		t.Errorf("benchmark_kind = %q", result.BenchmarkKind)
+	}
+
+	// The grid is per scenario (issue #184, phase 5): "small" (300 files) is
+	// swept over 2 connections x 2 concurrency at easySFTP's own
+	// request_concurrency, and "single" (one 32 MiB file) collapses to a single
+	// connections/concurrency cell but is the one scenario the request axis
+	// applies to. 2 builds each: 8 + 6.
+	if len(result.Cells) != 14 {
+		t.Errorf("measured %d cells, want 14", len(result.Cells))
+	}
+	if got := len(cells(result, "single", "candidate")); got != 3 {
+		t.Errorf("a one-file scenario was measured at %d coordinates, want the 3 request values", got)
+	}
+	for _, cell := range cells(result, "small", "candidate") {
+		if cell.RequestConcurrency != nil {
+			t.Errorf("the request axis was swept on a payload of 4 KiB files: %v", *cell.RequestConcurrency)
+		}
+	}
+	axes, ok := result.Axes.PerScenario["single"]
+	if !ok || axes.Files != 1 {
+		t.Errorf("per-scenario axes for single: %+v", axes)
+	}
+
+	// A matrix run has no runs[], so a cell is the finest grain there is: the
+	// phase and round-trip detail has to survive into it (issue #184, phase 2).
+	for _, cell := range result.Cells {
+		if len(cell.Phases) == 0 || len(cell.Operations) == 0 {
+			t.Errorf("%s c%d/w%d lost its detail", cell.Scenario, cell.Connections, cell.Concurrency)
+		}
+		if cell.MadMS != nil {
+			t.Errorf("a one-repeat cell reports a MAD of %v; 0 there would read as precision", *cell.MadMS)
+		}
+		for _, phase := range cell.Phases {
+			if phase.Name == "delete_sweep" {
+				t.Errorf("%s picked up a delete phase", cell.Scenario)
+			}
+		}
+	}
+
+	// The policy measurement of issue #184 phase 5. The stub resolves "auto" to
+	// easySFTP's own defaults (1/4/16) and gets faster with more parallelism,
+	// so the best cell of "small" is 2/4 and auto must come out behind it.
+	if len(result.Auto) != 2 {
+		t.Errorf("measured auto %d time(s), want once per scenario and profile", len(result.Auto))
+	}
+	for _, cell := range result.Cells {
+		if cell.Label == "auto" {
+			t.Error("auto reached cells[]; it chooses a coordinate rather than sitting at one")
+		}
+	}
+	auto := autoRow(t, result, "small")
+	if auto.Chosen.Connections == nil || *auto.Chosen.Connections != 1 ||
+		auto.Chosen.Concurrency == nil || *auto.Chosen.Concurrency != 4 {
+		t.Errorf("auto reported chosen settings %+v, want the stub's 1/4", auto.Chosen)
+	}
+	if auto.RegretPercent == nil || *auto.RegretPercent <= 0 {
+		t.Errorf("auto picked the slower cell, so the regret should be positive, got %v", auto.RegretPercent)
+	}
+
+	// Start, middle and end of the grid: 2 connections x 2 concurrency x 2
+	// scenarios x 2 builds leaves the middle canary a middle to sit in.
+	if got := canaryOrder(result); got != "start mid end" {
+		t.Errorf("the canary ran %q, want start mid end", got)
+	}
+
+	// One delete row per cell, minus the first cell of each (build, scenario):
+	// its pre-clean has an empty directory in front of it. The auto runs
+	// contribute none, because their coordinates are not a coordinate of the
+	// grid.
+	if len(result.Deletes) != 10 {
+		t.Errorf("stored %d delete rows, want 10", len(result.Deletes))
+	}
+	for _, row := range result.Deletes {
+		if row.Label == "auto" {
+			t.Error("an auto run contributed a delete row")
+		}
+	}
+
+	csv := lines(t, filepath.Join(opts.OutDir, "matrix.csv"))
+	if len(csv) != 15 {
+		t.Errorf("the matrix CSV has %d lines, want a header plus one row per cell", len(csv))
+	}
+	summary := read(t, filepath.Join(opts.OutDir, "matrix.md"))
+	for _, needle := range []string{
+		"## easySFTP connections/concurrency matrix", "### Delete sweeps", "### Canary",
+		"costs (policy regret)", "**The optimum sits on the edge of the grid**",
+	} {
+		if !strings.Contains(summary, needle) {
+			t.Errorf("matrix.md is missing %q", needle)
+		}
+	}
+}
+
+// TestMatrixDeployShapes is the payload side: a scenario carries a mode and a
+// base deploy, not only a payload (issue #184, phase 3).
+func TestMatrixDeployShapes(t *testing.T) {
+	opts := options(t)
+	opts.BaselineBin, opts.BaselineRef = "", ""
+	opts.Scenarios = []string{"redeploy", "sync", "calib-10x64k"}
+	opts.ConnectionsAxis = []int{1}
+	opts.ConcurrencyAxis = []int{2}
+	opts.RequestAxis = []*int{nil}
+	opts.ConnectionsDisplay, opts.ConcurrencyDisplay, opts.RequestDisplay = "1", "2", "default"
+	if err := driver.Matrix(opts); err != nil {
+		t.Fatalf("sweeping: %v", err)
+	}
+
+	result := readJSON[schema.Matrix](t, filepath.Join(opts.OutDir, "matrix.json"))
+	if got := scenarios(result); got != "calib-10x64k redeploy sync" {
+		t.Errorf("measured %q", got)
+	}
+	if got := result.Scenarios["calib-10x64k"]; got != "10 files x 64 KiB, uniform (calibration)" {
+		t.Errorf("the calibration scenario is documented as %q", got)
+	}
+
+	logs := read(t, filepath.Join(opts.LogDir, "baseline-candidate-sync-c1-w2-rdefault-1.log"))
+	if !strings.Contains(logs, "stub: mode=sync") {
+		t.Errorf("the sync scenario was not measured in mode sync: %q", logs)
+	}
+	logs = read(t, filepath.Join(opts.LogDir, "baseline-candidate-redeploy-c1-w2-rdefault-1.log"))
+	if !strings.Contains(logs, "stub: mode=overlay skip_unchanged=true") {
+		t.Errorf("the redeploy scenario was not measured with skip_unchanged: %q", logs)
+	}
+
+	// The unmeasured deploy the measured run redeploys over. Two cells plus the
+	// two auto runs of the same scenarios: the policy run is a deployment of
+	// that scenario like any other, so it gets the base deploy too. A scenario
+	// without a base deploy runs one deploy only.
+	if got := len(glob(t, opts.LogDir, "*.base.log")); got != 4 {
+		t.Errorf("found %d base deploys, want 4", got)
+	}
+	if got := len(glob(t, opts.LogDir, "*calib-10x64k*.base.log")); got != 0 {
+		t.Errorf("a scenario without a base deploy laid down %d", got)
+	}
+}
+
+// TestRemoteBaseIsRefused pins the guard that keeps a typo from wiping
+// something else: the benchmark deletes everything below its remote base.
+func TestRemoteBaseIsRefused(t *testing.T) {
+	for _, base := range []string{"/", ".", "..", "/easysftp-benchmark/"} {
+		opts := options(t)
+		opts.RemoteBase = base
+		if err := driver.Standard(opts); err == nil {
+			t.Errorf("REMOTE_BASE %q was accepted", base)
+		}
+	}
+}
+
+// TestLogDirInsideOutDirIsRefused pins the other guard: run logs name the host
+// and the user, and the output directory is uploaded as an artifact, where
+// nothing is masked.
+func TestLogDirInsideOutDirIsRefused(t *testing.T) {
+	opts := options(t)
+	opts.LogDir = filepath.Join(opts.OutDir, "logs")
+	if err := driver.Standard(opts); err == nil {
+		t.Error("a log directory inside the artifact directory was accepted")
+	}
+}
+
+func intp(v int) *int { return &v }
+
+func comparison(t *testing.T, result schema.Standard, label, name string) *float64 {
+	t.Helper()
+	for _, row := range result.Comparison {
+		if row.Label == label && row.Scenario == name {
+			return row.DeltaPercent
+		}
+	}
+	t.Fatalf("no comparison for %s/%s", label, name)
+	return nil
+}
+
+func deleteRow(t *testing.T, result schema.Standard, label, name string) schema.StandardDelete {
+	t.Helper()
+	for _, row := range result.Deletes {
+		if row.Label == label && row.Scenario == name {
+			return row
+		}
+	}
+	t.Fatalf("no delete row for %s/%s", label, name)
+	return schema.StandardDelete{}
+}
+
+func autoRow(t *testing.T, result schema.Matrix, name string) schema.Auto {
+	t.Helper()
+	for _, row := range result.Auto {
+		if row.Scenario == name {
+			return row
+		}
+	}
+	t.Fatalf("no auto row for %s", name)
+	return schema.Auto{}
+}
+
+func cells(result schema.Matrix, name, label string) []schema.Cell {
+	var out []schema.Cell
+	for _, cell := range result.Cells {
+		if cell.Scenario == name && cell.Label == label {
+			out = append(out, cell)
+		}
+	}
+	return out
+}
+
+func canaryOrder(result schema.Matrix) string {
+	var at []string
+	for _, row := range result.Canary {
+		at = append(at, row.At)
+	}
+	return strings.Join(at, " ")
+}
+
+func names(phases []schema.Phase) string {
+	var out []string
+	for _, phase := range phases {
+		out = append(out, phase.Name)
+	}
+	sortStrings(out)
+	return strings.Join(out, " ")
+}
+
+func scenarios(result schema.Matrix) string {
+	seen := map[string]bool{}
+	var out []string
+	for _, cell := range result.Cells {
+		if !seen[cell.Scenario] {
+			seen[cell.Scenario] = true
+			out = append(out, cell.Scenario)
+		}
+	}
+	sortStrings(out)
+	return strings.Join(out, " ")
+}
+
+func sortStrings(values []string) {
+	for i := 1; i < len(values); i++ {
+		for j := i; j > 0 && values[j] < values[j-1]; j-- {
+			values[j], values[j-1] = values[j-1], values[j]
+		}
+	}
+}
+
+func read(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func lines(t *testing.T, path string) []string {
+	t.Helper()
+	return strings.Split(strings.TrimRight(read(t, path), "\n"), "\n")
+}
+
+func glob(t *testing.T, dir, pattern string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, pattern))
+	if err != nil {
+		t.Fatalf("globbing %s: %v", pattern, err)
+	}
+	return matches
+}

--- a/internal/benchmark/driver/matrix.go
+++ b/internal/benchmark/driver/matrix.go
@@ -1,0 +1,567 @@
+package driver
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/eiserv/easySFTP/internal/benchmark"
+	"github.com/eiserv/easySFTP/internal/benchmark/link"
+	"github.com/eiserv/easySFTP/internal/benchmark/runner"
+	"github.com/eiserv/easySFTP/internal/benchmark/scenario"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// The canary cell. Deliberately constants and not options: three canaries of
+// one run are compared against each other, and two runs' canaries against each
+// other, which only works while the cell stays the same everywhere.
+const (
+	CanaryScenario    = "small"
+	CanaryConnections = 1
+	CanaryConcurrency = 4
+)
+
+// axes is one scenario's own grid, after its payload capped what was asked for.
+type axes struct {
+	connections []int
+	concurrency []int
+	request     []*int
+	files       int
+}
+
+// cells is how many measured runs this scenario contributes to one profile.
+func (a axes) cells(labels, repeats int) int {
+	return len(a.connections) * len(a.concurrency) * len(a.request) * labels * repeats
+}
+
+// Matrix sweeps advanced.connections against advanced.concurrency (optionally
+// advanced.request_concurrency as a third axis) and records one cell per
+// combination, so the result can be read as a heatmap or as a scaling curve
+// rather than as a single number.
+//
+// Candidate and baseline are measured back to back *within* each cell, not as
+// two separate sweeps: a shared host drifts over the hour such a sweep takes,
+// and a per-sweep layout would charge all of that drift to whichever build ran
+// second.
+func Matrix(opts Options) error {
+	r, err := newRun(opts)
+	if err != nil {
+		return err
+	}
+	defer r.closeFiles()
+	defer r.shaper.Clear()
+
+	for _, f := range []struct{ name, filename string }{
+		{"runs", "matrix-runs.jsonl"},
+		{"probes", "link-probes.jsonl"},
+		{"canary", "canary.jsonl"},
+		{"deletes", "deletes.jsonl"},
+		{"auto", "auto.jsonl"},
+	} {
+		if _, err := r.open(f.name, f.filename); err != nil {
+			return err
+		}
+	}
+	r.setBuilds(false)
+
+	// The grid is per scenario, not global (issue #184, phase 5). Two payload
+	// facts decide it, and both are properties of the payload rather than of
+	// the code: a value above the file count cannot be used by anything, and
+	// request_concurrency is per file, so a payload of 4 KiB files cannot show
+	// it at all. Computed once, up front, because the run count printed below
+	// has to be the count that is actually measured.
+	perScenario := map[string]axes{}
+	cellsPerProfile := 0
+	for _, name := range opts.Scenarios {
+		a, err := axesFor(name, opts)
+		if err != nil {
+			return err
+		}
+		perScenario[name] = a
+		cellsPerProfile += a.cells(len(r.labels), opts.Repeats)
+		logf("matrix: %s (%d file(s)) sweeps connections %s, concurrency %s, request_concurrency %s",
+			name, a.files, joinInts(a.connections), joinInts(a.concurrency), joinRequests(a.request))
+	}
+	total := cellsPerProfile * len(opts.LinkProfiles)
+	logf("matrix: %d scenario(s) x %d link profile(s) x %d build(s) x %d repeat(s) = %d measured run(s), "+
+		"plus up to %d canary run(s) and %d auto run(s)",
+		len(opts.Scenarios), len(opts.LinkProfiles), len(r.labels), opts.Repeats, total,
+		3*len(opts.LinkProfiles), len(opts.Scenarios)*opts.Repeats*len(opts.LinkProfiles))
+
+	// A prepopulated scenario deploys its tree twice per cell, and only the
+	// second one is measured. Worth saying before the hours start rather than
+	// after.
+	var prepopulated []string
+	for _, name := range opts.Scenarios {
+		if scenario.ShapeOf(name).Prepopulate {
+			prepopulated = append(prepopulated, name)
+		}
+	}
+	if len(prepopulated) > 0 {
+		logf("matrix: %s are redeploy scenarios; each of their cells runs an unmeasured full deploy first, "+
+			"so those cells cost roughly twice their measured time", join(prepopulated))
+	}
+
+	// The canary payload has to exist even when its scenario is not swept.
+	datasetScenarios := append([]string(nil), opts.Scenarios...)
+	if !contains(opts.Scenarios, CanaryScenario) {
+		datasetScenarios = append(datasetScenarios, CanaryScenario)
+	}
+	if err := scenario.Generate(opts.DatasetDir, datasetScenarios, logf, warnf); err != nil {
+		return err
+	}
+	r.shapeIfNeeded("swept")
+
+	// The profile loop is the outermost one: re-applying tc per cell would
+	// itself be noise, and a sweep already takes hours. Each profile is probed
+	// before and after its own grid, so drift inside a profile is visible; two
+	// probes of different profiles are not comparable and are not meant to be.
+	for _, profile := range opts.LinkProfiles {
+		r.profile = profile
+		if err := r.shaper.Apply(profile); err == nil {
+			r.shaper.Guard()
+		}
+		if err := r.probe(profile, "start"); err != nil {
+			return err
+		}
+		if err := r.measureCanary("start"); err != nil {
+			return err
+		}
+
+		// Counted in measured runs rather than in wall clock, so the middle
+		// canary sits in the middle of the work and not of an estimate. A grid
+		// of one cell has no middle, and then there are two canaries instead of
+		// three.
+		done := 0
+		for _, name := range opts.Scenarios {
+			a := perScenario[name]
+			for repeat := 1; repeat <= opts.Repeats; repeat++ {
+				// Before this repeat's cells, so the policy run and the grid it
+				// is scored against sit inside the same stretch of the sweep.
+				if err := r.measureAuto(name, repeat); err != nil {
+					return err
+				}
+				for _, conns := range a.connections {
+					for _, conc := range a.concurrency {
+						for _, request := range a.request {
+							// Innermost, so candidate and baseline of one cell
+							// are measured within seconds of each other.
+							for i := range r.labels {
+								if err := r.measureCell(i, name, conns, conc, request, repeat); err != nil {
+									return err
+								}
+								done++
+								if done == cellsPerProfile/2 {
+									if err := r.measureCanary("mid"); err != nil {
+										return err
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		if err := r.measureCanary("end"); err != nil {
+			return err
+		}
+		if err := r.probe(profile, "end"); err != nil {
+			return err
+		}
+	}
+
+	// The deferred Clear does this too, but only on the way out: doing it here
+	// keeps the cleanup runs below on the unshaped line.
+	r.shaper.Clear()
+
+	// Leave the server as we found it. Best effort: a cleanup hiccup must not
+	// hide the results.
+	for _, name := range opts.Scenarios {
+		for i, label := range r.labels {
+			stem := filepath.Join(opts.LogDir, "cleanup-"+label+"-"+name)
+			if code, err := r.cleanAt(r.binaries[i],
+				opts.RemoteBase+"/matrix/"+label+"/"+name, stem, "", ""); err != nil || code != 0 {
+				warnf("cleanup of %s/%s failed", label, name)
+			}
+		}
+		stem := filepath.Join(opts.LogDir, "cleanup-auto-"+name)
+		if code, err := r.cleanAt(opts.CandidateBin,
+			opts.RemoteBase+"/matrix/auto/"+name, stem, "", ""); err != nil || code != 0 {
+			warnf("cleanup of auto/%s failed", name)
+		}
+	}
+	if code, err := r.cleanAt(opts.CandidateBin, opts.RemoteBase+"/matrix/canary",
+		filepath.Join(opts.LogDir, "cleanup-canary"), "", ""); err != nil || code != 0 {
+		warnf("cleanup of the canary directory failed")
+	}
+	r.cleanupLinkProbe()
+
+	return r.aggregateMatrix(perScenario)
+}
+
+// axesFor caps a scenario's axes against its payload and decides whether the
+// request axis applies to it at all.
+func axesFor(name string, opts Options) (axes, error) {
+	files, err := scenario.Files(name)
+	if err != nil {
+		return axes{}, err
+	}
+	connections, err := scenario.AxisFor(name, opts.ConnectionsAxis)
+	if err != nil {
+		return axes{}, err
+	}
+	concurrency, err := scenario.AxisFor(name, opts.ConcurrencyAxis)
+	if err != nil {
+		return axes{}, err
+	}
+	sweeps, err := scenario.SweepsRequests(name)
+	if err != nil {
+		return axes{}, err
+	}
+	request := opts.RequestAxis
+	if !sweeps {
+		// The one pass that sets nothing and leaves easySFTP its own value,
+		// stored as a null coordinate.
+		request = []*int{nil}
+	}
+	return axes{connections: connections, concurrency: concurrency, request: request, files: files}, nil
+}
+
+// deploy runs one deployment of a scenario exactly the way its shape says: a
+// pre-clean, the unmeasured base deploy plus mutation a redeploy scenario
+// needs, then the measured run. Shared by the cells and the auto runs, which
+// differ only in the advanced block they pass and in what they do with the
+// result.
+//
+// The pre-clean is only instrumented where its numbers are wanted, which is the
+// cells: an auto run's coordinates are not a coordinate of the grid, so a
+// delete row of it would sit in deletes[] under settings nobody asked for.
+func (r *run) deploy(binary, name, remote, stem, advanced string, instrumentClean bool, what string) (code, cleanCode int, err error) {
+	shape := scenario.ShapeOf(name)
+
+	// Kept off the pre-clean: skip_unchanged applies to overlay only, and a
+	// clean deployment carrying it just logs a warning about being ignored.
+	deployAdvanced := advanced
+	if shape.Prepopulate && shape.Mode == "overlay" {
+		deployAdvanced = advanced + "\nskip_unchanged: true"
+	}
+
+	cleanCode, err = r.preClean(binary, remote, stem, advanced, instrumentClean)
+	if err != nil {
+		return 0, 0, err
+	}
+	if cleanCode != 0 {
+		warnf("pre-clean of %s exited %d", what, cleanCode)
+		cat(stem + ".clean.log")
+	}
+
+	// The deploy the measured run redeploys over. Unmeasured, with the same
+	// settings: what is under test is the second run, and a base laid down at
+	// other settings would put a different remote tree under each cell.
+	if shape.Prepopulate {
+		baseCode, err := r.runner.Do(runner.Run{
+			Binary:   binary,
+			Source:   filepath.Join(r.opts.DatasetDir, name),
+			Remote:   remote,
+			Mode:     shape.Mode,
+			Log:      stem + ".base.log",
+			Outputs:  stem + ".base.out",
+			Advanced: deployAdvanced,
+		})
+		if err != nil {
+			return 0, 0, err
+		}
+		if baseCode != 0 {
+			warnf("base deploy of %s failed", what)
+			cat(stem + ".base.log")
+		}
+		if err := scenario.Mutate(filepath.Join(r.opts.DatasetDir, name), scenario.ChangedFiles); err != nil {
+			return 0, 0, err
+		}
+	}
+
+	code, err = r.runner.Do(runner.Run{
+		Binary:   binary,
+		Source:   filepath.Join(r.opts.DatasetDir, name),
+		Remote:   remote,
+		Mode:     shape.Mode,
+		Log:      stem + ".log",
+		Outputs:  stem + ".out",
+		Metrics:  stem + ".metrics.json",
+		Advanced: deployAdvanced,
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+	if code != 0 {
+		// Into the job log, which masks secrets. Never into the artifact.
+		warnf("%s exited %d", what, code)
+		cat(stem + ".log")
+	}
+	return code, cleanCode, nil
+}
+
+// measureCell measures one coordinate of the grid.
+//
+// The remote path is per (build, scenario) rather than per cell: every run is
+// preceded by an unmeasured clean anyway, so a path per cell would only leave
+// more empty directories behind on the server.
+func (r *run) measureCell(build int, name string, conns, conc int, request *int, repeat int) error {
+	label, binary, ref := r.labels[build], r.binaries[build], r.refs[build]
+	remote := r.opts.RemoteBase + "/matrix/" + label + "/" + name
+	stem := r.stem(link.Slug(r.profile), label, name,
+		fmt.Sprintf("c%d", conns), fmt.Sprintf("w%d", conc), "r"+requestToken(request), fmt.Sprint(repeat))
+	what := fmt.Sprintf("%s/%s c%d/w%d/r%s repeat %d", label, name, conns, conc, requestToken(request), repeat)
+
+	advanced := fmt.Sprintf("connections: %d\nconcurrency: %d", conns, conc)
+	if request != nil {
+		advanced += fmt.Sprintf("\nrequest_concurrency: %d", *request)
+	}
+
+	code, cleanCode, err := r.deploy(binary, name, remote, stem, advanced, true, what)
+	if err != nil {
+		return err
+	}
+
+	sweep := readDelete(stem, cleanCode)
+	sweep.Label, sweep.Scenario, sweep.LinkProfile, sweep.Repeat = label, name, r.profile, repeat
+	sweep.Connections, sweep.Concurrency, sweep.RequestConcurrency = &conns, &conc, request
+	if err := r.append("deletes", sweep); err != nil {
+		return err
+	}
+
+	duration := runner.StepNumber(stem+".out", "duration-ms")
+	retries := runner.CountLines(stem+".log", runner.ContainsAny("retrying", "reconnecting"))
+	errorLines := runner.CountLines(stem+".log", runner.HasPrefix("::error::"))
+	if err := r.append("runs", runRecord{
+		Label:              label,
+		Ref:                ref,
+		Scenario:           name,
+		LinkProfile:        r.profile,
+		Connections:        &conns,
+		Concurrency:        &conc,
+		RequestConcurrency: request,
+		Repeat:             repeat,
+		ExitCode:           code,
+		DurationMS:         duration,
+		Files:              runner.StepNumber(stem+".out", "files-uploaded"),
+		Bytes:              runner.StepNumber(stem+".out", "bytes-uploaded"),
+		Retries:            &retries,
+		Errors:             &errorLines,
+		Metrics:            runner.ReadMetrics(stem + ".metrics.json"),
+	}); err != nil {
+		return err
+	}
+
+	logf("%s %s/%s connections=%d concurrency=%d request=%s repeat %d: %s ms, exit %d",
+		r.profile, label, name, conns, conc, requestToken(request), repeat, stats.Format(duration), code)
+	return nil
+}
+
+// measureAuto measures the candidate build with connections, concurrency and
+// request_concurrency all left at "auto" (issue #184, phase 5).
+//
+// This is the policy under test, not a coordinate: auto picks its own settings,
+// so what the run is measured for is the gap to the best cell of the same
+// scenario and profile. Which settings it picked is read back out of the run's
+// own counters (config_connections and friends, see internal/uploader) rather
+// than assumed here, because the point of the measurement is what easySFTP did,
+// not what this package believes it does.
+//
+// It runs inside the repeat loop, next to the cells it is compared against, and
+// on the candidate build only: a regret against a baseline build's grid would
+// compare two different products.
+func (r *run) measureAuto(name string, repeat int) error {
+	stem := r.stem("auto", link.Slug(r.profile), name, fmt.Sprint(repeat))
+	remote := r.opts.RemoteBase + "/matrix/auto/" + name
+	what := fmt.Sprintf("auto/%s repeat %d", name, repeat)
+	advanced := "connections: auto\nconcurrency: auto\nrequest_concurrency: auto"
+
+	code, _, err := r.deploy(r.opts.CandidateBin, name, remote, stem, advanced, false, what)
+	if err != nil {
+		return err
+	}
+
+	duration := runner.StepNumber(stem+".out", "duration-ms")
+	if err := r.append("auto", runRecord{
+		Label:       "auto",
+		Ref:         r.opts.CandidateRef,
+		Scenario:    name,
+		LinkProfile: r.profile,
+		Repeat:      repeat,
+		ExitCode:    code,
+		DurationMS:  duration,
+		Files:       runner.StepNumber(stem+".out", "files-uploaded"),
+		Bytes:       runner.StepNumber(stem+".out", "bytes-uploaded"),
+		Metrics:     runner.ReadMetrics(stem + ".metrics.json"),
+	}); err != nil {
+		return err
+	}
+
+	logf("%s auto/%s repeat %d: %s ms, exit %d", r.profile, name, repeat, stats.Format(duration), code)
+	return nil
+}
+
+// measureCanary measures the fixed cell, always the candidate build, three
+// times per profile ("start", "mid", "end").
+//
+// Its numbers are kept apart from cells[] on purpose: they measure the server's
+// steadiness, not a coordinate of the grid, and mixing them into an aggregate
+// would hide exactly what they are there to show.
+func (r *run) measureCanary(at string) error {
+	stem := r.stem("canary", link.Slug(r.profile), at)
+	remote := r.opts.RemoteBase + "/matrix/canary"
+	advanced := fmt.Sprintf("connections: %d\nconcurrency: %d", CanaryConnections, CanaryConcurrency)
+
+	if code, err := r.cleanAt(r.opts.CandidateBin, remote, stem+".clean", advanced, ""); err != nil || code != 0 {
+		warnf("pre-clean of the %s canary on %s failed", at, r.profile)
+	}
+
+	code, err := r.runner.Do(runner.Run{
+		Binary:   r.opts.CandidateBin,
+		Source:   filepath.Join(r.opts.DatasetDir, CanaryScenario),
+		Remote:   remote,
+		Mode:     "overlay",
+		Log:      stem + ".log",
+		Outputs:  stem + ".out",
+		Advanced: advanced,
+	})
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		warnf("the %s canary on %s exited %d", at, r.profile, code)
+	}
+
+	duration := runner.StepNumber(stem+".out", "duration-ms")
+	if err := r.append("canary", schema.Canary{
+		LinkProfile: r.profile,
+		At:          at,
+		Scenario:    CanaryScenario,
+		Connections: CanaryConnections,
+		Concurrency: CanaryConcurrency,
+		ExitCode:    code,
+		DurationMS:  duration,
+		Files:       runner.StepNumber(stem+".out", "files-uploaded"),
+		Bytes:       runner.StepNumber(stem+".out", "bytes-uploaded"),
+	}); err != nil {
+		return err
+	}
+
+	logf("%s canary %s: %s ms, exit %d", r.profile, at, stats.Format(duration), code)
+	return nil
+}
+
+// aggregateMatrix hands the sweep over to the aggregation half.
+//
+// One scenario entry each, carrying both what it is and the axes its payload
+// allowed. The display strings are the ones the summary prints, kept verbatim
+// so a rewrite cannot reformat a stored document by accident.
+func (r *run) aggregateMatrix(perScenario map[string]axes) error {
+	settings := fmt.Sprintf("matrix sweep; every other advanced.* setting stays at easySFTP's defaults "+
+		"(retries 2, timeout 30s). The mode belongs to the scenario, see scenarios below: a redeploy scenario "+
+		"is deployed once unmeasured and then measured over itself with %d file(s) changed. Each scenario is "+
+		"swept over the axis values its payload can use, see axes.per_scenario", scenario.ChangedFiles)
+	if r.opts.LinkProfilesRaw != "" {
+		settings += "; swept over the link profiles " + join(r.opts.LinkProfiles)
+	}
+
+	scenarios := make([]benchmark.ManifestScenario, 0, len(r.opts.Scenarios))
+	for _, name := range r.opts.Scenarios {
+		a := perScenario[name]
+		shape := scenario.ShapeOf(name)
+		mode := shape.Mode
+		if shape.Prepopulate {
+			mode += ", redeployed"
+		}
+		scenarios = append(scenarios, benchmark.ManifestScenario{
+			Name:               name,
+			Description:        scenario.Description(name),
+			Mode:               mode,
+			Files:              a.files,
+			ConnectionsDisplay: joinInts(a.connections) + " ",
+			ConcurrencyDisplay: joinInts(a.concurrency) + " ",
+			RequestDisplay:     joinRequests(a.request),
+			Connections:        a.connections,
+			Concurrency:        a.concurrency,
+			RequestConcurrency: a.request,
+		})
+	}
+
+	runnerLine, runnerDisplay := r.runnerLine()
+	manifest := &benchmark.Manifest{
+		Kind:           schema.BenchmarkMatrix,
+		CandidateRef:   r.opts.CandidateRef,
+		BaselineRef:    r.opts.BaselineRef,
+		ReferenceLabel: r.reference,
+		Repeats:        r.opts.Repeats,
+		Runner:         runnerLine,
+		RunnerDisplay:  runnerDisplay,
+		Environment:    r.environment(),
+		Settings:       settings,
+		Labels:         r.labels,
+		Scenarios:      scenarios,
+		Link:           r.linkManifest(),
+		Grid: &benchmark.ManifestGrid{
+			Connections:        r.opts.ConnectionsAxis,
+			Concurrency:        r.opts.ConcurrencyAxis,
+			RequestConcurrency: r.opts.RequestAxis,
+			ConnectionsDisplay: r.opts.ConnectionsDisplay,
+			ConcurrencyDisplay: r.opts.ConcurrencyDisplay,
+			RequestDisplay:     r.opts.RequestDisplay,
+			Canary: benchmark.ManifestCanary{
+				Scenario:    CanaryScenario,
+				Connections: CanaryConnections,
+				Concurrency: CanaryConcurrency,
+			},
+		},
+		Files: benchmark.ManifestFiles{
+			Runs:    r.path("runs"),
+			Deletes: r.path("deletes"),
+			Probes:  r.path("probes"),
+			Canary:  r.path("canary"),
+			Auto:    r.path("auto"),
+		},
+	}
+	return r.finish(manifest)
+}
+
+// requestToken is how a request_concurrency coordinate appears in a log file
+// name and in the job log. The token "default" is the pass that sets nothing
+// and leaves easySFTP its own value; it travels as that token rather than as an
+// empty string because it has to survive being stored in the per-scenario axis
+// strings.
+func requestToken(request *int) string {
+	if request == nil {
+		return "default"
+	}
+	return fmt.Sprint(*request)
+}
+
+func joinRequests(values []*int) string {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, requestToken(v))
+	}
+	return strings.Join(parts, " ")
+}
+
+func joinInts(values []int) string {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, fmt.Sprint(v))
+	}
+	return strings.Join(parts, " ")
+}
+
+func join(values []string) string { return strings.Join(values, " ") }
+
+func contains(values []string, needle string) bool {
+	for _, v := range values {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/benchmark/driver/standard.go
+++ b/internal/benchmark/driver/standard.go
@@ -1,0 +1,221 @@
+package driver
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/eiserv/easySFTP/internal/benchmark"
+	"github.com/eiserv/easySFTP/internal/benchmark/link"
+	"github.com/eiserv/easySFTP/internal/benchmark/runner"
+	"github.com/eiserv/easySFTP/internal/benchmark/scenario"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// StandardScenarios is the standard benchmark's scenario set, and it is fixed:
+// adding one here would make every stored result before it incomparable. The
+// matrix benchmark is where new scenarios such as "single" live.
+var StandardScenarios = []string{"small", "mixed", "large"}
+
+// Standard measures one or two builds of easySFTP at the default settings and
+// writes results.json, results.csv and summary.md (issue #169).
+//
+// It collects data only: nothing here fails on a slow number, because
+// run-to-run variance against an external host is not understood yet.
+//
+// Candidate and baseline are interleaved repeat by repeat, not run as two
+// blocks: a shared host's throughput drifts over minutes, and a block layout
+// would charge that drift to whichever build ran second.
+func Standard(opts Options) error {
+	r, err := newRun(opts)
+	if err != nil {
+		return err
+	}
+	defer r.closeFiles()
+	defer r.shaper.Clear()
+
+	for _, f := range []struct{ name, filename string }{
+		{"runs", "runs.jsonl"},
+		{"probes", "link-probes.jsonl"},
+		{"deletes", "deletes.jsonl"},
+	} {
+		if _, err := r.open(f.name, f.filename); err != nil {
+			return err
+		}
+	}
+
+	r.setBuilds(true)
+	if err := scenario.Generate(opts.DatasetDir, StandardScenarios, logf, warnf); err != nil {
+		return err
+	}
+	r.shapeIfNeeded("measured")
+
+	// The profile loop is the outermost one: re-applying tc per measured run
+	// would itself be noise. The price is that drift over the hours falls onto
+	// this axis instead of spreading across it, which is why each profile is
+	// probed twice, before and after its own runs, and still shaped for both. A
+	// start and an end probe of the same profile are comparable; two probes of
+	// different profiles are not, which is what makes drift visible here at
+	// all.
+	for _, profile := range opts.LinkProfiles {
+		r.profile = profile
+		if err := r.shaper.Apply(profile); err == nil {
+			r.shaper.Guard()
+		}
+		if err := r.probe(profile, "start"); err != nil {
+			return err
+		}
+		for _, name := range StandardScenarios {
+			for repeat := 1; repeat <= opts.Repeats; repeat++ {
+				for i := range r.labels {
+					if err := r.measure(i, name, repeat); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		if err := r.probe(profile, "end"); err != nil {
+			return err
+		}
+	}
+
+	// The deferred Clear does this too, but only on the way out: doing it here
+	// keeps the cleanup runs below on the same unshaped line every run ends on.
+	r.shaper.Clear()
+
+	// Leave the benchmark directories empty so the payload does not linger on
+	// the server. Best effort: a cleanup hiccup must not hide the results.
+	for _, name := range StandardScenarios {
+		for i, label := range r.labels {
+			stem := filepath.Join(opts.LogDir, "cleanup-"+label+"-"+name)
+			code, err := r.cleanAt(r.binaries[i], opts.RemoteBase+"/"+label+"/"+name, stem, r.advanced[i], "")
+			if err != nil || code != 0 {
+				warnf("cleanup of %s/%s failed", label, name)
+			}
+		}
+	}
+	r.cleanupLinkProbe()
+
+	return r.aggregateStandard()
+}
+
+// probe records one link probe, or nothing when there is no probe binary.
+func (r *run) probe(profile, at string) error {
+	document := r.prober.Probe(profile, at)
+	if document == nil {
+		return nil
+	}
+	return r.append("probes", document)
+}
+
+// measure runs one build against one scenario once, and appends what it
+// reported.
+func (r *run) measure(build int, name string, repeat int) error {
+	label, binary, ref, advanced := r.labels[build], r.binaries[build], r.refs[build], r.advanced[build]
+	remote := r.opts.RemoteBase + "/" + label + "/" + name
+	stem := r.stem(link.Slug(r.profile), label, name, fmt.Sprint(repeat))
+
+	cleanCode, err := r.preClean(binary, remote, stem, "", true)
+	if err != nil {
+		return err
+	}
+	if cleanCode != 0 {
+		warnf("pre-clean of %s/%s repeat %d exited %d", label, name, repeat, cleanCode)
+		cat(stem + ".clean.log")
+	}
+	sweep := readDelete(stem, cleanCode)
+	sweep.Label, sweep.Scenario, sweep.LinkProfile, sweep.Repeat = label, name, r.profile, repeat
+	if err := r.append("deletes", sweep); err != nil {
+		return err
+	}
+
+	code, err := r.runner.Do(runner.Run{
+		Binary:   binary,
+		Source:   filepath.Join(r.opts.DatasetDir, name),
+		Remote:   remote,
+		Mode:     "overlay",
+		Log:      stem + ".log",
+		Outputs:  stem + ".out",
+		Metrics:  stem + ".metrics.json",
+		Advanced: advanced,
+	})
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		// Into the job log, which masks secrets. Never into the artifact.
+		warnf("%s/%s repeat %d exited %d", label, name, repeat, code)
+		cat(stem + ".log")
+	}
+
+	duration := runner.StepNumber(stem+".out", "duration-ms")
+	retries := runner.CountLines(stem+".log", runner.ContainsAny("retrying", "reconnecting"))
+	errorLines := runner.CountLines(stem+".log", runner.HasPrefix("::error::"))
+	refused := runner.CountLines(stem+".log", runner.ContainsAny("could not open connection"))
+	if err := r.append("runs", runRecord{
+		Label:       label,
+		Ref:         ref,
+		Scenario:    name,
+		LinkProfile: r.profile,
+		Repeat:      repeat,
+		ExitCode:    code,
+		DurationMS:  duration,
+		Files:       runner.StepNumber(stem+".out", "files-uploaded"),
+		Bytes:       runner.StepNumber(stem+".out", "bytes-uploaded"),
+		Retries:     &retries,
+		Errors:      &errorLines,
+		Refused:     &refused,
+		Metrics:     runner.ReadMetrics(stem + ".metrics.json"),
+	}); err != nil {
+		return err
+	}
+
+	logf("%s %s/%s repeat %d: %s ms, exit %d", r.profile, label, name, repeat, stats.Format(duration), code)
+	return nil
+}
+
+// aggregateStandard hands the run over to the aggregation half.
+//
+// The display strings travel verbatim rather than being rebuilt on the other
+// side. This half already has them, and a summary table that reformats itself
+// during a rewrite is a change to a stored document made by accident.
+func (r *run) aggregateStandard() error {
+	settings := "easySFTP defaults (no advanced.* overrides): concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay"
+	if r.opts.Connections > 0 {
+		settings += fmt.Sprintf("; the pool%d build is the same binary with advanced.connections: %d",
+			r.opts.Connections, r.opts.Connections)
+	}
+	if r.opts.LinkProfilesRaw != "" {
+		settings += "; measured over the link profiles " + join(r.opts.LinkProfiles)
+	}
+
+	scenarios := make([]benchmark.ManifestScenario, 0, len(StandardScenarios))
+	for _, name := range StandardScenarios {
+		scenarios = append(scenarios, benchmark.ManifestScenario{
+			Name:        name,
+			Description: scenario.Description(name),
+		})
+	}
+
+	runnerLine, runnerDisplay := r.runnerLine()
+	manifest := &benchmark.Manifest{
+		Kind:           schema.BenchmarkStandard,
+		CandidateRef:   r.opts.CandidateRef,
+		BaselineRef:    r.opts.BaselineRef,
+		ReferenceLabel: r.reference,
+		Repeats:        r.opts.Repeats,
+		Runner:         runnerLine,
+		RunnerDisplay:  runnerDisplay,
+		Environment:    r.environment(),
+		Settings:       settings,
+		Labels:         r.labels,
+		Scenarios:      scenarios,
+		Link:           r.linkManifest(),
+		Files: benchmark.ManifestFiles{
+			Runs:    r.path("runs"),
+			Deletes: r.path("deletes"),
+			Probes:  r.path("probes"),
+		},
+	}
+	return r.finish(manifest)
+}

--- a/internal/benchmark/driver/stub_test.go
+++ b/internal/benchmark/driver/stub_test.go
@@ -1,0 +1,206 @@
+// The stub the tests in this package measure instead of a real easySFTP build.
+//
+// The driver does not care what the binary it runs is: it sets EASYSFTP_*, plus
+// GITHUB_OUTPUT and EASYSFTP_METRICS_FILE, and runs it. So this writes
+// plausible step outputs and a plausible metrics file, derived from the two
+// things the driver varies (the source tree and, from the generated config
+// file, advanced.*).
+//
+// It is the Go form of the stub scripts/test-benchmark.sh writes, and it
+// answers the same way, so the two self-checks measure the same fiction.
+//
+// It is a *mode of the test binary* rather than a program of its own: TestMain
+// re-executes this binary with stubMarker set (see driver_test.go), so nothing
+// has to be compiled at test time and there is no second main package to keep
+// building.
+package driver_test
+
+import (
+	"fmt"
+	"io/fs"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// stubMarker turns this binary into the stub. Its value is read before any test
+// runs, so a child process never re-enters the test suite.
+const stubMarker = "EASYSFTP_BENCH_STUB"
+
+func stubMain() {
+
+	source := os.Getenv("EASYSFTP_SOURCE")
+	target := os.Getenv("EASYSFTP_TARGET")
+	mode := os.Getenv("EASYSFTP_MODE")
+	connections, concurrency, requests := 1, 4, 16
+	skipUnchanged := false
+
+	if config := os.Getenv("EASYSFTP_CONFIG"); config != "" {
+		data, err := os.ReadFile(config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "::error::%v\n", err)
+			os.Exit(1)
+		}
+		text := string(data)
+		source = stubQuoted(text, "    source:")
+		target = stubQuoted(text, "    target:")
+		mode = stubBare(text, "    mode:")
+		// "auto" resolves to easySFTP's own defaults here, exactly as autoInt.or
+		// does in internal/config/configfile.go: an auto run has to come out
+		// somewhere on the grid, otherwise the regret arithmetic has nothing to
+		// compare.
+		connections = stubSetting(text, "  connections:", 1)
+		concurrency = stubSetting(text, "  concurrency:", 4)
+		requests = stubSetting(text, "  request_concurrency:", 16)
+		skipUnchanged = strings.Contains(text, "\n  skip_unchanged: true")
+	}
+
+	// Into the run log, which is what the checks on the deploy shapes read: the
+	// mode and skip_unchanged are chosen per scenario, and nothing else in the
+	// output would show which ones a cell actually ran with.
+	if mode == "" {
+		mode = "none"
+	}
+	fmt.Printf("stub: mode=%s skip_unchanged=%v source=%s\n", mode, skipUnchanged, source)
+
+	files, bytes := stubWalk(source)
+
+	// Just enough remote state to make a "clean" run delete what an earlier run
+	// put there: one file per remote target holding its file count. Without it
+	// every pre-clean would report zero deletions, and the delete aggregation
+	// (issue #184, phase 4) would have nothing to aggregate.
+	deleted := 0
+	if state := os.Getenv("EASYSFTP_STUB_STATE"); state != "" && target != "" {
+		os.MkdirAll(state, 0o755)
+		path := filepath.Join(state, strings.ReplaceAll(strings.TrimPrefix(target, "/"), "/", "_"))
+		if mode == "clean" {
+			if data, err := os.ReadFile(path); err == nil {
+				deleted, _ = strconv.Atoi(strings.TrimSpace(string(data)))
+			}
+			os.Remove(path)
+		} else {
+			os.WriteFile(path, []byte(strconv.Itoa(files)), 0o644)
+		}
+	}
+
+	// More connections and more workers finish sooner, with a floor: exactly
+	// the shape a scaling curve should have, so the matrix output can be
+	// checked against a known answer.
+	parallel := min(connections, concurrency)
+	duration := 200 + (files+deleted)*4/parallel + rand.Intn(7)
+
+	if outputs := os.Getenv("GITHUB_OUTPUT"); outputs != "" {
+		file, err := os.OpenFile(outputs, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "::error::%v\n", err)
+			os.Exit(1)
+		}
+		for _, out := range [][2]any{
+			{"files-uploaded", files}, {"bytes-uploaded", bytes},
+			{"files-deleted", deleted}, {"duration-ms", duration},
+		} {
+			fmt.Fprintf(file, "%s<<EOF\n%v\nEOF\n", out[0], out[1])
+		}
+		file.Close()
+	}
+
+	if metrics := os.Getenv("EASYSFTP_METRICS_FILE"); metrics != "" {
+		os.WriteFile(metrics, []byte(stubReport(mode, duration, files, bytes, deleted,
+			connections, concurrency, requests, parallel)), 0o644)
+	}
+}
+
+// A clean deployment runs different phases and different round-trips than an
+// upload, and the delete aggregation reads exactly those.
+func stubReport(mode string, duration, files int, bytes int64, deleted, connections, concurrency, requests, parallel int) string {
+	phases := fmt.Sprintf(`[{"name": "upload", "wall_ms": %d, "count": 1},
+    {"name": "connect", "wall_ms": 40, "count": 1},
+    {"name": "local_scan", "wall_ms": 15, "count": 1},
+    {"name": "create_dirs", "wall_ms": 5, "count": 1}]`, duration-60)
+	operations := fmt.Sprintf(`[{"name": "file_upload", "count": %d, "errors": 0, "total_ms": %d,
+     "avg_ms": 3.5, "min_ms": 1, "p50_ms": 3, "p90_ms": 6, "p99_ms": 9, "max_ms": 11},
+    {"name": "sftp_open", "count": %d, "errors": 0, "total_ms": %d,
+     "avg_ms": 1.7, "min_ms": 1, "p50_ms": 1.5, "p90_ms": 3, "p99_ms": 5, "max_ms": 6}]`,
+		files, duration*2, files, duration)
+	if mode == "clean" {
+		phases = fmt.Sprintf(`[{"name": "remote_scan", "wall_ms": %d, "count": 1},
+    {"name": "delete_sweep", "wall_ms": %d, "count": 1},
+    {"name": "connect", "wall_ms": 40, "count": 1}]`, duration/3, duration*2/3)
+		operations = fmt.Sprintf(`[{"name": "sftp_remove", "count": %d, "errors": 0, "total_ms": %d,
+     "avg_ms": 2.1, "min_ms": 1, "p50_ms": 2, "p90_ms": 4, "p99_ms": 7, "max_ms": 8},
+    {"name": "sftp_rmdir", "count": 8, "errors": 0, "total_ms": 24,
+     "avg_ms": 3, "min_ms": 2, "p50_ms": 3, "p90_ms": 4, "p99_ms": 5, "max_ms": 5}]`,
+			deleted, duration/2)
+	}
+	return fmt.Sprintf(`{
+  "schema_version": 1,
+  "note": "stub",
+  "process": {
+    "wall_ms": %d, "user_cpu_ms": 40, "sys_cpu_ms": 12, "cpu_percent": 26,
+    "max_rss_bytes": 41943040, "go_total_alloc_bytes": 10485760, "go_mallocs": 5000,
+    "go_heap_sys_bytes": 20971520, "go_gc_count": 3, "go_gc_pause_total_ms": 0.4,
+    "go_peak_goroutines": %d, "go_max_procs": 4,
+    "disk_read_bytes": %d, "disk_write_bytes": 0,
+    "net_read_bytes": 4096, "net_write_bytes": %d
+  },
+  "phases": %s,
+  "operations": %s,
+  "counters": {
+    "connections_opened": %d, "connections_used": %d,
+    "connections_refused": 0, "reconnects": 0, "retries": 0, "stalls": 0, "errors": 0,
+    "config_connections": %d, "config_concurrency": %d,
+    "config_request_concurrency": %d,
+    "files_uploaded": %d, "bytes_uploaded": %d, "files_deleted": %d
+  }
+}
+`, duration, parallel+5, bytes, bytes, phases, operations,
+		connections, connections, connections, concurrency, requests, files, bytes, deleted)
+}
+
+func stubWalk(dir string) (int, int64) {
+	files, bytes := 0, int64(0)
+	if dir == "" {
+		return 0, 0
+	}
+	filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || !entry.Type().IsRegular() {
+			return nil //nolint:nilerr // a missing tree is an empty one here
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil
+		}
+		files++
+		bytes += info.Size()
+		return nil
+	})
+	return files, bytes
+}
+
+// quoted reads a `key: "value"` line, bare a `key: value` one.
+func stubQuoted(text, key string) string {
+	value := stubBare(text, key)
+	return strings.Trim(value, `"`)
+}
+
+func stubBare(text, key string) string {
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, key) {
+			return strings.TrimSpace(strings.TrimPrefix(line, key))
+		}
+	}
+	return ""
+}
+
+func stubSetting(text, key string, fallback int) int {
+	value := stubBare(text, key)
+	if value == "" || value == "auto" {
+		return fallback
+	}
+	if number, err := strconv.Atoi(value); err == nil {
+		return number
+	}
+	return fallback
+}

--- a/internal/benchmark/link/link.go
+++ b/internal/benchmark/link/link.go
@@ -1,0 +1,90 @@
+// Package link is the link half of the benchmark measurement (issue #184,
+// phase 1), moved off scripts/benchmark-link.sh (issue #190, step 4).
+//
+// internal/benchmark/runner measures easySFTP. This package measures the path
+// easySFTP runs over, and optionally shapes it, so RTT and bandwidth become
+// variables instead of invisible constants. Two things live here:
+//
+//	Prober   run cmd/linkprobe once and record its document
+//	Shaper   apply a "tc" profile, and take it down again
+//
+// Profile grammar, validated before a single byte is measured:
+//
+//	baseline | unshaped        the real line, untouched
+//	+<N>ms                     netem delay, so +50ms means +50 ms of RTT
+//	<delay>/<rate>             the same plus a tbf rate, e.g. +50ms/5mbit
+//	baseline/<rate>            rate only, e.g. baseline/5mbit
+//
+// Shaping is egress only, which is the direction a deploy sends bytes in. The
+// return path stays untouched, so a delay of N adds N to the round-trip rather
+// than 2N.
+package link
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// profilePattern is the grammar above. Kept as one expression so a typo is
+// refused in one place, before the measuring starts rather than after hours of
+// it.
+var profilePattern = regexp.MustCompile(`^(baseline|unshaped|\+[0-9]+ms)(/[0-9]+(kbit|mbit|gbit))?$`)
+
+// ParseProfiles validates the requested profiles, defaulting to the real line
+// when none were asked for.
+func ParseProfiles(raw string) ([]string, error) {
+	profiles := strings.Fields(raw)
+	if len(profiles) == 0 {
+		return []string{"baseline"}, nil
+	}
+	for _, profile := range profiles {
+		if !profilePattern.MatchString(profile) {
+			return nil, fmt.Errorf(
+				"link profile '%s' is not understood. Use baseline, +50ms, +50ms/5mbit or baseline/5mbit", profile)
+		}
+	}
+	return profiles, nil
+}
+
+// Delay is the netem delay of a profile, empty when it has none.
+func Delay(profile string) string {
+	head, _, _ := strings.Cut(profile, "/")
+	if strings.HasPrefix(head, "+") {
+		return strings.TrimPrefix(head, "+")
+	}
+	return ""
+}
+
+// Rate is the tbf rate of a profile, empty when it has none.
+func Rate(profile string) string {
+	if _, rate, found := strings.Cut(profile, "/"); found {
+		return rate
+	}
+	return ""
+}
+
+// Slug is a profile as a filename component. Profiles contain "+" and "/", and
+// a log file called "+50ms/5mbit-small-1.log" is a missing directory, not a
+// log.
+func Slug(profile string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		default:
+			return '_'
+		}
+	}, profile)
+}
+
+// ShapeNeeded reports whether any of these profiles asks for shaping. A sweep
+// that only wants the real line must not need tc, sudo or NET_ADMIN.
+func ShapeNeeded(profiles []string) bool {
+	for _, profile := range profiles {
+		if Delay(profile) != "" || Rate(profile) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/benchmark/link/link_test.go
+++ b/internal/benchmark/link/link_test.go
@@ -1,0 +1,66 @@
+package link_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/link"
+)
+
+// The grammar is validated before a single byte is measured, which is the whole
+// point of doing it up front rather than after hours of uploading.
+func TestParseProfiles(t *testing.T) {
+	if got, err := link.ParseProfiles(""); err != nil || len(got) != 1 || got[0] != "baseline" {
+		t.Errorf("an empty request parsed as %v (%v), want the real line", got, err)
+	}
+	good := "baseline unshaped +50ms +50ms/5mbit baseline/500kbit +150ms/1gbit"
+	got, err := link.ParseProfiles(good)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", good, err)
+	}
+	if strings.Join(got, " ") != good {
+		t.Errorf("parsed %q, want the input back in order", strings.Join(got, " "))
+	}
+	for _, bad := range []string{"+50", "50ms", "baseline/5mb", "+50ms/", "fast", "+50ms/5mbit/3"} {
+		if _, err := link.ParseProfiles(bad); err == nil {
+			t.Errorf("profile %q was accepted", bad)
+		}
+	}
+}
+
+func TestProfileParts(t *testing.T) {
+	for _, tc := range []struct {
+		profile, delay, rate, slug string
+		shapes                     bool
+	}{
+		{"baseline", "", "", "baseline", false},
+		{"unshaped", "", "", "unshaped", false},
+		{"+50ms", "50ms", "", "_50ms", true},
+		{"+50ms/5mbit", "50ms", "5mbit", "_50ms_5mbit", true},
+		{"baseline/5mbit", "", "5mbit", "baseline_5mbit", true},
+	} {
+		if got := link.Delay(tc.profile); got != tc.delay {
+			t.Errorf("%s: delay %q, want %q", tc.profile, got, tc.delay)
+		}
+		if got := link.Rate(tc.profile); got != tc.rate {
+			t.Errorf("%s: rate %q, want %q", tc.profile, got, tc.rate)
+		}
+		// Profiles contain "+" and "/", and a log file called
+		// "+50ms/5mbit-small-1.log" is a missing directory, not a log.
+		if got := link.Slug(tc.profile); got != tc.slug {
+			t.Errorf("%s: slug %q, want %q", tc.profile, got, tc.slug)
+		}
+		if got := link.ShapeNeeded([]string{tc.profile}); got != tc.shapes {
+			t.Errorf("%s: needs shaping %v, want %v", tc.profile, got, tc.shapes)
+		}
+	}
+
+	// A sweep that only wants the real line must not need tc, sudo or
+	// NET_ADMIN, and one profile that does is enough to need them.
+	if link.ShapeNeeded([]string{"baseline", "unshaped"}) {
+		t.Error("the real line alone asked for shaping")
+	}
+	if !link.ShapeNeeded([]string{"baseline", "+50ms"}) {
+		t.Error("a shaped profile in the list did not ask for shaping")
+	}
+}

--- a/internal/benchmark/link/probe.go
+++ b/internal/benchmark/link/probe.go
@@ -1,0 +1,180 @@
+package link
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"sync"
+	"syscall"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// guardOnce keeps the interrupt handler to one installation per process, the
+// way link_shape_trap kept it to one trap per shell.
+var guardOnce sync.Once
+
+// Guard makes sure an interrupted run still takes its shaping down.
+//
+// Without it an aborted or timed out run leaves the runner shaped, and every
+// later measurement on that machine is quietly wrong with nothing in its output
+// to say so. Callers pair it with a deferred Clear for the normal way out; this
+// covers the ways out that skip defers.
+//
+// Installed on the first Apply rather than at startup, so a run that shapes
+// nothing keeps the default signal behaviour.
+func (s *Shaper) Guard() {
+	guardOnce.Do(func() {
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+		go func() {
+			received := <-signals
+			s.Clear()
+			if received == syscall.SIGTERM {
+				os.Exit(143)
+			}
+			os.Exit(130)
+		}()
+	})
+}
+
+// Prober runs cmd/linkprobe and records what it reported.
+type Prober struct {
+	// Binary is the built cmd/linkprobe. Empty means "do not probe", so a local
+	// run without it still works and stores an empty probe list.
+	Binary string
+
+	Host       string
+	Port       int
+	Username   string
+	Password   string
+	KnownHosts string
+	RemotePath string
+
+	Logf  func(format string, args ...any)
+	Warnf func(format string, args ...any)
+}
+
+// Probe runs the probe once and returns the document, wrapped with the profile
+// it belongs to and whether it was taken before or after the measured runs.
+//
+// It returns nil rather than an error when there is nothing to record: an empty
+// probe list is honest, an invented entry is not.
+func (p *Prober) Probe(profile, at string) json.RawMessage {
+	if p.Binary == "" {
+		return nil
+	}
+	if !executable(p.Binary) {
+		p.Warnf("LINKPROBE_BIN ('%s') is not executable; the link is not being probed", p.Binary)
+		return nil
+	}
+
+	// The probe's own stderr goes to the job log, which masks secrets. Its
+	// stdout is the document and is stored, which is why cmd/linkprobe keeps
+	// the host and the user out of it.
+	cmd := exec.Command(p.Binary)
+	cmd.Env = append(os.Environ(),
+		"LINKPROBE_HOST="+p.Host,
+		fmt.Sprintf("LINKPROBE_PORT=%d", p.Port),
+		"LINKPROBE_USERNAME="+p.Username,
+		"LINKPROBE_PASSWORD="+p.Password,
+		"LINKPROBE_KNOWN_HOSTS="+p.KnownHosts,
+		"LINKPROBE_REMOTE_PATH="+p.RemotePath,
+	)
+	cmd.Stderr = os.Stderr
+	document, err := cmd.Output()
+	if err != nil {
+		p.Warnf("the link probe for profile %s (%s) failed; no document stored", profile, at)
+		return nil
+	}
+	if !json.Valid(document) {
+		p.Warnf("the link probe for profile %s (%s) produced no JSON; no document stored", profile, at)
+		return nil
+	}
+
+	wrapped, err := wrap(profile, at, document)
+	if err != nil {
+		p.Warnf("the link probe for profile %s (%s) produced no JSON object; no document stored", profile, at)
+		return nil
+	}
+	p.Logf("%s", summarize(wrapped))
+	return wrapped
+}
+
+// executable is the "-x" test the shell did before running the probe, so a
+// binary that was never built gets the message that says so rather than a
+// generic failure. Windows has no executable bit, so there it is a file test.
+func executable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+// wrap prepends the coordinates to the probe document without re-encoding what
+// the probe measured.
+//
+// The document is stored verbatim (see schema.Probe.MarshalJSON): re-encoding
+// it from the fields this repository models would silently drop anything
+// cmd/linkprobe reports that they do not cover, and would rewrite the numbers
+// they do cover, so a load of "1.0" would come back as "1".
+func wrap(profile, at string, document []byte) (json.RawMessage, error) {
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, document); err != nil {
+		return nil, err
+	}
+	body := compact.Bytes()
+	if len(body) < 2 || body[0] != '{' || body[len(body)-1] != '}' {
+		return nil, fmt.Errorf("the probe document is not a JSON object")
+	}
+
+	head, err := json.Marshal(struct {
+		Profile string `json:"profile"`
+		At      string `json:"at"`
+	}{profile, at})
+	if err != nil {
+		return nil, err
+	}
+
+	var out bytes.Buffer
+	out.Write(head[:len(head)-1]) // everything but the closing brace
+	if len(body) > 2 {
+		out.WriteByte(',')
+		out.Write(body[1:])
+	} else {
+		out.WriteByte('}')
+	}
+	return out.Bytes(), nil
+}
+
+// summarize is the one line a probe prints into the job log.
+func summarize(wrapped []byte) string {
+	var probe schema.Probe
+	if err := json.Unmarshal(wrapped, &probe); err != nil {
+		return "link probe: unreadable"
+	}
+	rtt := "n/a"
+	if probe.RTTMS != nil && probe.RTTMS.P50 != nil {
+		rtt = stats.Format(*probe.RTTMS.P50)
+	}
+	single, multi := "n/a", "n/a"
+	if probe.Control != nil {
+		if probe.Control.SingleStreamMiBPerS != nil {
+			single = stats.Format(*probe.Control.SingleStreamMiBPerS)
+		}
+		if probe.Control.NStreamMiBPerS != nil {
+			multi = stats.Format(*probe.Control.NStreamMiBPerS)
+		}
+	}
+	return fmt.Sprintf("link probe %s (%s): rtt p50 %s ms, control %s MiB/s single / %s MiB/s multi",
+		probe.Profile, probe.At, rtt, single, multi)
+}

--- a/internal/benchmark/link/shape.go
+++ b/internal/benchmark/link/shape.go
@@ -1,0 +1,213 @@
+package link
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Shaper applies link profiles with "tc", and is responsible for taking them
+// down again.
+//
+// That last part is the safety-critical half of this file. A run that is
+// aborted or times out while a qdisc is in place leaves the runner shaped, and
+// every later measurement on that machine is quietly wrong with nothing in its
+// output to say so. Callers must therefore install Clear on both the normal and
+// the interrupted way out; see Guard.
+type Shaper struct {
+	// Iface is the interface towards the server. Empty means "resolve it", and
+	// only the name is ever printed: the route also reports the server's
+	// address, and the host is a secret in this repository.
+	Iface string
+
+	// Sudo is "0"/"no"/"none" for never, a command string to override, and
+	// empty for "sudo -n when not root".
+	Sudo string
+
+	// Host is the SFTP server, used to resolve the interface.
+	Host string
+
+	// Logf and Warnf go to the job log, which masks secrets.
+	Logf  func(format string, args ...any)
+	Warnf func(format string, args ...any)
+
+	// Available and Reason are set by Probe and stored in the result. Shaping
+	// that is unavailable is recorded, never fatal.
+	Available bool
+	Reason    string
+
+	// Requested is every profile the run was asked for, Applied every one that
+	// was actually put in place (an unshaped profile counts as applied, because
+	// the real line is what it asks for).
+	Requested []string
+	Applied   []string
+}
+
+// NewShaper builds a Shaper in the state a run starts in: nothing probed for
+// yet, which is a different thing from "probed and unavailable".
+func NewShaper(iface, sudo, host string, logf, warnf func(string, ...any)) *Shaper {
+	return &Shaper{
+		Iface:  iface,
+		Sudo:   sudo,
+		Host:   host,
+		Logf:   logf,
+		Warnf:  warnf,
+		Reason: "no profile asked for shaping, so it was never probed for",
+	}
+}
+
+// tc is the tc invocation, sudo included when one is needed and allowed.
+func (s *Shaper) tc(args ...string) *exec.Cmd {
+	var argv []string
+	switch s.Sudo {
+	case "0", "no", "none":
+		argv = []string{"tc"}
+	case "":
+		if os.Geteuid() == 0 {
+			argv = []string{"tc"}
+		} else {
+			argv = []string{"sudo", "-n", "tc"}
+		}
+	default:
+		argv = append(strings.Fields(s.Sudo), "tc")
+	}
+	argv = append(argv, args...)
+	return exec.Command(argv[0], argv[1:]...)
+}
+
+func (s *Shaper) tcDisplay() string {
+	cmd := s.tc()
+	return strings.Join(cmd.Args, " ")
+}
+
+// resolveIface is the interface packets to the SFTP server leave through.
+func (s *Shaper) resolveIface() (string, error) {
+	if s.Iface != "" {
+		return s.Iface, nil
+	}
+	if _, err := exec.LookPath("ip"); err != nil {
+		return "", err
+	}
+	if iface := ifaceFrom(exec.Command("ip", "route", "get", s.Host)); iface != "" {
+		return iface, nil
+	}
+	if iface := ifaceFrom(exec.Command("ip", "route", "show", "default")); iface != "" {
+		return iface, nil
+	}
+	return "", fmt.Errorf("no interface found")
+}
+
+// ifaceFrom picks the word after "dev" out of an "ip route" line. Nothing else
+// of the output is read, and none of it is printed.
+func ifaceFrom(cmd *exec.Cmd) string {
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(string(out))
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] == "dev" {
+			return fields[i+1]
+		}
+	}
+	return ""
+}
+
+// Probe decides once whether shaping is possible, by doing it.
+//
+// Checking for "tc" and for root is not enough (a container may have the binary
+// and no NET_ADMIN, or CAP_NET_ADMIN and no sudo), so this adds a real qdisc
+// and removes it again. It never fails the run, because a benchmark of the real
+// line is still a benchmark.
+func (s *Shaper) Probe() {
+	s.Available = false
+
+	if _, err := exec.LookPath("tc"); err != nil {
+		s.Reason = "tc is not installed on this runner (iproute2)"
+		return
+	}
+	iface, err := s.resolveIface()
+	if err != nil {
+		s.Reason = "could not determine the interface towards the server; set LINK_IFACE"
+		return
+	}
+	s.Iface = iface
+
+	if err := s.tc("qdisc", "show", "dev", s.Iface).Run(); err != nil {
+		s.Reason = fmt.Sprintf("cannot run '%s' on %s (NET_ADMIN missing, or sudo needs a password)",
+			s.tcDisplay(), s.Iface)
+		return
+	}
+	// The real thing: a netem qdisc with no delay, removed immediately.
+	if err := s.tc("qdisc", "add", "dev", s.Iface, "root", "handle", "1:", "netem").Run(); err != nil {
+		s.Reason = fmt.Sprintf(
+			"adding a qdisc on %s was refused (NET_ADMIN missing, or something else already shapes it)", s.Iface)
+		return
+	}
+	_ = s.tc("qdisc", "del", "dev", s.Iface, "root").Run()
+
+	s.Available = true
+	s.Reason = ""
+	s.Logf("link shaping is available on %s", s.Iface)
+}
+
+// Clear puts the link back the way it was found. Idempotent, and quiet about a
+// qdisc that is already gone.
+func (s *Shaper) Clear() {
+	if s == nil || s.Iface == "" {
+		return
+	}
+	_ = s.tc("qdisc", "del", "dev", s.Iface, "root").Run()
+}
+
+// Apply shapes the link for this profile, or reports that it could not.
+// Returns an error so the caller can record that the runs were measured
+// unshaped instead of pretending they were not.
+func (s *Shaper) Apply(profile string) error {
+	delay := Delay(profile)
+	rate := Rate(profile)
+
+	// An unshaped profile is not a no-op: whatever the previous profile applied
+	// has to come off first.
+	s.Clear()
+	if delay == "" && rate == "" {
+		s.Applied = append(s.Applied, profile)
+		return nil
+	}
+	if !s.Available {
+		s.Warnf("link profile %s requested but shaping is unavailable (%s); measuring the real line instead",
+			profile, s.Reason)
+		return fmt.Errorf("shaping unavailable")
+	}
+
+	if delay != "" {
+		if err := s.tc("qdisc", "add", "dev", s.Iface, "root", "handle", "1:", "netem", "delay", delay).Run(); err != nil {
+			s.Warnf("could not add netem delay %s on %s; measuring the real line instead", delay, s.Iface)
+			s.Clear()
+			return err
+		}
+		if rate != "" {
+			// tbf below netem, so packets are delayed and then metered. burst
+			// and latency are tbf's own buffer sizing, not part of the profile:
+			// too small a burst throttles below the configured rate.
+			if err := s.tc("qdisc", "add", "dev", s.Iface, "parent", "1:", "handle", "2:",
+				"tbf", "rate", rate, "burst", "32kbit", "latency", "400ms").Run(); err != nil {
+				s.Warnf("could not add a tbf rate of %s on %s; measuring the real line instead", rate, s.Iface)
+				s.Clear()
+				return err
+			}
+		}
+	} else {
+		if err := s.tc("qdisc", "add", "dev", s.Iface, "root", "handle", "1:",
+			"tbf", "rate", rate, "burst", "32kbit", "latency", "400ms").Run(); err != nil {
+			s.Warnf("could not add a tbf rate of %s on %s; measuring the real line instead", rate, s.Iface)
+			s.Clear()
+			return err
+		}
+	}
+
+	s.Applied = append(s.Applied, profile)
+	s.Logf("link profile %s applied on %s", profile, s.Iface)
+	return nil
+}

--- a/internal/benchmark/output.go
+++ b/internal/benchmark/output.go
@@ -1,0 +1,131 @@
+package benchmark
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/report"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// Write turns one measured run into the three documents it stores, choosing the
+// pair of aggregations by the manifest's kind. It returns the name of the
+// summary the caller prints.
+func Write(m *Manifest, in *Inputs, outDir string) (string, error) {
+	if m.Kind == schema.BenchmarkMatrix {
+		return "matrix.md", WriteMatrix(m, in, outDir)
+	}
+	return "summary.md", WriteStandard(m, in, outDir)
+}
+
+// WriteStandard writes results.json, results.csv and summary.md.
+func WriteStandard(m *Manifest, in *Inputs, outDir string) error {
+	result := BuildStandard(m, in)
+	summary := report.Standard{
+		Result:        result,
+		CandidateRef:  m.CandidateRef,
+		BaselineRef:   m.BaselineRef,
+		Repeats:       m.Repeats,
+		RunnerDisplay: m.RunnerDisplay,
+		LinkRequested: m.Link.Requested,
+		Settings:      m.Settings,
+		Labels:        m.Labels,
+		Scenarios:     scenarioNames(m),
+		LinkProfiles:  m.Link.Profiles,
+	}
+	if err := WriteJSON(filepath.Join(outDir, "results.json"), result); err != nil {
+		return err
+	}
+	if err := WriteFile(filepath.Join(outDir, "results.csv"), summary.CSV()); err != nil {
+		return err
+	}
+	return WriteFile(filepath.Join(outDir, "summary.md"), summary.Markdown())
+}
+
+// WriteMatrix writes matrix.json, matrix.csv and matrix.md.
+func WriteMatrix(m *Manifest, in *Inputs, outDir string) error {
+	result := BuildMatrix(m, in)
+	summary := report.Matrix{
+		Result:             result,
+		CandidateRef:       m.CandidateRef,
+		BaselineRef:        m.BaselineRef,
+		Repeats:            m.Repeats,
+		RunnerDisplay:      m.RunnerDisplay,
+		LinkRequested:      m.Link.Requested,
+		ConnectionsDisplay: m.Grid.ConnectionsDisplay,
+		ConcurrencyDisplay: m.Grid.ConcurrencyDisplay,
+		RequestDisplay:     m.Grid.RequestDisplay,
+		Labels:             m.Labels,
+		LinkProfiles:       m.Link.Profiles,
+		Scenarios:          matrixScenarios(m),
+		Canary: schema.Canary{
+			Scenario:    m.Grid.Canary.Scenario,
+			Connections: m.Grid.Canary.Connections,
+			Concurrency: m.Grid.Canary.Concurrency,
+		},
+		HasBaseline: m.BaselineRef != "",
+	}
+	if err := WriteJSON(filepath.Join(outDir, "matrix.json"), result); err != nil {
+		return err
+	}
+	if err := WriteFile(filepath.Join(outDir, "matrix.csv"), summary.CSV()); err != nil {
+		return err
+	}
+	return WriteFile(filepath.Join(outDir, "matrix.md"), summary.Markdown())
+}
+
+func scenarioNames(m *Manifest) []string {
+	names := make([]string, 0, len(m.Scenarios))
+	for _, s := range m.Scenarios {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func matrixScenarios(m *Manifest) []report.MatrixScenario {
+	out := make([]report.MatrixScenario, 0, len(m.Scenarios))
+	for _, s := range m.Scenarios {
+		out = append(out, report.MatrixScenario{
+			Name:               s.Name,
+			Description:        s.Description,
+			Mode:               s.Mode,
+			ConnectionsDisplay: s.ConnectionsDisplay,
+			ConcurrencyDisplay: s.ConcurrencyDisplay,
+			RequestDisplay:     s.RequestDisplay,
+			Connections:        s.Connections,
+			Concurrency:        s.Concurrency,
+			RequestConcurrency: s.RequestConcurrency,
+		})
+	}
+	return out
+}
+
+// WriteJSON writes a document the way jq does: two-space indentation, a
+// trailing newline, and no HTML escaping.
+//
+// That last part is the reason this does not use json.MarshalIndent, which
+// rewrites the three HTML-significant characters as unicode escapes. jq leaves
+// them alone, and a ref or a label carrying one of them would otherwise make a
+// Go-written result differ from the jq-written results already stored, for no
+// reason a reader could make sense of.
+func WriteJSON(path string, value any) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(value); err != nil {
+		return err
+	}
+	// Encode already ends the document with a newline.
+	return WriteFile(path, buf.String())
+}
+
+// WriteFile writes a text document, creating the directory it goes in.
+func WriteFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/internal/benchmark/runner/runner.go
+++ b/internal/benchmark/runner/runner.go
@@ -1,0 +1,277 @@
+// Package runner runs one build of easySFTP and reads back what it reported.
+//
+// It is the Go form of run_easysftp, step_number, count_matches and
+// metrics_json from scripts/benchmark-lib.sh (issue #190, step 3). Nothing here
+// decides *what* to measure; it only knows how to start a build, where its step
+// outputs land and how to read them back.
+//
+// Nothing here writes into the output directory: run logs and the generated
+// config file name the host and the user, and that directory is uploaded as a
+// workflow artifact, where nothing is masked.
+package runner
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Server is the SFTP server every run connects to. Every field is a secret in
+// the benchmark workflow, which is why the generated config file goes to LogDir
+// and never to the result directory.
+type Server struct {
+	Host       string
+	Port       int
+	Username   string
+	Password   string
+	KnownHosts string
+}
+
+// Runner starts easySFTP builds against one server.
+type Runner struct {
+	Server Server
+
+	// LogDir holds the per-run logs and the generated config file. It must not
+	// be inside the directory that is uploaded as an artifact.
+	LogDir string
+}
+
+// Run is one invocation of an easySFTP build.
+type Run struct {
+	Binary string
+	Source string
+	Remote string
+	Mode   string
+
+	// Log is the combined output of the run, Outputs the file the build writes
+	// its step outputs into.
+	Log     string
+	Outputs string
+
+	// Metrics names where the run writes its instrumentation (see
+	// internal/metrics). An empty value leaves the run uninstrumented.
+	Metrics string
+
+	// Advanced is the advanced.* YAML block, without indentation. Empty means
+	// an inline run.
+	Advanced string
+}
+
+// Do runs one build and returns its exit code.
+//
+// Without an advanced block this is an inline run, exactly what a workflow with
+// source/target inputs does. With one, the run goes through a generated config
+// file instead: advanced.* settings have no inputs (every non-secret setting
+// has exactly one home in v3), and inline inputs may not be combined with a
+// config file.
+//
+// A non-zero exit code is returned as a code, not as an error: a failed run is
+// data the benchmark records rather than a reason to stop. An error means the
+// build could not be started or its files could not be written.
+func (r *Runner) Do(run Run) (int, error) {
+	if err := os.WriteFile(run.Outputs, nil, 0o644); err != nil {
+		return 0, err
+	}
+
+	env := append(os.Environ(),
+		"GITHUB_OUTPUT="+run.Outputs,
+		"EASYSFTP_PASSWORD="+r.Server.Password,
+	)
+	if run.Metrics != "" {
+		if err := os.Remove(run.Metrics); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return 0, err
+		}
+		env = append(env, "EASYSFTP_METRICS_FILE="+run.Metrics)
+	}
+
+	if run.Advanced != "" {
+		config := filepath.Join(r.LogDir, "config.yml")
+		if err := os.WriteFile(config, []byte(r.configFile(run)), 0o600); err != nil {
+			return 0, err
+		}
+		env = append(env, "EASYSFTP_CONFIG="+config)
+	} else {
+		env = append(env,
+			"EASYSFTP_HOST="+r.Server.Host,
+			"EASYSFTP_PORT="+strconv.Itoa(r.Server.Port),
+			"EASYSFTP_USERNAME="+r.Server.Username,
+			"EASYSFTP_KNOWN_HOSTS="+r.Server.KnownHosts,
+			"EASYSFTP_SOURCE="+run.Source,
+			"EASYSFTP_TARGET="+run.Remote,
+			"EASYSFTP_MODE="+run.Mode,
+		)
+	}
+
+	log, err := os.Create(run.Log)
+	if err != nil {
+		return 0, err
+	}
+	defer log.Close()
+
+	cmd := exec.Command(run.Binary)
+	cmd.Env = env
+	cmd.Stdout = log
+	cmd.Stderr = log
+	if err := cmd.Run(); err != nil {
+		var exit *exec.ExitError
+		if errors.As(err, &exit) {
+			return exit.ExitCode(), nil
+		}
+		return 0, fmt.Errorf("running %s: %w", run.Binary, err)
+	}
+	return 0, nil
+}
+
+// configFile is the v3 config a run with an advanced block goes through. It
+// names the host and the user, which is why it is written to LogDir.
+func (r *Runner) configFile(run Run) string {
+	var b strings.Builder
+	b.WriteString("version: 3\n")
+	b.WriteString("connection:\n")
+	fmt.Fprintf(&b, "  host: %q\n", r.Server.Host)
+	fmt.Fprintf(&b, "  port: %d\n", r.Server.Port)
+	fmt.Fprintf(&b, "  username: %q\n", r.Server.Username)
+	b.WriteString("  known_hosts: |\n")
+	b.WriteString(indent(r.Server.KnownHosts, "    "))
+	b.WriteString("deployments:\n")
+	b.WriteString("  benchmark:\n")
+	fmt.Fprintf(&b, "    source: %q\n", run.Source)
+	fmt.Fprintf(&b, "    target: %q\n", run.Remote)
+	fmt.Fprintf(&b, "    mode: %s\n", run.Mode)
+	b.WriteString("advanced:\n")
+	b.WriteString(indent(run.Advanced, "  "))
+	return b.String()
+}
+
+// indent prefixes every line of text, which is what "sed 's/^/  /'" did. The
+// result always ends in a newline, because the block it produces is followed by
+// the next YAML key.
+func indent(text, prefix string) string {
+	text = strings.TrimSuffix(text, "\n")
+	lines := strings.Split(text, "\n")
+	var b strings.Builder
+	for _, line := range lines {
+		b.WriteString(prefix)
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// StepNumber reads a number written in the GITHUB_OUTPUT heredoc format, 0 when
+// the run died before writing it.
+func StepNumber(outputs, key string) float64 {
+	file, err := os.Open(outputs)
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
+
+	prefix := key + "<<"
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if !strings.HasPrefix(scanner.Text(), prefix) {
+			continue
+		}
+		if !scanner.Scan() {
+			return 0
+		}
+		value := scanner.Text()
+		if !isDigits(value) {
+			return 0
+		}
+		number, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return 0
+		}
+		return number
+	}
+	return 0
+}
+
+func isDigits(text string) bool {
+	if text == "" {
+		return false
+	}
+	for i := 0; i < len(text); i++ {
+		if text[i] < '0' || text[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// CountLines counts the lines of a log the matcher accepts. A missing or
+// unreadable log counts as zero, so a run that died before writing one still
+// produces a number.
+func CountLines(path string, match func(string) bool) float64 {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
+
+	count := 0
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if match(scanner.Text()) {
+			count++
+		}
+	}
+	return float64(count)
+}
+
+// ContainsAny is the matcher behind "grep -e a -e b": a line counts once,
+// however many of the needles it holds.
+func ContainsAny(needles ...string) func(string) bool {
+	return func(line string) bool {
+		for _, needle := range needles {
+			if strings.Contains(line, needle) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// HasPrefix is the matcher behind an anchored grep pattern.
+func HasPrefix(prefix string) func(string) bool {
+	return func(line string) bool { return strings.HasPrefix(line, prefix) }
+}
+
+// ReadMetrics is the run's metrics document, or nil (which encodes as JSON
+// null) when the run died before writing one, or wrote something unreadable.
+// Never an error: an absent metrics file is a run that failed, which the
+// benchmark records rather than stops for.
+//
+// The document travels as the bytes it was written as, not through
+// schema.Metrics. The measuring half has no reason to understand it, and a
+// counter or a field this repository does not model yet must reach the
+// aggregation intact rather than be dropped in passing.
+func ReadMetrics(path string) json.RawMessage {
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	if !json.Valid(data) {
+		return nil
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, data); err != nil {
+		return nil
+	}
+	return json.RawMessage(compact.Bytes())
+}

--- a/internal/benchmark/runner/runner_test.go
+++ b/internal/benchmark/runner/runner_test.go
@@ -1,0 +1,147 @@
+package runner_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/runner"
+)
+
+func write(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+	return path
+}
+
+// StepNumber reads the GITHUB_OUTPUT heredoc format, and answers 0 rather than
+// failing where a run died before writing the value.
+func TestStepNumber(t *testing.T) {
+	dir := t.TempDir()
+	outputs := write(t, dir, "run.out", strings.Join([]string{
+		"files-uploaded<<EOF", "300", "EOF",
+		"bytes-uploaded<<EOF", "1228800", "EOF",
+		"duration-ms<<EOF", "412", "EOF",
+	}, "\n")+"\n")
+
+	for _, tc := range []struct {
+		key  string
+		want float64
+	}{
+		{"files-uploaded", 300},
+		{"bytes-uploaded", 1228800},
+		{"duration-ms", 412},
+		{"files-deleted", 0}, // never written
+	} {
+		if got := runner.StepNumber(outputs, tc.key); got != tc.want {
+			t.Errorf("%s = %v, want %v", tc.key, got, tc.want)
+		}
+	}
+
+	if got := runner.StepNumber(filepath.Join(dir, "missing.out"), "duration-ms"); got != 0 {
+		t.Errorf("a run that wrote no outputs reported %v", got)
+	}
+	// Anything that is not a plain number is a run that failed halfway, not a
+	// value: a partial heredoc must not become a measurement.
+	broken := write(t, dir, "broken.out", "duration-ms<<EOF\nnot-a-number\nEOF\n")
+	if got := runner.StepNumber(broken, "duration-ms"); got != 0 {
+		t.Errorf("a non-numeric output reported %v", got)
+	}
+}
+
+func TestCountLines(t *testing.T) {
+	dir := t.TempDir()
+	log := write(t, dir, "run.log", strings.Join([]string{
+		"uploading 300 files",
+		"::warning::retrying after a dropped connection",
+		"reconnecting to the server",
+		"a line that says retrying and reconnecting at once",
+		"::error::the deploy failed",
+		"note: ::error:: is not at the start here",
+		"could not open connection 3 of 4",
+	}, "\n")+"\n")
+
+	// A line counts once, however many of the needles it holds.
+	if got := runner.CountLines(log, runner.ContainsAny("retrying", "reconnecting")); got != 3 {
+		t.Errorf("counted %v retry lines, want 3", got)
+	}
+	// The error pattern is anchored: a mention mid-line is not an error.
+	if got := runner.CountLines(log, runner.HasPrefix("::error::")); got != 1 {
+		t.Errorf("counted %v error lines, want 1", got)
+	}
+	if got := runner.CountLines(log, runner.ContainsAny("could not open connection")); got != 1 {
+		t.Errorf("counted %v refused connections, want 1", got)
+	}
+	if got := runner.CountLines(filepath.Join(dir, "missing.log"), runner.HasPrefix("::error::")); got != 0 {
+		t.Errorf("a run that wrote no log reported %v", got)
+	}
+}
+
+// ReadMetrics keeps the document as the run wrote it: the measuring half has no
+// reason to understand it, and a counter this repository does not model yet
+// must reach the aggregation intact.
+func TestReadMetrics(t *testing.T) {
+	dir := t.TempDir()
+	path := write(t, dir, "metrics.json", `{"schema_version": 1, "counters": {"something_new": 7}}`)
+	got := string(runner.ReadMetrics(path))
+	if !strings.Contains(got, `"something_new":7`) {
+		t.Errorf("metrics came back as %q", got)
+	}
+
+	if runner.ReadMetrics(filepath.Join(dir, "missing.json")) != nil {
+		t.Error("a run that wrote no metrics reported some")
+	}
+	broken := write(t, dir, "broken.json", "{not json")
+	if runner.ReadMetrics(broken) != nil {
+		t.Error("an unreadable metrics document was passed on")
+	}
+}
+
+// A run with an advanced block goes through a generated config file, because
+// advanced.* settings have no inputs and inline inputs may not be combined with
+// a config file. That file names the host and the user, so it lands in the log
+// directory and never in the artifact.
+func TestConfigFileIsWrittenToTheLogDir(t *testing.T) {
+	dir := t.TempDir()
+	r := &runner.Runner{
+		LogDir: dir,
+		Server: runner.Server{
+			Host: "sftp.example.invalid", Port: 2222, Username: "deployer",
+			Password: "secret", KnownHosts: "sftp.example.invalid ssh-ed25519 AAAA\nsecond line",
+		},
+	}
+	// A binary that does not exist fails to start, which is an error rather
+	// than an exit code; the config file is written before that happens.
+	_, _ = r.Do(runner.Run{
+		Binary:   filepath.Join(dir, "no-such-binary"),
+		Source:   "/payload",
+		Remote:   "/target",
+		Mode:     "overlay",
+		Log:      filepath.Join(dir, "run.log"),
+		Outputs:  filepath.Join(dir, "run.out"),
+		Advanced: "connections: 2\nconcurrency: 8",
+	})
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.yml"))
+	if err != nil {
+		t.Fatalf("the config file was not written: %v", err)
+	}
+	config := string(data)
+	for _, needle := range []string{
+		"version: 3\n",
+		"  host: \"sftp.example.invalid\"\n",
+		"  port: 2222\n",
+		"  known_hosts: |\n    sftp.example.invalid ssh-ed25519 AAAA\n    second line\n",
+		"    source: \"/payload\"\n",
+		"    mode: overlay\n",
+		"advanced:\n  connections: 2\n  concurrency: 8\n",
+	} {
+		if !strings.Contains(config, needle) {
+			t.Errorf("the config file is missing %q:\n%s", needle, config)
+		}
+	}
+}

--- a/internal/benchmark/scenario/dataset.go
+++ b/internal/benchmark/scenario/dataset.go
@@ -1,0 +1,191 @@
+package scenario
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Logf is where dataset generation reports what it is doing. The measuring
+// scripts print these lines into the job log, so they stay plain text.
+type Logf func(format string, args ...any)
+
+// Generate writes each scenario's payload under datasetDir, plus the empty
+// directory used for the pre-clean and cleanup runs.
+func Generate(datasetDir string, names []string, logf Logf, warnf Logf) error {
+	if err := os.MkdirAll(filepath.Join(datasetDir, "empty"), 0o755); err != nil {
+		return err
+	}
+	for _, name := range names {
+		if err := generateOne(datasetDir, name, logf, warnf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generateOne(datasetDir, name string, logf, warnf Logf) error {
+	groups, err := Spec(name)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(datasetDir, name)
+	if err := os.RemoveAll(dir); err != nil {
+		return err
+	}
+	layout := ShapeOf(name).Layout
+
+	// Before writing, not after: the calibration family takes a count and a
+	// size from whoever typed it, and "calib-1000x16m" is 16 GiB of local disk
+	// plus the hours to upload it. Said early, and not refused, because a
+	// deliberate large run is a legitimate thing to ask this for.
+	plannedKiB := 0
+	for _, g := range groups {
+		plannedKiB += g.Count * g.KiB
+	}
+	logf("dataset %s: generating %d MiB", name, plannedKiB/1024)
+	if plannedKiB > 2*1024*1024 {
+		warnf("the %s payload is %d GiB; that is local disk on the runner and upload time in every cell that uses it",
+			name, plannedKiB/1024/1024)
+	}
+
+	index := 0
+	for _, g := range groups {
+		for i := 0; i < g.Count; i++ {
+			sub := filepath.Join(dir, subdirFor(layout, index))
+			if err := os.MkdirAll(sub, 0o755); err != nil {
+				return err
+			}
+			path := filepath.Join(sub, fmt.Sprintf("file%d.bin", index))
+			if err := writeRandom(path, int64(g.KiB)*1024, os.O_CREATE|os.O_TRUNC|os.O_WRONLY); err != nil {
+				return err
+			}
+			index++
+		}
+	}
+
+	size, err := treeSize(dir)
+	if err != nil {
+		return err
+	}
+	logf("dataset %s: %d file(s), %s", name, index, humanSize(size))
+	return nil
+}
+
+// subdirFor is where file <index> of a payload goes, relative to the scenario
+// directory.
+//
+// The deep layout puts one directory per 7-bit pattern of the index: 128 leaf
+// directories holding a handful of files each, which is the node_modules shape.
+// It separates create_dirs and sftp_mkdirall cost from transfer cost, and at
+// this RTT that is a large share of a real deploy.
+//
+// The flat one spreads over 8 subdirectories so remote directory creation is
+// part of the measurement, as it is in a real site upload.
+func subdirFor(layout string, index int) string {
+	if layout != LayoutDeep {
+		return fmt.Sprintf("part%d", index%8)
+	}
+	parts := make([]string, 0, 7)
+	rest := index
+	for level := 0; level < 7; level++ {
+		parts = append(parts, fmt.Sprintf("d%d", rest%2))
+		rest /= 2
+	}
+	return filepath.Join(parts...)
+}
+
+func writeRandom(path string, size int64, flags int) error {
+	file, err := os.OpenFile(path, flags, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.CopyN(file, rand.Reader, size); err != nil {
+		file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+// Mutate changes the first <count> files of a payload, in sorted order, so a
+// prepopulated scenario's measured run has something to deploy. Called between
+// the unmeasured deploy and the measured one.
+//
+// The change appends rather than rewriting in place, because it has to be
+// visible to both detectors: the sync manifest compares content hashes, but
+// advanced.skip_unchanged compares the remote *size* only (see uploadFiles in
+// internal/uploader/transfer.go), and a same-size rewrite would be skipped. The
+// files therefore grow by a few hundred bytes per repeat, which is deliberate
+// and negligible against the payload.
+func Mutate(dir string, count int) error {
+	files, err := listFiles(dir)
+	if err != nil {
+		return err
+	}
+	sort.Strings(files)
+	if count > len(files) {
+		count = len(files)
+	}
+	for _, path := range files[:count] {
+		if err := writeRandom(path, 512, os.O_APPEND|os.O_WRONLY); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func listFiles(dir string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type().IsRegular() {
+			out = append(out, path)
+		}
+		return nil
+	})
+	return out, err
+}
+
+func treeSize(dir string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	return total, err
+}
+
+// humanSize is the "du -sh" style figure the generation log used to print.
+func humanSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%dB", bytes)
+	}
+	suffixes := []string{"K", "M", "G", "T"}
+	value := float64(bytes) / unit
+	i := 0
+	for value >= unit && i < len(suffixes)-1 {
+		value /= unit
+		i++
+	}
+	if value < 10 {
+		return fmt.Sprintf("%.1f%s", value, suffixes[i])
+	}
+	return fmt.Sprintf("%.0f%s", value, suffixes[i])
+}

--- a/internal/benchmark/scenario/scenario.go
+++ b/internal/benchmark/scenario/scenario.go
@@ -1,0 +1,269 @@
+// Package scenario is the payload half of the benchmark: what a scenario is
+// made of, how it is deployed, and which axis values its payload can use.
+//
+// It is the Go form of the scenario_* functions scripts/benchmark-lib.sh grew
+// (issue #190, step 3). The tables are copied over unchanged on purpose: a
+// scenario whose payload or shape moves during the rewrite makes every stored
+// result before it incomparable, which is the one thing this migration may not
+// do.
+package scenario
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ChangedFiles is how many files Mutate changes between the unmeasured deploy
+// and the measured one. Small on purpose: "500 files, 3 changed" is the CI
+// case, and a larger number would measure the upload again instead of the scan.
+const ChangedFiles = 3
+
+// RequestAxisMinKiB is the file size from which advanced.request_concurrency
+// can do anything at all.
+//
+// That setting is sftp.MaxConcurrentRequestsPerFile (see
+// internal/uploader/connection.go): how many write requests of *one* file may
+// be in flight. pkg/sftp writes in 32 KiB packets, so a 4 KiB file is a single
+// packet and cannot use a second request no matter what the value is, and a
+// file needs 32 packets (1 MiB) before a value above easySFTP's default of 16
+// has anything left to pipeline. Below this threshold the axis measures the
+// same number repeatedly, which is what keeps it from tripling a grid it cannot
+// move.
+const RequestAxisMinKiB = 1024
+
+// Layouts a payload can be written in.
+const (
+	LayoutFlat = "flat"
+	LayoutDeep = "deep"
+)
+
+// Group is one "<count>:<KiB each>" group of a payload.
+type Group struct {
+	Count int
+	KiB   int
+}
+
+// Shape is the three things that make a scenario a *deploy* rather than a
+// payload.
+//
+//	Mode         the easySFTP mode the measured run uses
+//	Prepopulate  the measured run is preceded by an unmeasured full deploy of
+//	             the same tree, of which Mutate then changes a few files. That
+//	             is what makes remote_scan, hash, manifest_read / manifest_write
+//	             and the skip path measurable at all; without it every one of
+//	             them runs against an empty target
+//	Layout       flat (8 sibling directories) or deep (7 levels, few files each)
+type Shape struct {
+	Mode        string
+	Prepopulate bool
+	Layout      string
+}
+
+// Spec is a scenario's payload, as groups of "<count> files of <KiB> each".
+//
+// Fixed on purpose: a benchmark whose payload changes between runs measures
+// nothing.
+//
+// "single" exists for the matrix benchmark: one large file cannot be spread
+// over connections at all, which makes it the control against which a
+// connections/concurrency curve is read.
+//
+// The scenarios below "single" are issue #184, phase 3: every result before
+// them was a full upload into an empty target in mode overlay, which is the
+// rarest real deploy. They cover the redeploy, the sync mode, a deep tree, a
+// file count high enough for the per-run fixed costs to fall away, and a
+// calibration family that is uniform by construction. See Shape for how a
+// scenario is run, which for these is as much of the measurement as the payload
+// is.
+func Spec(name string) ([]Group, error) {
+	switch {
+	case name == "small": // per-file round-trip overhead dominates
+		return []Group{{300, 4}}, nil
+	case name == "mixed": // roughly a built website
+		return []Group{{40, 16}, {12, 256}, {4, 2048}}, nil
+	case name == "large": // raw transfer throughput
+		return []Group{{2, 16384}}, nil
+	case name == "single": // one 32 MiB file, no parallelism to find
+		return []Group{{1, 32768}}, nil
+	case name == "redeploy": // the CI case: almost nothing changed
+		return []Group{{500, 4}}, nil
+	case name == "sync": // the same payload, through mode sync
+		return []Group{{500, 4}}, nil
+	case name == "deep": // node_modules-shaped, see Shape
+		return []Group{{400, 4}}, nil
+	case name == "bulk": // per-file cost past the fixed costs
+		return []Group{{2000, 4}}, nil
+	case strings.HasPrefix(name, "calib-"):
+		return calibSpec(name)
+	default:
+		return nil, fmt.Errorf("unknown scenario %s", name)
+	}
+}
+
+// calibSpec parses the calibration family, "calib-<count>x<size>" with the size
+// as <n>k or <n>m, e.g. calib-100x64k. One size per scenario, so
+// "t_file = r * RTT + size / B" can be fitted against it; "mixed" mixes three
+// sizes and structurally cannot give that (issue #184, phase 3).
+func calibSpec(name string) ([]Group, error) {
+	malformed := fmt.Errorf(
+		"calibration scenario '%s' must look like calib-<count>x<size>, size in k or m (for example calib-100x64k)", name)
+
+	rest := strings.TrimPrefix(name, "calib-")
+	countText, sizeText, found := strings.Cut(rest, "x")
+	if !found {
+		return nil, malformed
+	}
+	count, err := positiveInt(countText)
+	if err != nil {
+		return nil, malformed
+	}
+	if sizeText == "" {
+		return nil, malformed
+	}
+	unit := sizeText[len(sizeText)-1]
+	size, err := positiveInt(sizeText[:len(sizeText)-1])
+	if err != nil {
+		return nil, malformed
+	}
+	switch unit {
+	case 'k':
+		return []Group{{count, size}}, nil
+	case 'm':
+		return []Group{{count, size * 1024}}, nil
+	default:
+		return nil, malformed
+	}
+}
+
+// positiveInt accepts what the shell's ^[1-9][0-9]*$ accepted, and nothing
+// else: no sign, no leading zero, no whitespace.
+func positiveInt(text string) (int, error) {
+	if text == "" || text[0] == '0' {
+		return 0, fmt.Errorf("not a positive integer: %q", text)
+	}
+	for i := 0; i < len(text); i++ {
+		if text[i] < '0' || text[i] > '9' {
+			return 0, fmt.Errorf("not a positive integer: %q", text)
+		}
+	}
+	return strconv.Atoi(text)
+}
+
+// Description is the one-line summary the summary tables print.
+func Description(name string) string {
+	switch {
+	case name == "small":
+		return "300 files x 4 KiB"
+	case name == "mixed":
+		return "40 x 16 KiB + 12 x 256 KiB + 4 x 2 MiB"
+	case name == "large":
+		return "2 files x 16 MiB"
+	case name == "single":
+		return "1 file x 32 MiB"
+	case name == "redeploy":
+		return "500 x 4 KiB, redeployed over itself with 3 files changed, overlay plus advanced.skip_unchanged"
+	case name == "sync":
+		return "500 x 4 KiB, redeployed over itself with 3 files changed, mode sync"
+	case name == "deep":
+		return "400 x 4 KiB in a tree 7 directories deep, 1 to 3 files per directory"
+	case name == "bulk":
+		return "2000 files x 4 KiB"
+	case strings.HasPrefix(name, "calib-"):
+		groups, err := Spec(name)
+		if err != nil {
+			return "unknown"
+		}
+		return fmt.Sprintf("%d files x %d KiB, uniform (calibration)", groups[0].Count, groups[0].KiB)
+	default:
+		return "unknown"
+	}
+}
+
+// ShapeOf reports how a scenario is deployed. Everything not listed keeps the
+// shape every stored result was measured with, so the existing scenarios are
+// untouched by this table existing.
+//
+// A prepopulated overlay scenario is measured with advanced.skip_unchanged on:
+// an overlay redeploy without it re-uploads everything, which is the fresh
+// upload the other scenarios already measure.
+func ShapeOf(name string) Shape {
+	switch name {
+	case "redeploy":
+		return Shape{Mode: "overlay", Prepopulate: true, Layout: LayoutFlat}
+	case "sync":
+		return Shape{Mode: "sync", Prepopulate: true, Layout: LayoutFlat}
+	case "deep":
+		return Shape{Mode: "overlay", Prepopulate: false, Layout: LayoutDeep}
+	default:
+		return Shape{Mode: "overlay", Prepopulate: false, Layout: LayoutFlat}
+	}
+}
+
+// Files is how many files the payload has, summed over its groups.
+func Files(name string) (int, error) {
+	groups, err := Spec(name)
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for _, g := range groups {
+		total += g.Count
+	}
+	return total, nil
+}
+
+// MaxKiB is the largest single file in the payload, in KiB.
+func MaxKiB(name string) (int, error) {
+	groups, err := Spec(name)
+	if err != nil {
+		return 0, err
+	}
+	max := 0
+	for _, g := range groups {
+		if g.KiB > max {
+			max = g.KiB
+		}
+	}
+	return max, nil
+}
+
+// SweepsRequests reports whether the request_concurrency axis applies to this
+// scenario, or whether it is measured at easySFTP's own default only.
+func SweepsRequests(name string) (bool, error) {
+	max, err := MaxKiB(name)
+	if err != nil {
+		return false, err
+	}
+	return max >= RequestAxisMinKiB, nil
+}
+
+// AxisFor is the requested axis values that can actually differ for this
+// payload, in the order they were given.
+//
+// Only the per-file upload path spreads over connections and workers, so at
+// most <file count> files are ever in flight: an axis value above that is the
+// same configuration measured a second time under a different name. The stored
+// "single" grid is the demonstration, 30 cells of 0.38 MiB/s for one 32 MiB
+// file (issue #184, phase 5). Values are therefore capped at the file count and
+// deduplicated, which is what buys the room for a longer concurrency axis where
+// it can move and for the request axis where it can.
+func AxisFor(name string, values []int) ([]int, error) {
+	files, err := Files(name)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[int]bool, len(values))
+	out := make([]int, 0, len(values))
+	for _, value := range values {
+		if value > files {
+			value = files
+		}
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out, nil
+}

--- a/internal/benchmark/scenario/scenario_test.go
+++ b/internal/benchmark/scenario/scenario_test.go
@@ -1,0 +1,196 @@
+package scenario_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/scenario"
+)
+
+func TestCalibrationGrammar(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		count int
+		kib   int
+	}{
+		{"calib-10x64k", 10, 64},
+		{"calib-1000x16m", 1000, 16384},
+	} {
+		groups, err := scenario.Spec(tc.name)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if len(groups) != 1 || groups[0].Count != tc.count || groups[0].KiB != tc.kib {
+			t.Errorf("%s parsed as %+v, want %d x %d KiB", tc.name, groups, tc.count, tc.kib)
+		}
+	}
+	for _, name := range []string{"calib-nonsense", "calib-10x64", "calib-0x64k", "calib-10x0k", "calib-x64k"} {
+		if _, err := scenario.Spec(name); err == nil {
+			t.Errorf("%s was accepted", name)
+		}
+	}
+}
+
+// The per-scenario grid of issue #184 phase 5. Both rules are properties of the
+// payload: an axis value above the file count is the same configuration twice,
+// and request_concurrency is per file, so small files cannot use it at all.
+func TestPerScenarioAxes(t *testing.T) {
+	if files, _ := scenario.Files("mixed"); files != 56 {
+		t.Errorf("the file count is summed over the payload groups: got %d, want 56", files)
+	}
+	if max, _ := scenario.MaxKiB("mixed"); max != 2048 {
+		t.Errorf("the largest file of a payload decides the request axis: got %d, want 2048", max)
+	}
+	if sweeps, _ := scenario.SweepsRequests("single"); !sweeps {
+		t.Error("the request axis must apply where a file is large enough")
+	}
+	if sweeps, _ := scenario.SweepsRequests("small"); sweeps {
+		t.Error("the request axis must not apply to a payload of 4 KiB files")
+	}
+
+	for _, tc := range []struct {
+		name string
+		want []int
+	}{
+		{"single", []int{1}}, // capped and deduplicated at the file count
+		{"small", []int{1, 2, 4, 8}},
+		{"large", []int{1, 2}}, // a partial cap keeps the values below it
+	} {
+		got, err := scenario.AxisFor(tc.name, []int{1, 2, 4, 8})
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if !equal(got, tc.want) {
+			t.Errorf("%s: axis %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want scenario.Shape
+	}{
+		{"redeploy", scenario.Shape{Mode: "overlay", Prepopulate: true, Layout: scenario.LayoutFlat}},
+		{"sync", scenario.Shape{Mode: "sync", Prepopulate: true, Layout: scenario.LayoutFlat}},
+		{"deep", scenario.Shape{Mode: "overlay", Prepopulate: false, Layout: scenario.LayoutDeep}},
+		// The scenarios that predate this table keep the old shape.
+		{"small", scenario.Shape{Mode: "overlay", Prepopulate: false, Layout: scenario.LayoutFlat}},
+	} {
+		if got := scenario.ShapeOf(tc.name); got != tc.want {
+			t.Errorf("%s: shape %+v, want %+v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestGenerateAndMutate(t *testing.T) {
+	dir := t.TempDir()
+	quiet := func(string, ...any) {}
+	if err := scenario.Generate(dir, []string{"deep", "calib-10x64k"}, quiet, quiet); err != nil {
+		t.Fatalf("generating: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "empty")); err != nil {
+		t.Errorf("the empty payload the pre-clean deploys is missing: %v", err)
+	}
+
+	files := list(t, filepath.Join(dir, "deep"))
+	if len(files) != 400 {
+		t.Errorf("the deep payload has %d files, want the 400 of its spec", len(files))
+	}
+	// 7 levels of two directories each: many directories holding a handful of
+	// files, which is what separates create_dirs cost from transfer cost.
+	if got := countDirs(t, filepath.Join(dir, "deep"), 7); got != 128 {
+		t.Errorf("the deep payload has %d leaf directories, want 128", got)
+	}
+	if got := countDirs(t, filepath.Join(dir, "deep"), 8); got != 0 {
+		t.Errorf("%d directories sit deeper than 7 levels", got)
+	}
+
+	calib := filepath.Join(dir, "calib-10x64k")
+	for _, path := range list(t, calib) {
+		if size(t, path) != 64*1024 {
+			t.Errorf("%s is %d bytes; a calibration payload is uniform", path, size(t, path))
+		}
+	}
+
+	scenario.Mutate(calib, scenario.ChangedFiles)
+	changed := 0
+	for _, path := range list(t, calib) {
+		if size(t, path) == 64*1024+512 {
+			changed++
+		}
+	}
+	if changed != scenario.ChangedFiles {
+		t.Errorf("the mutation changed %d files, want %d", changed, scenario.ChangedFiles)
+	}
+}
+
+func list(t *testing.T, dir string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type().IsRegular() {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", dir, err)
+	}
+	return out
+}
+
+func countDirs(t *testing.T, root string, depth int) int {
+	t.Helper()
+	count := 0
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || !entry.IsDir() || path == root {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		if depthOf(rel) == depth {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return count
+}
+
+func depthOf(rel string) int {
+	depth := 1
+	for _, r := range rel {
+		if r == filepath.Separator || r == '/' {
+			depth++
+		}
+	}
+	return depth
+}
+
+func size(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Size()
+}
+
+func equal(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/benchmark/schema/fixtures_test.go
+++ b/internal/benchmark/schema/fixtures_test.go
@@ -152,10 +152,10 @@ func TestStoredIndexDecodesStrictly(t *testing.T) {
 		// A matrix entry reports a best cell per scenario and a standard one a
 		// median per scenario. Neither fills the other's map, because the two
 		// are different numbers.
-		if e.BenchmarkKind == schema.BenchmarkMatrix && len(e.MedianMS) > 0 {
+		if e.BenchmarkKind == schema.BenchmarkMatrix && e.MedianMS.Len() > 0 {
 			t.Errorf("%s: a matrix entry must not report median_ms", e.RecordedAt)
 		}
-		if e.BenchmarkKind != schema.BenchmarkMatrix && len(e.BestMS) > 0 {
+		if e.BenchmarkKind != schema.BenchmarkMatrix && e.BestMS.Len() > 0 {
 			t.Errorf("%s: a standard entry must not report best_ms", e.RecordedAt)
 		}
 	}

--- a/internal/benchmark/schema/index.go
+++ b/internal/benchmark/schema/index.go
@@ -9,14 +9,14 @@ const IndexSchemaVersion = 2
 // It is regenerated in full on every store, so it always describes what is
 // actually on disk.
 type Index struct {
-	SchemaVersion int               `json:"schema_version"`
-	GeneratedAt   string            `json:"generated_at"`
-	GeneratedBy   string            `json:"generated_by"`
-	Documentation string            `json:"documentation"`
-	Layout        map[string]string `json:"layout"`
-	KeepReleases  int               `json:"keep_releases"`
-	LatestRelease *string           `json:"latest_release"`
-	Entries       []IndexEntry      `json:"entries"`
+	SchemaVersion int             `json:"schema_version"`
+	GeneratedAt   string          `json:"generated_at"`
+	GeneratedBy   string          `json:"generated_by"`
+	Documentation string          `json:"documentation"`
+	Layout        Ordered[string] `json:"layout"`
+	KeepReleases  int             `json:"keep_releases"`
+	LatestRelease *string         `json:"latest_release"`
+	Entries       []IndexEntry    `json:"entries"`
 }
 
 // IndexEntry is one stored result as the index lists it.
@@ -25,19 +25,22 @@ type Index struct {
 // and BestMS the best cell per scenario for a matrix one. Each kind fills its
 // own and leaves the other empty, because the two are not the same number and a
 // single field would invite reading them as one.
+// Every field a stored entry can carry as JSON null is a pointer here. The
+// store rewrites this file from these types, so a null that came back as an
+// empty string would be a change to a committed document made in passing.
 type IndexEntry struct {
 	Kind         string  `json:"kind"`
 	Version      *string `json:"version"`
 	Label        *string `json:"label"`
 	Official     bool    `json:"official"`
 	RecordedAt   string  `json:"recorded_at"`
-	Commit       string  `json:"commit"`
-	RunURL       string  `json:"run_url"`
-	CandidateRef string  `json:"candidate_ref"`
+	Commit       *string `json:"commit"`
+	RunURL       *string `json:"run_url"`
+	CandidateRef *string `json:"candidate_ref"`
 
 	BenchmarkKind          string       `json:"benchmark_kind"`
 	BenchmarkSchemaVersion int          `json:"benchmark_schema_version"`
-	Runner                 string       `json:"runner"`
+	Runner                 *string      `json:"runner"`
 	Environment            *Environment `json:"environment"`
 
 	// LinkProfiles and RTTP50MS keep a chart from reading a slower line as a
@@ -51,6 +54,6 @@ type IndexEntry struct {
 	Markdown string  `json:"markdown"`
 	CSV      *string `json:"csv,omitzero"`
 
-	MedianMS map[string]float64 `json:"median_ms"`
-	BestMS   map[string]float64 `json:"best_ms"`
+	MedianMS Ordered[float64] `json:"median_ms"`
+	BestMS   Ordered[float64] `json:"best_ms"`
 }

--- a/internal/benchmark/schema/ordered.go
+++ b/internal/benchmark/schema/ordered.go
@@ -1,0 +1,129 @@
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Ordered is a JSON object whose keys keep the order they were written in.
+//
+// It exists because a Go map re-encodes its keys sorted, and the documents this
+// package describes are committed to the repository. index.json lists a
+// median per scenario in the order the run measured them, and rewriting that
+// object as "large, mixed, small" on the next store would be a change to a
+// stored document made by nobody, which is exactly what issue #190 asks the
+// migration not to do.
+//
+// Keys are unique: setting one twice replaces its value and keeps its place.
+type Ordered[V any] struct {
+	keys   []string
+	values map[string]V
+}
+
+// NewOrdered builds an empty object.
+func NewOrdered[V any]() *Ordered[V] {
+	return &Ordered[V]{values: map[string]V{}}
+}
+
+// Set appends a key, or replaces the value of one that is already there.
+func (o *Ordered[V]) Set(key string, value V) {
+	if o.values == nil {
+		o.values = map[string]V{}
+	}
+	if _, seen := o.values[key]; !seen {
+		o.keys = append(o.keys, key)
+	}
+	o.values[key] = value
+}
+
+// Get reports the value stored under a key.
+func (o Ordered[V]) Get(key string) (V, bool) {
+	value, ok := o.values[key]
+	return value, ok
+}
+
+// Keys is the insertion order.
+func (o Ordered[V]) Keys() []string { return o.keys }
+
+// Len is how many keys the object has.
+func (o Ordered[V]) Len() int { return len(o.keys) }
+
+// MarshalJSON writes the keys in the order they were set. An object that was
+// never written to is "{}", not "null": an empty median list means "this kind
+// of result does not report one", and a null there would read as missing data.
+//
+// Nothing here is HTML-escaped, for the same reason the documents around it are
+// not: jq leaves the three HTML-significant characters alone, and the index
+// layout strings are full of them ("manual-<stamp>-<label>").
+func (o Ordered[V]) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, key := range o.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		name, err := encode(key)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(name)
+		buf.WriteByte(':')
+		value, err := encode(o.values[key])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(value)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+func encode(value any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(value); err != nil {
+		return nil, err
+	}
+	// Encode appends a newline that a JSON value inside an object must not
+	// carry.
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// UnmarshalJSON reads an object through the token stream, which is the only way
+// to see the order the keys arrived in.
+func (o *Ordered[V]) UnmarshalJSON(data []byte) error {
+	o.keys = nil
+	o.values = map[string]V{}
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return fmt.Errorf("expected a JSON object, got %v", token)
+	}
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := token.(string)
+		if !ok {
+			return fmt.Errorf("expected an object key, got %v", token)
+		}
+		var value V
+		if err := decoder.Decode(&value); err != nil {
+			return err
+		}
+		o.Set(key, value)
+	}
+	_, err = decoder.Token() // the closing brace
+	return err
+}

--- a/internal/benchmark/schema/schema.go
+++ b/internal/benchmark/schema/schema.go
@@ -49,8 +49,12 @@ type Envelope struct {
 	Label         *string `json:"label"`
 	Official      bool    `json:"official"`
 	RecordedAt    string  `json:"recorded_at"`
-	Commit        string  `json:"commit"`
-	RunURL        string  `json:"run_url"`
+
+	// Commit and RunURL are null when the run did not know them, and the store
+	// rewrites this file from these types: an empty string in their place would
+	// be a change to a committed document made in passing.
+	Commit *string `json:"commit"`
+	RunURL *string `json:"run_url"`
 
 	// Benchmark is results.json or matrix.json exactly as the measuring script
 	// wrote it. Kept raw so an envelope can be read, listed and rewritten

--- a/internal/benchmark/store/index.go
+++ b/internal/benchmark/store/index.go
@@ -1,0 +1,366 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/eiserv/easySFTP/internal/benchmark"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// stored is one entry on disk, decoded once so the index and trend.csv can both
+// read it.
+type stored struct {
+	// path is relative to the benchmark directory, which is what an entry
+	// links.
+	path     string
+	archived bool
+
+	envelope schema.Envelope
+	kind     string
+}
+
+// retain enforces the window and returns the newest kept release.
+//
+// Releases are kept by version order, not by date: a late benchmark of an old
+// release must not push a newer one out of the window.
+func retain(opts Options) (string, error) {
+	releases, err := stems(filepath.Join(opts.Dir, "releases"), "release-v", ".json")
+	if err != nil {
+		return "", err
+	}
+	versions := make([]string, 0, len(releases))
+	for _, stem := range releases {
+		versions = append(versions, strings.TrimPrefix(stem, "release-"))
+	}
+	sortVersions(versions)
+
+	if len(versions) > opts.KeepReleases {
+		drop := len(versions) - opts.KeepReleases
+		for _, version := range versions[:drop] {
+			if err := archive(opts.Dir, "releases", "release-"+version); err != nil {
+				return "", err
+			}
+		}
+		versions = versions[drop:]
+	}
+	if len(versions) == 0 {
+		return "", nil
+	}
+
+	newest := versions[len(versions)-1]
+	for _, ext := range []string{".json", ".md"} {
+		if err := copyFile(
+			filepath.Join(opts.Dir, "releases", "release-"+newest+ext),
+			filepath.Join(opts.Dir, "latest"+ext)); err != nil {
+			return "", err
+		}
+	}
+
+	// Manual and matrix runs follow the same window: anything recorded before
+	// the oldest kept release is history too. ISO 8601 UTC compares correctly
+	// as a string.
+	cutoff := ""
+	for _, version := range versions {
+		recorded, err := recordedAt(filepath.Join(opts.Dir, "releases", "release-"+version+".json"))
+		if err != nil {
+			return "", err
+		}
+		if cutoff == "" || recorded < cutoff {
+			cutoff = recorded
+		}
+	}
+	if cutoff == "" {
+		return newest, nil
+	}
+	for _, dir := range []string{"manual", "matrix"} {
+		names, err := stems(filepath.Join(opts.Dir, dir), dir+"-", ".json")
+		if err != nil {
+			return "", err
+		}
+		for _, name := range names {
+			recorded, err := recordedAt(filepath.Join(opts.Dir, dir, name+".json"))
+			if err != nil {
+				return "", err
+			}
+			if recorded != "" && recorded < cutoff {
+				if err := archive(opts.Dir, dir, name); err != nil {
+					return "", err
+				}
+			}
+		}
+	}
+	return newest, nil
+}
+
+// stems lists the base names, without the extension, of everything in a
+// directory matching a prefix. A directory that does not exist yet holds
+// nothing, which is not an error.
+func stems(dir, prefix, ext string) ([]string, error) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []string
+	for _, file := range files {
+		name := file.Name()
+		if file.IsDir() || !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ext) {
+			continue
+		}
+		out = append(out, strings.TrimSuffix(name, ext))
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// sortVersions orders vMAJOR.MINOR.PATCH numerically, which is what "sort -V"
+// did: sorted as text, v1.0.10 would be archived and v1.0.2 kept.
+func sortVersions(versions []string) {
+	sort.Slice(versions, func(i, j int) bool {
+		a, b := parseVersion(versions[i]), parseVersion(versions[j])
+		for k := 0; k < 3; k++ {
+			if a[k] != b[k] {
+				return a[k] < b[k]
+			}
+		}
+		return versions[i] < versions[j]
+	})
+}
+
+func parseVersion(version string) [3]int {
+	var out [3]int
+	for i, part := range strings.SplitN(strings.TrimPrefix(version, "v"), ".", 3) {
+		if i > 2 {
+			break
+		}
+		out[i], _ = strconv.Atoi(part)
+	}
+	return out
+}
+
+// archive moves an entry and everything belonging to it into the archive,
+// keeping the per-kind subdirectory.
+func archive(root, dir, name string) error {
+	target := filepath.Join(root, "archive", dir)
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		return err
+	}
+	if err := os.Rename(filepath.Join(root, dir, name+".json"), filepath.Join(target, name+".json")); err != nil {
+		return err
+	}
+	for _, ext := range []string{".md", ".csv"} {
+		from := filepath.Join(root, dir, name+ext)
+		if _, err := os.Stat(from); err != nil {
+			continue
+		}
+		if err := os.Rename(from, filepath.Join(target, name+ext)); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("archived %s/%s\n", dir, name)
+	return nil
+}
+
+func copyFile(from, to string) error {
+	data, err := os.ReadFile(from)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(to, data, 0o644)
+}
+
+func recordedAt(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var probe struct {
+		RecordedAt string `json:"recorded_at"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return "", fmt.Errorf("%s: %w", path, err)
+	}
+	return probe.RecordedAt, nil
+}
+
+// list reads every stored entry, live directories before archived ones, in the
+// order the index used to glob them.
+func list(root string) ([]stored, error) {
+	var out []stored
+	for _, source := range []struct {
+		dir      string
+		prefix   string
+		archived bool
+	}{
+		{"releases", "release-v", false},
+		{"manual", "manual-", false},
+		{"matrix", "matrix-", false},
+		{filepath.Join("archive", "releases"), "release-v", true},
+		{filepath.Join("archive", "manual"), "manual-", true},
+		{filepath.Join("archive", "matrix"), "matrix-", true},
+	} {
+		names, err := stems(filepath.Join(root, source.dir), source.prefix, ".json")
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range names {
+			rel := filepath.ToSlash(filepath.Join(source.dir, name+".json"))
+			data, err := os.ReadFile(filepath.Join(root, source.dir, name+".json"))
+			if err != nil {
+				return nil, err
+			}
+			var envelope schema.Envelope
+			if err := json.Unmarshal(data, &envelope); err != nil {
+				return nil, fmt.Errorf("%s: %w", rel, err)
+			}
+			kind, err := envelope.BenchmarkKind()
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", rel, err)
+			}
+			out = append(out, stored{path: rel, archived: source.archived, envelope: envelope, kind: kind})
+		}
+	}
+	return out, nil
+}
+
+// writeIndex rebuilds index.json, the entry point for anything that reads this
+// directory without opening every file, agents included. Every entry carries
+// the paths of its files, so a consumer never has to reconstruct the layout.
+func writeIndex(opts Options, entries []stored, latest string) error {
+	index := schema.Index{
+		SchemaVersion: schema.IndexSchemaVersion,
+		GeneratedAt:   opts.RecordedAt,
+		GeneratedBy:   "cmd/easysftp-bench store",
+		Documentation: "benchmarks/README.md",
+		KeepReleases:  opts.KeepReleases,
+		LatestRelease: nullable(latest),
+		Entries:       make([]schema.IndexEntry, 0, len(entries)),
+	}
+	for _, layout := range [][2]string{
+		{"releases", "releases/release-vX.Y.Z.{json,md}"},
+		{"manual", "manual/manual-<stamp>-<label>.{json,md}"},
+		{"matrix", "matrix/matrix-<stamp>-<label>.{json,md,csv}"},
+		{"archive", "archive/<kind>/<same names>"},
+		{"latest", "latest.{json,md}"},
+	} {
+		index.Layout.Set(layout[0], layout[1])
+	}
+
+	for _, entry := range entries {
+		row, err := indexEntry(entry)
+		if err != nil {
+			return err
+		}
+		index.Entries = append(index.Entries, row)
+	}
+	// Newest first, and stable, so two entries recorded in the same second keep
+	// the order they were globbed in.
+	sort.SliceStable(index.Entries, func(i, j int) bool {
+		return index.Entries[i].RecordedAt < index.Entries[j].RecordedAt
+	})
+	reverse(index.Entries)
+
+	return benchmark.WriteJSON(filepath.Join(opts.Dir, "index.json"), index)
+}
+
+func reverse(entries []schema.IndexEntry) {
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+}
+
+func indexEntry(entry stored) (schema.IndexEntry, error) {
+	row := schema.IndexEntry{
+		Kind:                   entry.envelope.Kind,
+		Version:                entry.envelope.Version,
+		Label:                  entry.envelope.Label,
+		Official:               entry.envelope.Official,
+		RecordedAt:             entry.envelope.RecordedAt,
+		Commit:                 entry.envelope.Commit,
+		RunURL:                 entry.envelope.RunURL,
+		BenchmarkKind:          entry.kind,
+		BenchmarkSchemaVersion: 1,
+		Archived:               entry.archived,
+		JSON:                   entry.path,
+		Markdown:               strings.TrimSuffix(entry.path, ".json") + ".md",
+		LinkProfiles:           []string{},
+	}
+
+	// The measurement is read through the type its own kind declares, so a
+	// matrix entry reports the best cell of a sweep and a standard one the
+	// candidate median. The two are different numbers, and one field for both
+	// would invite reading them as one.
+	if entry.kind == schema.BenchmarkMatrix {
+		m, err := entry.envelope.Matrix()
+		if err != nil {
+			return row, fmt.Errorf("%s: %w", entry.path, err)
+		}
+		row.CandidateRef = nullable(m.CandidateRef)
+		row.Runner = nullable(m.Runner)
+		row.Environment = m.Environment
+		if m.SchemaVersion != 0 {
+			row.BenchmarkSchemaVersion = m.SchemaVersion
+		}
+		if m.Link != nil {
+			row.LinkProfiles = m.Link.Shaping.Requested
+			row.RTTP50MS = startRTT(m.Link.Probes)
+		}
+		for _, s := range m.Scaling {
+			if s.Label == "candidate" {
+				row.BestMS.Set(s.Scenario, s.Best.MedianMS)
+			}
+		}
+	} else {
+		s, err := entry.envelope.Standard()
+		if err != nil {
+			return row, fmt.Errorf("%s: %w", entry.path, err)
+		}
+		row.CandidateRef = nullable(s.CandidateRef)
+		row.Runner = nullable(s.Runner)
+		row.Environment = s.Environment
+		if s.SchemaVersion != 0 {
+			row.BenchmarkSchemaVersion = s.SchemaVersion
+		}
+		if s.Link != nil {
+			row.LinkProfiles = s.Link.Shaping.Requested
+			row.RTTP50MS = startRTT(s.Link.Probes)
+		}
+		for _, result := range s.Results {
+			if result.Label == "candidate" {
+				row.MedianMS.Set(result.Scenario, result.MedianMS)
+			}
+		}
+	}
+	if row.LinkProfiles == nil {
+		row.LinkProfiles = []string{}
+	}
+	return row, nil
+}
+
+// startRTT is the opening probe of the baseline profile, i.e. the real line as
+// the run found it. Here so that "was that release measured on a slower line"
+// can be answered without opening every file. Null on everything measured
+// before the probe existed.
+func startRTT(probes []schema.Probe) *float64 {
+	var fallback *float64
+	for _, probe := range probes {
+		if probe.At != "start" || probe.RTTMS == nil || probe.RTTMS.P50 == nil {
+			continue
+		}
+		if probe.Profile == "baseline" {
+			return probe.RTTMS.P50
+		}
+		if fallback == nil {
+			fallback = probe.RTTMS.P50
+		}
+	}
+	return fallback
+}

--- a/internal/benchmark/store/store.go
+++ b/internal/benchmark/store/store.go
@@ -1,0 +1,281 @@
+// Package store files one benchmark result set under benchmarks/.
+//
+// It is the Go form of scripts/benchmark-store.sh (issue #190, step 4). The
+// measuring half writes its results into a throwaway directory; this turns such
+// a set into a permanent entry, filed by kind:
+//
+//	benchmarks/releases/release-vX.Y.Z.{json,md}            official reference
+//	benchmarks/manual/manual-<stamp>-<label>.{json,md}      manual or experimental
+//	benchmarks/matrix/matrix-<stamp>-<label>.{json,md,csv}  matrix sweep
+//	benchmarks/latest.{json,md}                             copy of the newest release
+//	benchmarks/index.json                                   machine readable listing
+//	benchmarks/archive/<kind>/                              everything past the window
+//
+// Three rules the callers depend on:
+//
+//   - A stored file is never rewritten. Storing a name that already exists
+//     fails, in the live directory and in the archive alike.
+//   - latest.* is only ever a copy of a release entry, so a manual or matrix run
+//     can never overwrite an official number. It stays at the top of benchmarks/
+//     so its link never moves.
+//   - A matrix run is never official: it sweeps settings that a normal deploy
+//     does not use, so it answers a different question than a release number.
+//
+// Only latest.*, index.json and the archive moves change on a later run; the
+// historical files themselves are moved, never edited.
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/eiserv/easySFTP/internal/benchmark"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// KindReindex rebuilds index.json, trend.csv and latest.* from what is already
+// on disk, which is how results moved by hand are picked up.
+const KindReindex = "reindex"
+
+// Options is one store, already validated by the command that built it.
+type Options struct {
+	// Kind is "release", "manual", "matrix" or "reindex".
+	Kind string
+
+	// ResultsJSON and SummaryMD come from the measuring script and are required
+	// unless Kind is "reindex". ResultsCSV is an optional flat export stored
+	// next to the pair.
+	ResultsJSON string
+	SummaryMD   string
+	ResultsCSV  string
+
+	// Version is vMAJOR.MINOR.PATCH and is required for a release.
+	Version string
+	// Label is the short slug of a manual or matrix run.
+	Label string
+
+	RecordedAt string
+	Commit     string
+	RunURL     string
+
+	// Dir is the target directory, KeepReleases how many releases stay outside
+	// the archive (the current one plus four, by default).
+	Dir          string
+	KeepReleases int
+}
+
+var (
+	versionPattern    = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
+	recordedAtPattern = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$`)
+	unsafeInSlug      = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+)
+
+// Run stores one result set and rebuilds the bookkeeping around it.
+func Run(opts Options) error {
+	if opts.KeepReleases < 1 {
+		return fmt.Errorf("KEEP_RELEASES must be a positive integer, got '%d'", opts.KeepReleases)
+	}
+	if !recordedAtPattern.MatchString(opts.RecordedAt) {
+		return fmt.Errorf("RECORDED_AT must look like 2026-07-27T12:00:00Z, got '%s'", opts.RecordedAt)
+	}
+
+	entry, err := plan(opts)
+	if err != nil {
+		return err
+	}
+	if entry != nil {
+		if err := write(opts, *entry); err != nil {
+			return err
+		}
+	}
+
+	latest, err := retain(opts)
+	if err != nil {
+		return err
+	}
+	stored, err := list(opts.Dir)
+	if err != nil {
+		return err
+	}
+	if err := writeIndex(opts, stored, latest); err != nil {
+		return err
+	}
+	if err := writeTrend(opts.Dir, stored); err != nil {
+		return err
+	}
+
+	if entry != nil {
+		fmt.Printf("stored %s/%s.json and %s/%s.md in %s\n", entry.subdir, entry.stem, entry.subdir, entry.stem, opts.Dir)
+	} else {
+		fmt.Printf("reindexed %s: %d entr(y|ies)\n", opts.Dir, len(stored))
+	}
+	return nil
+}
+
+// newEntry is where one stored result goes and how its own page describes
+// itself.
+type newEntry struct {
+	subdir   string
+	stem     string
+	slug     string
+	version  string
+	title    string
+	kindNote string
+}
+
+func plan(opts Options) (*newEntry, error) {
+	switch opts.Kind {
+	case KindReindex:
+		// Store nothing; only the bookkeeping runs.
+		return nil, nil
+	case schema.KindRelease:
+		// Exactly the tag release-please creates: anything else sorts wrong
+		// here and does not line up with .easysftp-version.
+		if !versionPattern.MatchString(opts.Version) {
+			return nil, fmt.Errorf(
+				"VERSION must be vMAJOR.MINOR.PATCH for a release benchmark, got '%s'", opts.Version)
+		}
+		return &newEntry{
+			subdir:   "releases",
+			stem:     "release-" + opts.Version,
+			version:  opts.Version,
+			title:    "release " + opts.Version,
+			kindNote: "official reference",
+		}, nil
+	case schema.KindManual:
+		slug, err := slugify(opts.Label)
+		if err != nil {
+			return nil, err
+		}
+		return &newEntry{
+			subdir:   "manual",
+			stem:     "manual-" + stamp(opts.RecordedAt) + "-" + slug,
+			slug:     slug,
+			title:    "manual run " + slug,
+			kindNote: "not an official reference",
+		}, nil
+	case schema.KindMatrix:
+		slug, err := slugify(opts.Label)
+		if err != nil {
+			return nil, err
+		}
+		return &newEntry{
+			subdir:   "matrix",
+			stem:     "matrix-" + stamp(opts.RecordedAt) + "-" + slug,
+			slug:     slug,
+			title:    "connections/concurrency matrix " + slug,
+			kindNote: "a settings sweep, never an official reference",
+		}, nil
+	default:
+		return nil, fmt.Errorf("KIND must be 'release', 'manual', 'matrix' or 'reindex', got '%s'", opts.Kind)
+	}
+}
+
+// slugify keeps a workflow input inside the benchmark directory and inside what
+// a Windows checkout can write (no colons, so the timestamp loses them too).
+func slugify(label string) (string, error) {
+	slug := unsafeInSlug.ReplaceAllString(label, "-")
+	if strings.Trim(slug, "-") == "" {
+		return "", fmt.Errorf("LABEL must contain at least one letter or digit")
+	}
+	return slug, nil
+}
+
+func stamp(recordedAt string) string {
+	return strings.NewReplacer(":", "", "-", "").Replace(recordedAt)
+}
+
+// write files the new entry, refusing to touch a name that already exists.
+func write(opts Options, entry newEntry) error {
+	dir := filepath.Join(opts.Dir, entry.subdir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	for _, base := range []string{dir, filepath.Join(opts.Dir, "archive", entry.subdir)} {
+		for _, ext := range []string{".json", ".md", ".csv"} {
+			path := filepath.Join(base, entry.stem+ext)
+			if _, err := os.Stat(path); err == nil {
+				return fmt.Errorf("%s already exists: stored benchmarks are never rewritten", path)
+			}
+		}
+	}
+
+	measurement, err := os.ReadFile(opts.ResultsJSON)
+	if err != nil {
+		return err
+	}
+	if !json.Valid(measurement) {
+		return fmt.Errorf("RESULTS_JSON ('%s') is not valid JSON", opts.ResultsJSON)
+	}
+	summary, err := os.ReadFile(opts.SummaryMD)
+	if err != nil {
+		return err
+	}
+
+	// The envelope keeps the measurement verbatim under .benchmark and adds
+	// only provenance around it, so a reader never has to guess which run a
+	// number is.
+	//
+	// schema_version 2 is the envelope's own version: the directory layout
+	// gained a level and the entry now records which measuring script produced
+	// it. Envelopes already stored as version 1 keep their number and stay
+	// readable; .benchmark carries its own schema_version.
+	envelope := schema.Envelope{
+		SchemaVersion: schema.EnvelopeSchemaVersion,
+		Kind:          opts.Kind,
+		Version:       nullable(entry.version),
+		Label:         nullable(entry.slug),
+		Official:      opts.Kind == schema.KindRelease,
+		RecordedAt:    opts.RecordedAt,
+		Commit:        nullable(opts.Commit),
+		RunURL:        nullable(opts.RunURL),
+		Benchmark:     json.RawMessage(measurement),
+	}
+	if err := benchmark.WriteJSON(filepath.Join(dir, entry.stem+".json"), envelope); err != nil {
+		return err
+	}
+
+	var page strings.Builder
+	fmt.Fprintf(&page, "# easySFTP benchmark: %s\n\n", entry.title)
+	page.WriteString("| Field | Value |\n|---|---|\n")
+	fmt.Fprintf(&page, "| Kind | %s (%s) |\n", opts.Kind, entry.kindNote)
+	if entry.version != "" {
+		fmt.Fprintf(&page, "| Version | `%s` |\n", entry.version)
+	}
+	fmt.Fprintf(&page, "| Recorded | %s |\n", opts.RecordedAt)
+	if opts.Commit != "" {
+		fmt.Fprintf(&page, "| Commit | `%s` |\n", opts.Commit)
+	}
+	if opts.RunURL != "" {
+		fmt.Fprintf(&page, "| Workflow run | %s |\n", opts.RunURL)
+	}
+	fmt.Fprintf(&page, "| Raw data | [%s.json](%s.json) |\n", entry.stem, entry.stem)
+	if opts.ResultsCSV != "" {
+		fmt.Fprintf(&page, "| Flat export | [%s.csv](%s.csv) |\n", entry.stem, entry.stem)
+	}
+	page.WriteString("\n")
+	page.Write(summary)
+	if err := benchmark.WriteFile(filepath.Join(dir, entry.stem+".md"), page.String()); err != nil {
+		return err
+	}
+
+	if opts.ResultsCSV != "" {
+		data, err := os.ReadFile(opts.ResultsCSV)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dir, entry.stem+".csv"), data, 0o644)
+	}
+	return nil
+}
+
+func nullable(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}

--- a/internal/benchmark/store/store_test.go
+++ b/internal/benchmark/store/store_test.go
@@ -1,0 +1,373 @@
+package store_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/store"
+)
+
+// This is the Go form of scripts/test-benchmark-store.sh: the retention window,
+// the archiving, the latest.* pointer and the refusal to rewrite a stored
+// result, against a temporary directory and never against the repository's own
+// benchmarks/.
+
+const standardResult = `{
+  "schema_version": 2,
+  "benchmark_kind": "standard",
+  "candidate_ref": "test-ref",
+  "baseline_ref": "",
+  "repeats": 1,
+  "runner": "self-hosted, Linux 6.1.0, 4 cpu",
+  "environment": { "os": "Linux", "cpus": 4 },
+  "link": {
+    "iface": "eth0",
+    "shaping": {
+      "available": false,
+      "reason": "no profile asked for shaping, so it was never probed for",
+      "requested": ["baseline"],
+      "applied": ["baseline"]
+    },
+    "probes": [
+      {
+        "profile": "baseline", "at": "start", "handshake_ms": 41.2,
+        "rtt_ms": { "p50": 18.4, "p90": 21, "min": 17.1, "max": 44.2, "samples": 21 },
+        "control": { "streams": 4, "bytes": 8388608,
+                     "single_stream_mib_per_s": 0.41, "n_stream_mib_per_s": 1.6 },
+        "host_load": { "available": false, "reason": "SFTP-only account" },
+        "errors": []
+      }
+    ]
+  },
+  "results": [
+    { "label": "candidate", "scenario": "small", "link_profile": "baseline", "median_ms": 1000 },
+    { "label": "baseline", "scenario": "small", "link_profile": "baseline", "median_ms": 1200 }
+  ]
+}
+`
+
+const matrixResult = `{
+  "schema_version": 2,
+  "benchmark_kind": "matrix",
+  "candidate_ref": "test-ref",
+  "axes": { "connections": [1, 2], "concurrency": [1, 4] },
+  "cells": [
+    { "scenario": "small", "label": "candidate", "connections": 1, "concurrency": 1, "median_ms": 1400 },
+    { "scenario": "small", "label": "candidate", "connections": 2, "concurrency": 4, "median_ms": 800 }
+  ],
+  "scaling": [
+    { "scenario": "small", "label": "candidate", "best": { "connections": 2, "concurrency": 4, "median_ms": 800 } }
+  ]
+}
+`
+
+type fixture struct {
+	dir            string
+	standard       string
+	matrix         string
+	matrixCSV      string
+	summary        string
+	t              *testing.T
+	benchmarksPath string
+}
+
+func setup(t *testing.T) *fixture {
+	t.Helper()
+	work := t.TempDir()
+	f := &fixture{
+		t:              t,
+		dir:            work,
+		benchmarksPath: filepath.Join(work, "benchmarks"),
+		standard:       filepath.Join(work, "results.json"),
+		matrix:         filepath.Join(work, "matrix.json"),
+		matrixCSV:      filepath.Join(work, "matrix.csv"),
+		summary:        filepath.Join(work, "summary.md"),
+	}
+	for path, content := range map[string]string{
+		f.standard:  standardResult,
+		f.matrix:    matrixResult,
+		f.matrixCSV: "scenario,build,median_ms\nsmall,candidate,800\n",
+		f.summary:   "## easySFTP benchmark\n",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+	return f
+}
+
+func (f *fixture) store(kind, name, recordedAt string) error {
+	f.t.Helper()
+	opts := store.Options{
+		Kind: kind, SummaryMD: f.summary, ResultsJSON: f.standard,
+		Label: name, RecordedAt: recordedAt,
+		Dir: f.benchmarksPath, KeepReleases: 5,
+	}
+	if kind == schema.KindRelease {
+		opts.Version = name
+	}
+	if kind == schema.KindMatrix {
+		opts.ResultsJSON, opts.ResultsCSV = f.matrix, f.matrixCSV
+	}
+	return store.Run(opts)
+}
+
+func (f *fixture) mustStore(kind, name, recordedAt string) {
+	f.t.Helper()
+	if err := f.store(kind, name, recordedAt); err != nil {
+		f.t.Fatalf("storing %s %s: %v", kind, name, err)
+	}
+}
+
+func (f *fixture) exists(rel string) bool {
+	_, err := os.Stat(filepath.Join(f.benchmarksPath, rel))
+	return err == nil
+}
+
+func (f *fixture) read(rel string) string {
+	f.t.Helper()
+	data, err := os.ReadFile(filepath.Join(f.benchmarksPath, rel))
+	if err != nil {
+		f.t.Fatalf("reading %s: %v", rel, err)
+	}
+	return string(data)
+}
+
+func (f *fixture) index() schema.Index {
+	f.t.Helper()
+	index, err := schema.DecodeStrict[schema.Index]([]byte(f.read("index.json")))
+	if err != nil {
+		f.t.Fatalf("decoding index.json: %v", err)
+	}
+	return *index
+}
+
+func TestRetentionAndIndex(t *testing.T) {
+	f := setup(t)
+
+	// Eight releases plus two manual runs and a matrix sweep, oldest first.
+	// Three releases fall out of the five-wide window, which is where version
+	// order and plain string order disagree: sorted as text, v1.0.10 would be
+	// archived and v1.0.2 kept.
+	for _, entry := range [][3]string{
+		{schema.KindRelease, "v1.0.0", "2026-01-01T00:00:00Z"},
+		{schema.KindManual, "old-run", "2026-01-15T00:00:00Z"},
+		{schema.KindRelease, "v1.0.1", "2026-02-01T00:00:00Z"},
+		{schema.KindRelease, "v1.0.2", "2026-03-01T00:00:00Z"},
+		{schema.KindRelease, "v1.0.9", "2026-04-01T00:00:00Z"},
+		{schema.KindRelease, "v1.0.10", "2026-05-01T00:00:00Z"},
+		{schema.KindRelease, "v1.1.0", "2026-06-01T00:00:00Z"},
+		{schema.KindManual, "new-run", "2026-06-15T00:00:00Z"},
+		{schema.KindRelease, "v1.1.1", "2026-07-01T00:00:00Z"},
+		{schema.KindMatrix, "sweep", "2026-07-20T00:00:00Z"},
+		{schema.KindRelease, "v1.2.0", "2026-08-01T00:00:00Z"},
+	} {
+		f.mustStore(entry[0], entry[1], entry[2])
+	}
+
+	for _, version := range []string{"v1.0.0", "v1.0.1", "v1.0.2"} {
+		if f.exists("releases/release-" + version + ".json") {
+			t.Errorf("%s is outside the window and should have been archived", version)
+		}
+		for _, ext := range []string{".json", ".md"} {
+			if !f.exists("archive/releases/release-" + version + ext) {
+				t.Errorf("archive/releases/release-%s%s is missing", version, ext)
+			}
+		}
+	}
+	for _, version := range []string{"v1.0.9", "v1.0.10", "v1.1.0", "v1.1.1", "v1.2.0"} {
+		if !f.exists("releases/release-" + version + ".json") {
+			t.Errorf("%s should be inside the window", version)
+		}
+	}
+
+	// latest.* is only ever a copy of a release entry, so a manual or matrix
+	// run can never overwrite an official number.
+	latest, err := schema.DecodeStrict[schema.Envelope]([]byte(f.read("latest.json")))
+	if err != nil {
+		t.Fatalf("decoding latest.json: %v", err)
+	}
+	if latest.Version == nil || *latest.Version != "v1.2.0" || !latest.Official {
+		t.Errorf("latest.json is %+v, want the official v1.2.0", latest.Version)
+	}
+	if latest.SchemaVersion != schema.EnvelopeSchemaVersion {
+		t.Errorf("the envelope is schema_version %d", latest.SchemaVersion)
+	}
+	if !strings.Contains(f.read("latest.md"), "release v1.2.0") {
+		t.Error("latest.md does not carry the newest release")
+	}
+	// The store wraps a measurement, it does not summarise it.
+	if !strings.Contains(f.read("latest.json"), `"candidate_ref": "test-ref"`) ||
+		!strings.Contains(f.read("latest.json"), `"single_stream_mib_per_s": 0.41`) {
+		t.Error("the raw measurement was not kept verbatim")
+	}
+
+	// Manual and matrix runs follow the same window.
+	if f.exists("manual/manual-20260115T000000Z-old-run.json") ||
+		!f.exists("archive/manual/manual-20260115T000000Z-old-run.json") {
+		t.Error("a manual run older than the window was not archived")
+	}
+	if !f.exists("manual/manual-20260615T000000Z-new-run.json") {
+		t.Error("a manual run inside the window was archived")
+	}
+	// A matrix run is filed under its own kind and keeps its CSV.
+	for _, ext := range []string{".json", ".md", ".csv"} {
+		if !f.exists("matrix/matrix-20260720T000000Z-sweep" + ext) {
+			t.Errorf("matrix/matrix-20260720T000000Z-sweep%s is missing", ext)
+		}
+	}
+
+	index := f.index()
+	if len(index.Entries) != 11 {
+		t.Errorf("the index lists %d entries, want 11", len(index.Entries))
+	}
+	if index.LatestRelease == nil || *index.LatestRelease != "v1.2.0" {
+		t.Errorf("the index names %v as the latest release", index.LatestRelease)
+	}
+	archived := 0
+	for _, entry := range index.Entries {
+		if entry.Archived {
+			archived++
+		}
+	}
+	if archived != 4 {
+		t.Errorf("the index marks %d entries archived, want 4", archived)
+	}
+
+	// Newest first, and the newest is the release just stored.
+	newest := index.Entries[0]
+	if newest.JSON != "releases/release-v1.2.0.json" {
+		t.Errorf("the newest entry links %q", newest.JSON)
+	}
+	if median, ok := newest.MedianMS.Get("small"); !ok || median != 1000 {
+		t.Errorf("the index carries median %v for small", median)
+	}
+	if newest.Environment == nil || newest.Environment.OS != "Linux" {
+		t.Error("the index does not carry the environment forward")
+	}
+	// environment says which machine, the link fields say which path. Both have
+	// to survive into the index, or a reader has to open every file to find out
+	// whether two results are comparable at all.
+	if newest.RTTP50MS == nil || *newest.RTTP50MS != 18.4 {
+		t.Errorf("the index carries RTT %v", newest.RTTP50MS)
+	}
+	if strings.Join(newest.LinkProfiles, " ") != "baseline" {
+		t.Errorf("the index names link profiles %v", newest.LinkProfiles)
+	}
+
+	// A matrix entry has no single median per scenario (that is the point of a
+	// sweep), so it reports its best cell instead.
+	matrix := entryOfKind(t, index, schema.BenchmarkMatrix)
+	if best, ok := matrix.BestMS.Get("small"); !ok || best != 800 {
+		t.Errorf("the index reports best cell %v for the matrix run", best)
+	}
+	if matrix.MedianMS.Len() != 0 {
+		t.Error("a matrix entry must not report median_ms")
+	}
+
+	// trend.csv: a header plus one row per candidate scenario and link profile
+	// of every stored non-matrix result.
+	trend := strings.Split(strings.TrimRight(f.read("trend.csv"), "\n"), "\n")
+	if len(trend) != 11 {
+		t.Errorf("trend.csv has %d lines, want a header plus 10 rows", len(trend))
+	}
+	if !strings.Contains(trend[0], `"link_profile","rtt_p50_ms","control_single_mib_per_s"`) {
+		t.Errorf("trend.csv header: %s", trend[0])
+	}
+	filled := 0
+	for _, row := range trend[1:] {
+		if strings.Contains(row, `,"baseline",18.4,0.41,`) {
+			filled++
+		}
+		if strings.Contains(row, `"matrix"`) {
+			t.Errorf("trend.csv includes a matrix run: %s", row)
+		}
+	}
+	if filled != 10 {
+		t.Errorf("trend.csv filled the link columns on %d rows, want 10", filled)
+	}
+}
+
+// A stored file is never rewritten, in the live directory and in the archive
+// alike, and the kinds and versions are validated before anything is written.
+func TestRefusals(t *testing.T) {
+	f := setup(t)
+	f.mustStore(schema.KindRelease, "v1.0.0", "2026-01-01T00:00:00Z")
+	f.mustStore(schema.KindRelease, "v1.2.0", "2026-08-01T00:00:00Z")
+
+	for _, tc := range []struct {
+		what              string
+		kind, name, stamp string
+	}{
+		{"storing a release twice", schema.KindRelease, "v1.2.0", "2026-08-02T00:00:00Z"},
+		{"a non-release version", schema.KindRelease, "1.2.0", "2026-08-02T00:00:00Z"},
+		{"an unknown kind", "nightly", "whatever", "2026-08-02T00:00:00Z"},
+		{"a malformed timestamp", schema.KindManual, "run", "yesterday"},
+	} {
+		if err := f.store(tc.kind, tc.name, tc.stamp); err == nil {
+			t.Errorf("%s was accepted", tc.what)
+		}
+	}
+
+	// Storing an archived release again must fail too, or history could be
+	// overwritten by a rerun.
+	f.mustStore(schema.KindRelease, "v1.0.1", "2026-02-01T00:00:00Z")
+	f.mustStore(schema.KindRelease, "v1.0.2", "2026-03-01T00:00:00Z")
+	f.mustStore(schema.KindRelease, "v1.0.3", "2026-04-01T00:00:00Z")
+	f.mustStore(schema.KindRelease, "v1.0.4", "2026-05-01T00:00:00Z")
+	if !f.exists("archive/releases/release-v1.0.0.json") {
+		t.Fatal("v1.0.0 should be archived by now")
+	}
+	if err := f.store(schema.KindRelease, "v1.0.0", "2026-08-02T00:00:00Z"); err == nil {
+		t.Error("an archived release was stored again")
+	}
+}
+
+// A manual run must not be able to write outside the benchmark directory,
+// whatever the workflow input says.
+func TestLabelIsConfined(t *testing.T) {
+	f := setup(t)
+	f.mustStore(schema.KindManual, "../../escaped run", "2026-08-16T00:00:00Z")
+	if !f.exists("manual/manual-20260816T000000Z-..-..-escaped-run.json") {
+		t.Error("the label was not slugified into the manual directory")
+	}
+	if _, err := os.Stat(filepath.Join(f.dir, "..", "..", "escaped run.json")); err == nil {
+		t.Error("a label escaped the benchmark directory")
+	}
+	if err := f.store(schema.KindManual, "///", "2026-08-17T00:00:00Z"); err == nil {
+		t.Error("a label with no letter or digit was accepted")
+	}
+}
+
+// Reindexing rebuilds index.json, trend.csv and latest.* from what is on disk,
+// which is how results moved by hand are picked up.
+func TestReindex(t *testing.T) {
+	f := setup(t)
+	f.mustStore(schema.KindRelease, "v1.0.0", "2026-01-01T00:00:00Z")
+	if err := os.Remove(filepath.Join(f.benchmarksPath, "index.json")); err != nil {
+		t.Fatalf("removing the index: %v", err)
+	}
+	if err := store.Run(store.Options{
+		Kind: store.KindReindex, RecordedAt: "2026-08-01T00:00:00Z",
+		Dir: f.benchmarksPath, KeepReleases: 5,
+	}); err != nil {
+		t.Fatalf("reindexing: %v", err)
+	}
+	if len(f.index().Entries) != 1 {
+		t.Error("the reindex did not rebuild the index from disk")
+	}
+}
+
+func entryOfKind(t *testing.T, index schema.Index, kind string) schema.IndexEntry {
+	t.Helper()
+	for _, entry := range index.Entries {
+		if entry.BenchmarkKind == kind {
+			return entry
+		}
+	}
+	t.Fatalf("no %s entry in the index", kind)
+	return schema.IndexEntry{}
+}

--- a/internal/benchmark/store/trend.go
+++ b/internal/benchmark/store/trend.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/eiserv/easySFTP/internal/benchmark"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+)
+
+// trendColumns is one row per (stored standard result, scenario, link profile),
+// so a plot of runtime and throughput across releases needs neither a JSON
+// parser nor a pass over every file. index.json carries the medians but not the
+// throughput, which is exactly the second axis such a plot wants. Matrix
+// results are left out: their point is that they have no single number per
+// scenario.
+//
+// link_profile, rtt_p50_ms and control_single_mib_per_s ride along because a
+// trend line across months is otherwise a trend of the line as much as of the
+// code. A result measured before the probe existed has one row per scenario
+// with the profile empty, exactly as before.
+var trendColumns = []string{
+	"recorded_at", "kind", "version", "label", "candidate_ref", "runner", "scenario",
+	"link_profile", "rtt_p50_ms", "control_single_mib_per_s", "files", "bytes",
+	"median_ms", "min_ms", "max_ms", "mad_ms", "mib_per_s", "files_per_s",
+	"max_rss_bytes", "user_cpu_ms", "archived", "json",
+}
+
+func writeTrend(root string, entries []stored) error {
+	var out strings.Builder
+	out.WriteString(quoteAll(trendColumns))
+	out.WriteByte('\n')
+
+	for _, entry := range entries {
+		if entry.kind == schema.BenchmarkMatrix {
+			continue
+		}
+		s, err := entry.envelope.Standard()
+		if err != nil {
+			return err
+		}
+		var probes []schema.Probe
+		if s.Link != nil {
+			probes = s.Link.Probes
+		}
+		for _, result := range s.Results {
+			if result.Label != "candidate" {
+				continue
+			}
+			profile := result.LinkProfile
+			if profile == "" {
+				profile = "baseline"
+			}
+			probe := startProbe(probes, profile)
+
+			var rtt, control *float64
+			if probe != nil {
+				if probe.RTTMS != nil {
+					rtt = probe.RTTMS.P50
+				}
+				if probe.Control != nil {
+					control = probe.Control.SingleStreamMiBPerS
+				}
+			}
+			var maxRSS, userCPU *float64
+			if result.Process != nil {
+				maxRSS, userCPU = result.Process.MaxRSSBytes, result.Process.UserCPUMS
+			}
+
+			out.WriteString(strings.Join([]string{
+				quote(entry.envelope.RecordedAt),
+				quote(entry.envelope.Kind),
+				quoteOrNull(entry.envelope.Version),
+				quoteOrNull(entry.envelope.Label),
+				quoteOrNull(nullable(s.CandidateRef)),
+				quoteOrNull(nullable(s.Runner)),
+				quote(result.Scenario),
+				quoteOrNull(nullable(result.LinkProfile)),
+				number(rtt),
+				number(control),
+				stats.Format(result.Files),
+				stats.Format(result.Bytes),
+				stats.Format(result.MedianMS),
+				stats.Format(result.MinMS),
+				stats.Format(result.MaxMS),
+				number(result.MadMS),
+				stats.Format(result.MiBPerS),
+				stats.Format(result.FilesPerS),
+				number(maxRSS),
+				number(userCPU),
+				boolean(entry.archived),
+				quote(entry.path),
+			}, ","))
+			out.WriteByte('\n')
+		}
+	}
+	return benchmark.WriteFile(filepath.Join(root, "trend.csv"), out.String())
+}
+
+// startProbe is the opening probe of the profile a row was measured on. A row
+// whose profile was never probed keeps its link columns empty rather than
+// borrowing another profile's numbers.
+func startProbe(probes []schema.Probe, profile string) *schema.Probe {
+	for i := range probes {
+		if probes[i].Profile == profile && probes[i].At == "start" {
+			return &probes[i]
+		}
+	}
+	return nil
+}
+
+// The four renderers below are jq's "@csv": strings are quoted with inner
+// quotes doubled, numbers and booleans are bare, and null is an empty column.
+// An empty column says "this metric did not exist yet", and a 0 there would be
+// a measurement that was never taken.
+func quote(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}
+
+func quoteOrNull(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return quote(*value)
+}
+
+func number(value *float64) string {
+	if value == nil {
+		return ""
+	}
+	return stats.Format(*value)
+}
+
+func boolean(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func quoteAll(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, quote(value))
+	}
+	return strings.Join(quoted, ",")
+}


### PR DESCRIPTION
Steps 3 and 4 of #190: scenario generation and candidate/baseline process orchestration, then the matrix, canary, link-profile and result-store coordination.

The measurement itself is untouched, which is the point. The same runs happen in the same order at the same settings, and the manifest and the JSONL are the same documents the scripts wrote.

## What moved

New packages under `internal/benchmark`:

| Package | Replaces | What it holds |
|---|---|---|
| `scenario` | `scenario_*` in `benchmark-lib.sh` | payload tables, deploy shapes, the per-scenario axis caps, dataset generation, the redeploy mutation |
| `runner` | `run_easysftp`, `step_number`, `count_matches`, `metrics_json` | starting one build, the generated v3 config file, reading its outputs back |
| `link` | `benchmark-link.sh` | the profile grammar, `tc` shaping, `cmd/linkprobe` |
| `driver` | `benchmark.sh`, `benchmark-matrix.sh` | the two measuring loops |
| `store` | `benchmark-store.sh` | the result directory, its retention window and its exports |

`cmd/easysftp-bench` grows `standard`, `matrix` and `store` alongside `aggregate` and `validate`. The three new ones read the same environment variables the shell scripts read, so the workflows keep passing the same things.

## Two schema changes

Both fall out of the store moving into Go, and both exist so a rewritten document is the document it replaced:

- Everything a stored file holds as `null` is a pointer now: an envelope's `commit` and `run_url`, an index entry's `runner` and `candidate_ref`. Written from a plain `string` they would have come back as `""`.
- `schema.Ordered` keeps an object's keys in the order they were written, because a Go map re-encodes them sorted and `index.json` is committed. Without it the next store would reorder `median_ms` and the `layout` block for no reason a reader could make sense of.

## Evidence

Against the repository's own `benchmarks/`, on a copy:

- `KIND=reindex easysftp-bench store` reproduces `index.json` and `trend.csv` **byte for byte**, with one deliberate difference: `generated_by` now names the command that generated it.
- Re-storing the v3.4.0 measurement reproduces `benchmarks/releases/release-v3.4.0.json` **byte for byte**.

New self-checks, which are the Go form of the shell ones:

- `internal/benchmark/driver` drives both loops end to end against a stub that is a mode of the test binary (no helper is compiled at test time), and asserts on the cell count of a per-scenario grid, the deploy shapes and their unmeasured base deploys, the delete rows, the auto regret, the canary triple and the summary sections.
- `internal/benchmark/store` covers the retention window, the archiving, the `latest.*` invariant, the refusals and the confinement of a label.

`go build ./...`, `go vet ./...` and `go test ./...` all pass. The race pass could not run locally (`-race requires cgo` without a C toolchain), so CI owns it.

## What deliberately did not change

Nothing in `scripts/` or `.github/workflows/`. The shell stays as the behavioural reference that step 5 diffs against, and step 6 is where CI switches and the obsolete shell goes.

## A note on the commit

The issue asks for these as separate steps, and they are one commit here. A split was tried and abandoned: the standard driver already needs the `link` package for its profile loop, so "step 3 alone" is a tree that does not build. The two halves are separable by package, not by commit.

Refs #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)
