### PR TITLE
fix(uploader): do not retry permanent SFTP status codes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,7 +217,7 @@ sync:
 
 | Field | Default | Description |
 |---|---|---|
-| `retries` | `2` | Retries per file on transient errors, and the reconnect budget for dropped connections. `0` disables. |
+| `retries` | `2` | Retries per file on transient errors, and the reconnect budget for dropped connections. Failures the server reports with a permanent status code are never retried; see [which upload failures are retried](troubleshooting.md#which-upload-failures-easysftp-retries). `0` disables. |
 | `timeout` | `30` | Connection timeout in seconds. `0` disables. |
 | `stall_timeout` | `0` (off) | Abort when active remote operations make no progress for this many seconds. |
 | `concurrency` | `auto` (4) | Files uploaded in parallel. Also bounds the sync hashing worker pool. `auto` uses the built-in default. |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -104,6 +104,30 @@ The SFTP user cannot write to the target directory. Check ownership and
 permissions on the server. With chrooted SFTP setups remember that paths are
 relative to the chroot: `/upload/...`, not `/home/user/upload/...`.
 
+### Which upload failures easySFTP retries
+
+A failure the server itself reported reads like
+`sftp: "Disk quota exceeded" (SSH_FX_FAILURE)`. The quoted text is the server's
+own explanation and is usually the only part worth reading; the `SSH_FX_*` name
+after it is the protocol status code it sent, which decides whether easySFTP
+tries again.
+
+Codes that can only ever come back the same way fail the file immediately,
+whatever `retries` is set to: `SSH_FX_NO_SUCH_FILE` and
+`SSH_FX_PERMISSION_DENIED` (which reach you as `file does not exist` and
+`permission denied`), plus `SSH_FX_OP_UNSUPPORTED` and `SSH_FX_BAD_MESSAGE`,
+whose failures add `retrying would not have helped` so the skipped retries are
+not a mystery.
+
+`SSH_FX_FAILURE` is retried, because it is a catch-all: servers use it both for
+permanent conditions (a disk quota, a full or read-only filesystem, a path
+length limit) and for transient ones, and only the message text tells them
+apart. easySFTP does not guess from that text, so a quota-exceeded deploy pays
+the retry backoff for the files it has in flight when the quota runs out
+(remaining files are not started once one fails). If you already know the cause
+is permanent, `advanced.retries: 0` in the config file makes such a run fail
+immediately.
+
 ### Site deploys "successfully" but returns 403s, or files land with the wrong owner-readable bits
 
 Directories created by the run get whatever the server's umask produces, and

--- a/internal/uploader/atomic_test.go
+++ b/internal/uploader/atomic_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/sftp"
+
 	"github.com/eiserv/easySFTP/internal/config"
 )
 
