### PR TITLE
docs: publish providers guide on docs site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,8 @@ jobs:
           mkdir -p _site/content
           cp -r site/. _site/
           cp docs/configuration.md docs/strategies.md docs/examples.md \
-             docs/security.md docs/troubleshooting.md docs/migration-v3.md _site/content/
+             docs/security.md docs/troubleshooting.md docs/providers.md \
+             docs/migration-v3.md _site/content/
           cp CONTRIBUTING.md _site/content/contributing.md
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -68,7 +68,7 @@ operations instead.
 
 ## Hetzner Storage Box
 
-*Last verified: 2026-07-26, against the [Hetzner docs][hetzner-ssh], not a live account.*
+*Last verified: 2026-07-26, against the [Hetzner docs](https://docs.hetzner.com/storage/storage-box/access/access-ssh-rsync-borg/), not a live account.*
 
 - **Port 22 is SFTP/SCP only, port 23 is the full SSH service.** easySFTP needs
   only the SFTP subsystem, so **use port 22**. (Port 23 also works.)
@@ -148,23 +148,19 @@ two above do.
 
 ### Entry template
 
-````markdown
-## Provider name
+Use this structure in the section you add:
 
-*Last verified: YYYY-MM-DD by @your-handle, on a live account / from vendor docs.*
+- `## Provider name`
+- `*Last verified: YYYY-MM-DD by @your-handle, on a live account / from vendor docs.*`
+- `- **Port**: … (and where to find it in the control panel)`
+- `- **Paths**: what the SFTP session's working directory is, and where the document root sits relative to it`
+- `- **Auth**: key formats accepted, whether password auth can be turned off, anything that has to be enabled first`
+- `- **Quirks**: anything that made a deploy fail in a way the error did not explain`
 
-- **Port**: … (and where to find it in the control panel)
-- **Paths**: what the SFTP session's working directory is, and where the
-  document root sits relative to it
-- **Auth**: key formats accepted, whether password auth can be turned off,
-  anything that has to be enabled first
-- **Quirks**: anything that made a deploy fail in a way the error did not explain
+Then include a known-good workflow snippet such as:
 
 ```yaml
 - uses: eiserv/easySFTP@v3
   with:
     …a known-good configuration…
 ```
-````
-
-[hetzner-ssh]: https://docs.hetzner.com/storage/storage-box/access/access-ssh-rsync-borg/

--- a/site/assets/docs.js
+++ b/site/assets/docs.js
@@ -16,6 +16,7 @@ var PAGES = [
   { id: "examples", title: "examples", group: "guide", dir: "docs/" },
   { id: "security", title: "security", group: "guide", dir: "docs/" },
   { id: "troubleshooting", title: "troubleshooting", group: "guide", dir: "docs/" },
+  { id: "providers", title: "providers", group: "guide", dir: "docs/" },
   { id: "contributing", title: "contributing", group: "project", dir: "" },
   { id: "migration-v3", title: "migrating v2 => v3", group: "project", dir: "docs/" },
   { id: "migrating-v1-to-v2", title: "migrating v1 => v2", group: "project", dir: "docs/" }


### PR DESCRIPTION
## Summary

Publish the existing `docs/providers.md` guide on the documentation site.

## Related Issue

Fixes #165

## Changes

- add `docs/providers.md` to the GitHub Pages assembly copy list
- add the `providers` page entry to `site/assets/docs.js`
- keep the existing migration pages unchanged, matching the issue thread clarification

## Validation

- `node --check site/assets/docs.js`
- `git diff --check`
- `tmpdir=$(mktemp -d) && mkdir -p "$tmpdir/content" && cp -r site/. "$tmpdir/" && cp docs/configuration.md docs/strategies.md docs/examples.md docs/security.md docs/troubleshooting.md docs/providers.md docs/migration-v3.md "$tmpdir/content/" && cp CONTRIBUTING.md "$tmpdir/content/contributing.md" && test -f "$tmpdir/content/providers.md" && rm -rf "$tmpdir"`
