### PR TITLE
fix(uploader): keep the full plan out of sync's stale-temp sweep

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -145,7 +145,10 @@ concurrently running deploy's in-progress upload. The sweep intentionally
 runs in every mode, `overlay` included, and is on by default: even though
 overlay never deletes your files, the sweep only ever removes the action's
 own `*.easysftp-tmp` / `*.easysftp-tmp.<n>` debris, never a file it did not
-name itself. An orphan in a directory that no later deploy uploads into
+name itself. A real file of yours that happens to carry such a name is part
+of the deployment and is therefore never swept, in `sync` too, where it is
+protected even on runs that leave it unchanged. An orphan in a directory
+that no later deploy uploads into
 stays until one does, or until you delete it manually. If the target is a
 public web root, also add a deny rule for these names next to the manifest
 rule; see [security.md](security.md#temporary-upload-files-in-web-roots).

--- a/internal/uploader/staletemp_test.go
+++ b/internal/uploader/staletemp_test.go
@@ -234,6 +234,52 @@ func TestSweepStaysWithinDeploymentBase(t *testing.T) {
 	}
 }
 
+// Issue #186: sync narrows the upload to the changed files, but the sweep's
+// keep set must still cover the full plan. A literal-named target that is
+// unchanged this run is not in the upload subset, yet its directory is swept
+// because a sibling changed; removing it would be silent and permanent, since
+// the manifest still records it as up to date.
+func TestSyncSweepKeepsUnchangedTargetsNamedLikeTempFiles(t *testing.T) {
+	shrinkStaleTempMaxAge(t)
+
+	srv := startTestServer(t)
+	local := t.TempDir()
+	literal := "app.js" + tmpSuffix + ".3"
+	writeTree(t, local, map[string]string{literal: "real content", "other.txt": "1"})
+
+	cfg := syncConfig(srv, local)
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the sibling changes, so the second sync uploads just other.txt
+	// while still sweeping /www, where the unchanged literal-named file lives.
+	writeTree(t, local, map[string]string{literal: "real content", "other.txt": "2"})
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readRemote(t, srv, "/www/"+literal); got != "real content" {
+		t.Errorf("unchanged literal-named file was lost: %q", got)
+	}
+	for _, msg := range log.infos {
+		if strings.Contains(msg, "removed stale temporary file") {
+			t.Errorf("an unchanged planned target was swept as a stale temp file: %q", msg)
+		}
+	}
+
+	// A third run must find it unchanged as well: had the second run deleted
+	// it, the manifest hash would keep sync from restoring it.
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	if got := readRemote(t, srv, "/www/"+literal); got != "real content" {
+		t.Errorf("sync did not leave the literal-named file in place: %q", got)
+	}
+}
+
 // The sync strategy uploads through the same path, so a directory a sync run
 // touches is swept too, and the orphan does not linger despite sync's
 // manifest never having known about it.

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -124,8 +124,11 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 		dirs = p.remoteDirs
 	}
 	// skip-unchanged is always off here: sync already decided what changed