@@ -200,6 +202,19 @@ func TestIsRetryable(t *testing.T) {
 		{"wrapped permission", fmt.Errorf("open: %w", os.ErrPermission), false},
 		{"transient network error", errors.New("connection lost"), true},
 		{"wrapped context cancel", fmt.Errorf("copy: %w", context.Canceled), false},
+		// Server status codes. The permanent ones are named explicitly; the
+		// ambiguous and the connection-class ones keep their retry.
+		{"op unsupported", &sftp.StatusError{Code: uint32(sftp.ErrSSHFxOpUnsupported)}, false},
+		{"bad message", &sftp.StatusError{Code: uint32(sftp.ErrSSHFxBadMessage)}, false},
+		{"status no such file", &sftp.StatusError{Code: uint32(sftp.ErrSSHFxNoSuchFile)}, false},
+		{"status permission denied", &sftp.StatusError{Code: uint32(sftp.ErrSSHFxPermissionDenied)}, false},
+		{"wrapped op unsupported", fmt.Errorf("replacing %q: %w", "/www/a.txt",
+			&sftp.StatusError{Code: uint32(sftp.ErrSSHFxOpUnsupported)}), false},
+		// Quota, no space and read-only filesystems arrive as this one, but so
+		// do transient server-side failures; it stays retryable.
+		{"generic failure", &sftp.StatusError{Code: uint32(sftp.ErrSSHFxFailure)}, true},
+		{"connection lost status", &sftp.StatusError{Code: uint32(sftp.ErrSSHFxConnectionLost)}, true},
+		{"no connection status", &sftp.StatusError{Code: uint32(sftp.ErrSSHFxNoConnection)}, true},
 	}
 	for _, c := range cases {
 		if got := isRetryable(c.err); got != c.want {

--- a/internal/uploader/permanentstatus_test.go
+++ b/internal/uploader/permanentstatus_test.go
@@ -1,0 +1,90 @@
+package uploader
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/pkg/sftp"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// countRetryWarnings counts the per-file retry warnings a run logged, i.e. how
+// many extra attempts uploadFileWithRetry actually spent.
+func countRetryWarnings(log *recordingLogger) int {
+	log.mu.Lock()
+	defer log.mu.Unlock()
+	n := 0
+	for _, w := range log.warnings {
+		if strings.HasPrefix(w, "retrying upload of ") {
+			n++
+		}
+	}
+	return n
+}
+
+// A server that refuses the upload with a status code it will repeat verbatim
+// (SSH_FX_OP_UNSUPPORTED here) is not worth a second attempt: the run must
+// fail after the first one, without spending any backoff, and must say why it
+// did not retry.
+func TestPermanentServerStatusIsNotRetried(t *testing.T) {
+	srv := startTestServer(t, withStatusOnPut("/www/a.txt", sftp.ErrSSHFxOpUnsupported))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "a"})
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 1
+	cfg.Retries = 2
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	_, err := Run(context.Background(), cfg, log)
+	if err == nil {
+		t.Fatal("expected the upload to fail")
+	}
+	if n := countRetryWarnings(log); n != 0 {
+		t.Errorf("a permanent server status was retried %d time(s); want 0", n)
+	}
+	// The server's own status line stays in the failure, and the reason the
+	// configured retries did not run is spelled out next to it.
+	msg := err.Error()
+	if !strings.Contains(msg, "SSH_FX_OP_UNSUPPORTED") {
+		t.Errorf("failure does not carry the server's status: %v", err)
+	}
+	if !strings.Contains(msg, "retrying would not have helped") {
+		t.Errorf("failure does not explain why it was not retried: %v", err)
+	}
+}
+
+// The other half of the same rule: SSH_FX_FAILURE is the catch-all servers
+// also use for transient conditions, so it keeps its retries. Losing them
+// would trade a slow doomed deploy for a fast broken one, which is the worse
+// mistake (see isPermanentStatus).
+func TestAmbiguousServerStatusStillRetries(t *testing.T) {
+	srv := startTestServer(t, withStatusOnPut("/www/a.txt", sftp.ErrSSHFxFailure))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "a"})
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 1
+	cfg.Retries = 1 // one retry, so the test pays a single 1s backoff
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	_, err := Run(context.Background(), cfg, log)
+	if err == nil {
+		t.Fatal("expected the upload to fail")
+	}
+	if n := countRetryWarnings(log); n != 1 {
+		t.Errorf("SSH_FX_FAILURE produced %d retry warning(s); want 1", n)
+	}
+	if !strings.Contains(err.Error(), "SSH_FX_FAILURE") {
+		t.Errorf("failure does not carry the server's status: %v", err)
+	}
+	if strings.Contains(err.Error(), "retrying would not have helped") {
+		t.Errorf("an ambiguous status was reported as permanent: %v", err)
+	}
+}

--- a/internal/uploader/retry.go
+++ b/internal/uploader/retry.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/pkg/sftp"
+
 	"github.com/eiserv/easySFTP/internal/metrics"
 )
 
@@ -67,21 +69,72 @@ func uploadFileWithRetry(ctx context.Context, env *transferEnv, f fileItem, inde
 			}
 		}
 	}
+	// A status the server will repeat verbatim ended the loop early. Say so:
+	// otherwise a run configured with retries looks like it silently skipped
+	// them, and the reader has to guess whether the file was given up on too
+	// soon. The server's own status line stays in front of the clause.
+	if isPermanentStatus(lastErr) {
+		return 0, fmt.Errorf("uploading %q to %q: %w (the server rejected this outright; retrying would not have helped)",
+			f.localPath, f.remotePath, lastErr)
+	}
 	return 0, fmt.Errorf("uploading %q to %q: %w", f.localPath, f.remotePath, lastErr)
 }
 
 // isRetryable reports whether an error is worth another attempt. Permanent
-// failures (bad permissions, missing paths) and a cancelled/expired context
-// are not retried; transient ones (dropped connections, timeouts, EOF) are.
+// failures (bad permissions, missing paths, a status code the server will
+// repeat) and a cancelled/expired context are not retried; transient ones
+// (dropped connections, timeouts, EOF) are.
+//
+// Anything unrecognised stays retryable on purpose. For a momentary network
+// condition another attempt is what saves the run, and mistaking a transient
+// failure for a permanent one costs more than the reverse. The point of
+// isPermanentStatus is to name the failures that are known-permanent, not to
+// flip that bias.
 func isRetryable(err error) bool {
 	switch {
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return false
 	case errors.Is(err, os.ErrPermission), errors.Is(err, os.ErrNotExist):
 		return false
+	case isPermanentStatus(err):
+		return false
 	default:
 		return true
 	}
+}
+
+// isPermanentStatus reports whether err carries an SFTP status code the server
+// has already made up its mind about: a retry sends the identical request over
+// a healthy connection and gets the identical answer back, so it only costs
+// the backoff.
+//
+// Only unambiguous codes are listed. SSH_FX_FAILURE deliberately is not. It is
+// the catch-all servers use for a disk quota, a full or read-only filesystem
+// and a path-length limit (all permanent), but also for genuinely transient
+// conditions, and only the human-readable message tells the two apart.
+// Matching on that text is fragile across server implementations and locales,
+// so SSH_FX_FAILURE keeps its retry; the wrapped error carries the server's
+// own status line, which is what the user reads either way.
+//
+// SSH_FX_NO_SUCH_FILE and SSH_FX_PERMISSION_DENIED are listed even though
+// pkg/sftp normalises both into os.ErrNotExist and os.ErrPermission before
+// they reach here, so the errors.Is arms above catch them first: the
+// classification should not quietly change if that normalisation does.
+// SSH_FX_NO_CONNECTION and SSH_FX_CONNECTION_LOST are absent on purpose, being
+// exactly the failures a reconnect fixes.
+func isPermanentStatus(err error) bool {
+	var se *sftp.StatusError
+	if !errors.As(err, &se) {
+		return false
+	}
+	switch se.FxCode() {
+	case sftp.ErrSSHFxOpUnsupported, // the server does not implement this operation
+		sftp.ErrSSHFxBadMessage, // the request itself is malformed for this server
+		sftp.ErrSSHFxNoSuchFile,
+		sftp.ErrSSHFxPermissionDenied:
+		return true
+	}
+	return false
 }
 
 // sleepCtx waits for d, returning early with the context error if the

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -101,6 +102,35 @@ func (f *faultyList) Filelist(r *sftp.Request) (sftp.ListerAt, error) {
 func withFailList(path string) serverOption {
 	return func(s *testServer) {
 		s.handlers.FileList = &faultyList{inner: s.handlers.FileList, path: path}
+	}
+}
+
+// statusOnPut answers every write-open of a path starting with prefix (the
+// upload's temp file is prefix + tmpSuffix + index, so the prefix is the
+// target path) with one fixed SFTP status code, delegating everything else to
+// the in-memory handler.
+//
+// pkg/sftp's statusFromError puts an sftp.ErrSSHFx* value on the wire as that
+// exact status code, which is how a test simulates a server answering an
+// upload with a considered protocol-level refusal rather than dropping the
+// connection. The client turns it back into a *sftp.StatusError, which is what
+// isPermanentStatus classifies.
+type statusOnPut struct {
+	inner  sftp.FileWriter
+	prefix string
+	code   error // an sftp.ErrSSHFx* code
+}
+
+func (w *statusOnPut) Filewrite(r *sftp.Request) (io.WriterAt, error) {
+	if strings.HasPrefix(r.Filepath, w.prefix) {
+		return nil, w.code
+	}
+	return w.inner.Filewrite(r)
+}
+
+func withStatusOnPut(prefix string, code error) serverOption {
+	return func(s *testServer) {
+		s.handlers.FilePut = &statusOnPut{inner: s.handlers.FilePut, prefix: prefix, code: code}
 	}
 }
 


### PR DESCRIPTION
Closes #161.

## What changed

`isRetryable` now inspects the SFTP status code behind a failure before falling
through to its default, via a new `isPermanentStatus` helper in
[retry.go](internal/uploader/retry.go).

This follows the narrowed scope from the review comment on the issue rather
than the original suggestion: the premise there was broader than the actual
failure mode, and the check confirms it.

- `pkg/sftp` v1.13.11's `normaliseError` really does turn
  `SSH_FX_NO_SUCH_FILE` into `os.ErrNotExist` and `SSH_FX_PERMISSION_DENIED`
  into `os.ErrPermission` on every client path, so the existing `errors.Is`
  arms already caught both. They are listed in the new switch anyway, with a
  comment saying why: the classification should not quietly change if that
  normalisation does.
- `ErrSSHFxNoSuchPath` from the issue's sketch is not exported by this library
  version, so it is not in the set.
- The genuinely missing codes are `SSH_FX_OP_UNSUPPORTED` and
  `SSH_FX_BAD_MESSAGE`. Both mean the server has already made up its mind; a
  retry sends the identical request over a healthy connection and gets the
  identical answer, so it only buys the backoff.
- **`SSH_FX_FAILURE` stays retryable.** It is the catch-all that quota,
  no-space and read-only-filesystem failures arrive as, but also what some
  servers return for transient problems, and only the human-readable message
  separates them. Matching on that text is fragile across implementations and
  locales, and misreading a transient failure as permanent is the worse
  mistake. `default: true` is untouched, so unknown errors keep their retry.

The second half of the issue (messages matter more than the retry count) is
handled by one clause: when a permanent status ends the retry loop early, the
failure now reads

```
uploading "dist/a.js" to "/www/a.js": sftp: "..." (SSH_FX_OP_UNSUPPORTED) (the server rejected this outright; retrying would not have helped)
```

so a run configured with `retries: 2` that made a single attempt does not look
like it silently skipped them. The server's own status line stays in front of
the clause, where it already was.

## The `session.do` question

The issue asks whether the same classification belongs on `session.do`'s ops.
It does not, and nothing changed there: `do` retries **only** on
`isConnError`, returning every other error to its caller untouched, so a
permanent server status already fails fast on that path. The upload path was
the only one spending backoff on it.

## Tests

Fault-injected, as suggested; no benchmark.

- `withStatusOnPut` in `testserver_test.go` makes the test server answer a
  write-open with one fixed status code. `pkg/sftp`'s `statusFromError` puts an
  `sftp.ErrSSHFx*` value on the wire as exactly that code, so the client turns
  it back into the `*sftp.StatusError` the classification reads.
- `TestPermanentServerStatusIsNotRetried`: an `SSH_FX_OP_UNSUPPORTED` refusal
  with `retries: 2` produces zero retry warnings, spends no backoff (the test
  runs in ~0s), and the failure carries both the server's status and the
  reason the retries did not run.
- `TestAmbiguousServerStatusStillRetries` pins the other half: `SSH_FX_FAILURE`
  still retries and is never reported as permanent. Without it, a later
  "tidy-up" could fold `FAILURE` into the permanent set and no test would
  notice.
- `TestIsRetryable` gains the status-code table, including the connection-class
  codes that must stay retryable.

## Verification

`go test -count=1 ./...` is green. `-race` could not run on this machine
("-race requires cgo", no C toolchain); CI covers the race pass.

`docs/troubleshooting.md` gains a "Which upload failures easySFTP retries"
entry, linked from the `retries` row in `docs/configuration.md`.