-	// from the manifest hashes, which is strictly more precise.
-	completed, err := uploadFiles(ctx, cfg, sess, upload, dirs, base, stats, verb, watch, false, log)
+	// from the manifest hashes, which is strictly more precise. The full plan
+	// goes along with the changed subset because the stale-temp sweep must not
+	// remove an unchanged planned target that happens to be named like a temp
+	// file; see uploadFiles and issue #186.
+	completed, err := uploadFiles(ctx, cfg, sess, upload, p.files, dirs, base, stats, verb, watch, false, log)
 	if err != nil {
 		writeRecoveryManifest(ctx, cfg, sess, watch, base, mergedManifest(old, upload, completed, nil), log)
 		return err

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -56,10 +56,16 @@ type transferEnv struct {
 // same size is skipped instead of uploaded; the stat happens inside the
 // parallel workers so its latency is amortized by the concurrency.
 //
+// planned is the deployment's full plan, which is the same slice as files for
+// overlay and clean but a superset of it for sync (which narrows the upload to
+// the changed files). Only the stale-temp sweep needs the difference: the
+// directories it visits follow what is being uploaded, but the targets it must
+// not remove are every planned one. See sweepStaleTemps and issue #186.
+//
 // It returns which files completed, indexed like files, so that on a partial
 // failure the caller knows what actually made it to the server (the sync
 // strategy uses this to persist a recovery manifest).
-func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files []fileItem, dirs []string, base string, stats *Stats, verb string, watch *stallWatchdog, skipUnchanged bool, log Logger) ([]bool, error) {
+func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, planned []fileItem, dirs []string, base string, stats *Stats, verb string, watch *stallWatchdog, skipUnchanged bool, log Logger) ([]bool, error) {
 	// Declared before the first failure point: callers index the returned
 	// slice by file, so it must be sized even when nothing was uploaded.
 	completed := make([]bool, len(files))
@@ -82,7 +88,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files [
 		// run left in the directories this run uploads into; see
 		// sweepStaleTemps.
 		endSweep := metrics.Phase("sweep_stale_temps")
-		sweepStaleTemps(ctx, sess, watch, base, files, log)
+		sweepStaleTemps(ctx, sess, watch, base, files, planned, log)
 		endSweep()
 	}
 
@@ -315,7 +321,7 @@ func isTempFileName(name string) bool {
 // the target forever, publicly served when the target is a web root.
 //
 // The swept set is exactly the directories that receive files this run (the
-// parent directory of every planned remote path) plus the deployment's remote
+// parent directory of every uploaded remote path) plus the deployment's remote
 // base, where the sync manifest's temp file lives even when no changed file
 // does. Nothing above the base is ever listed or touched: a deploy to
 // /var/www/html/blog has no business reading /var. That keeps the added
@@ -326,7 +332,11 @@ func isTempFileName(name string) bool {
 // pattern (isTempFileName), the entry must be older than staleTempMaxAge (a
 // younger one is plausibly another live run's in-progress upload), and it
 // must not be a planned target of this run (a real deployed file can be named
-// like a temp file; see the literal-name test in atomic_test.go). Staleness
+// like a temp file; see the literal-name test in atomic_test.go). That third
+// guard reads the deployment's *full* plan, not the subset being uploaded:
+// under sync an unchanged file is absent from the upload subset, and sweeping
+// it would delete it silently and for good, because the manifest still records
+// it as up to date and no later run would restore it (issue #186). Staleness
 // compares the runner's clock against the mtime the server reports
 // (time.Since of the entry's ModTime), so a server clock running behind the
 // runner's can make a fresh temp file look older than it is; concurrent
@@ -344,9 +354,9 @@ func isTempFileName(name string) bool {
 // connection redials, but a listing or removal failure only warns and never
 // fails the deploy. Removals are logged, so a user who wondered what those
 // files were gets an answer.
-func sweepStaleTemps(ctx context.Context, sess *session, watch *stallWatchdog, base string, files []fileItem, log Logger) {
-	keep := make(map[string]struct{}, len(files))
-	for _, f := range files {
+func sweepStaleTemps(ctx context.Context, sess *session, watch *stallWatchdog, base string, files, planned []fileItem, log Logger) {
+	keep := make(map[string]struct{}, len(planned))
+	for _, f := range planned {
 		keep[f.remotePath] = struct{}{}
 	}
 	touched := make(map[string]struct{}, len(files)+1)

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -267,7 +267,9 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 	}
 
 	skipUnchanged := cfg.SkipUnchanged && p.strategy == config.StrategyOverlay
-	_, err := uploadFiles(ctx, cfg, sess, p.files, p.remoteDirs, base, stats, verb, watch, skipUnchanged, log)
+	// Overlay and clean upload the whole plan, so the uploaded set and the
+	// planned set are the same slice.
+	_, err := uploadFiles(ctx, cfg, sess, p.files, p.files, p.remoteDirs, base, stats, verb, watch, skipUnchanged, log)
 	return err
 }
 


### PR DESCRIPTION
Closes #186.

## The bug

`sweepStaleTemps` built its `keep` set from the file slice handed to
`uploadFiles`. In overlay and clean that slice is the whole plan, so a real
deployed file literally named like one of easySFTP's own temp files
(`*.easysftp-tmp.<n>`, the #42 collision case) was protected.

`executeSync` narrows the plan to the changed files and passes only that
subset. A literal-named file that is unchanged this run is therefore absent
from the keep set. If any other file in its directory changed (so the
directory is swept) and the entry is older than `staleTempMaxAge`, the sweep
removed it. Sync does not restore it: the manifest hash is unchanged, so the
next run counts it as up to date. Silent, permanent loss.

Narrow precondition, but no failure mode announces itself, which is why it is
worth fixing as a correctness bug rather than filing under "unlikely".

## The fix

Split "files to upload" from "planned remote paths to keep". `uploadFiles`
takes both:

- `files` still decides what gets uploaded and which directories the sweep
  visits (unchanged behavior, and what keeps a mostly-unchanged sync cheap),
- `planned` is the deployment's full plan and is the only thing the sweep's
  keep set is built from.

Overlay and clean pass the same slice for both; sync passes `p.files`
alongside its `upload` subset. Nothing else about the sweep changes: the swept
directory set, the age margin, the base-only scope and the best-effort error
handling are all as before.

## Test

`TestSyncSweepKeepsUnchangedTargetsNamedLikeTempFiles` in
`internal/uploader/staletemp_test.go` is the sync counterpart to the existing
overlay test. It deploys a literal `app.js.easysftp-tmp.3` plus a sibling,
changes only the sibling, and asserts the literal-named file survives the
second run's sweep, that no removal is logged, and that a third run still
finds it in place (the "the manifest would never restore it" half). It fails
on `main` with `removed stale temporary file /www/app.js.easysftp-tmp.3`.

`docs/troubleshooting.md` gains one sentence: the sweep never touches a real
file of yours that carries such a name, sync's unchanged files included.

## Verification

`go test ./...` passes. `-race` could not run here (`-race requires cgo` and
the machine has no C toolchain, as CLAUDE.md anticipates), so CI carries the
race pass.
