### PR TITLE
fix(uploader): fall back when a server lacks posix-rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,15 @@ granularity is a separate, later decision; don't build it speculatively.
   `withDropOnRequest` closes *every* live connection, including any
   `verifyClient` session opened before the drop fires; open verification
   clients after the run, not before.
+- Simulating a **non-OpenSSH server** takes two pieces, because the fake server
+  serves `posix-rename@openssh.com` whether or not it announces it:
+  `withFailPosixRename(code)` makes the extension fail with one exact SFTP
+  status (any `sftp.ErrSSHFx*` value; plain `Rename` keeps working, so the
+  remove+rename fallback can succeed), and `unadvertisePosixRename(t)` leaves
+  the extension out of the announced list a client reads. The second mutates a
+  pkg/sftp package-level variable, so it is process-global and restores itself
+  via `t.Cleanup`; no test in this package runs in parallel, which is what
+  makes that safe.
 - A run may hold more than one connection (`advanced.connections`, issue
   #158). Only the per-file upload path spreads over them, by file index;
   `session.do` and therefore everything else always uses the first one. A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,15 @@ granularity is a separate, later decision; don't build it speculatively.
   `withDropOnRequest` closes *every* live connection, including any
   `verifyClient` session opened before the drop fires; open verification
   clients after the run, not before.
+- Simulating a **non-OpenSSH server** takes two pieces, because the fake server
+  serves `posix-rename@openssh.com` whether or not it announces it:
+  `withFailPosixRename(code)` makes the extension fail with one exact SFTP
+  status (any `sftp.ErrSSHFx*` value; plain `Rename` keeps working, so the
+  remove+rename fallback can succeed), and `unadvertisePosixRename(t)` leaves
+  the extension out of the announced list a client reads. The second mutates a
+  pkg/sftp package-level variable, so it is process-global and restores itself
+  via `t.Cleanup`; no test in this package runs in parallel, which is what
+  makes that safe.
 - A run may hold more than one connection (`advanced.connections`, issue
   #158). Only the per-file upload path spreads over them, by file index;
   `session.do` and therefore everything else always uses the first one. A

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 | [Examples & use cases](examples.md) | Copy-paste recipes: static sites, mirroring, multi-target deploys, PR previews, outputs. |
 | [Security guide](security.md) | Host key pinning, credential handling, least privilege, supply-chain safety. |
 | [Troubleshooting & FAQ](troubleshooting.md) | Common errors and what to do about them. |
-| [Provider notes](providers.md) | Host-specific ports, paths and quirks; how to find your own. |
+| [Provider notes](providers.md) | Host-specific ports, paths and quirks; how to find your own; what easySFTP needs from a server. |
 | [Migrating from Dylan700/sftp-upload-action](migration.md) | Input mapping, before/after workflow, behavior differences. |
 | [Migrating from v2 to v3](migration-v3.md) | Renamed and removed inputs, the config-file format change. |
 | [Releasing](RELEASING.md) | How releases, tags and the changelog are automated (maintainers). |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,9 +266,11 @@ before you keep it. easySFTP's own numbers live in
 
 All three are best-effort: a server that rejects the `SETSTAT` request
 produces one warning per deployment (not one per file, and not a failure), so
-a multi-deployment run shows which deployments are affected. In inline mode
-the same three settings are the `file-mode`, `dir-mode` and `preserve-times`
-[inputs](#permissions-inline-mode).
+a multi-deployment run shows which deployments are affected. Servers without
+POSIX permissions behind them reject it as a matter of course; see
+[what easySFTP needs from a server](providers.md#what-easysftp-needs-from-a-server).
+In inline mode the same three settings are the `file-mode`, `dir-mode` and
+`preserve-times` [inputs](#permissions-inline-mode).
 
 > **Windows runners:** Windows has no POSIX permission bits, so "mirror local"
 > has nothing to mirror. Go reports `0666` for every writable file and `0444`

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -12,6 +12,7 @@ missing or out of date, [add it](#adding-a-provider): the
 provider is all you need to contribute.
 
 - [First: find your own settings](#first-find-your-own-settings)
+- [What easySFTP needs from a server](#what-easysftp-needs-from-a-server)
 - [Hetzner Storage Box](#hetzner-storage-box)
 - [cPanel and similar shared webhosting](#cpanel-and-similar-shared-webhosting)
 - [Adding a provider](#adding-a-provider)
@@ -65,6 +66,65 @@ shell (very common on managed hosting, and the default on some storage
 products) is fully supported. Tools that fail on such accounts usually do so
 because they shell out to `mkdir`/`chmod`; easySFTP uses the SFTP protocol
 operations instead.
+
+## What easySFTP needs from a server
+
+"SFTP" is a family of implementations, and they do not all offer the same
+things. This section says which protocol operations easySFTP uses, which of
+them a deploy cannot work without, and what you see when one is missing. It
+describes easySFTP's own behaviour, so it holds for every server; it makes no
+claim about any particular product.
+
+It is worth reading if your server is not OpenSSH, in particular if it is a
+managed SFTP front end over object storage rather than a POSIX filesystem.
+Those are the setups where the best-effort features below are most likely to
+do nothing.
+
+**Required.** Without these a deploy cannot work at all:
+
+| Operation | Used for |
+| --- | --- |
+| SSH with the `sftp` subsystem (protocol version 3) | everything; easySFTP never opens a shell |
+| `open` / `write` / `close` | uploading file contents |
+| `rename` | moving each finished upload onto its target name |
+| `remove` | removing the temporary upload file, and deleting in `sync` / `clean` |
+| `mkdir` | creating the target tree (via `MkdirAll`, so existing directories are fine) |
+| `stat` | skip-unchanged checks, and reporting a target that exists as a file |
+| `readdir` | the stale-temp sweep, and the remote scan in `sync` / `clean` |
+| `open` / `read` on a written file | reading back the [sync manifest](strategies.md#sync) |
+
+**Best effort.** Missing these degrades a feature, never the deploy:
+
+| Feature | If the server does not have it |
+| --- | --- |
+| `posix-rename@openssh.com` | overwrites are done as remove + rename instead, which is not atomic: there is a brief window in which the target does not exist. See below. |
+| `SETSTAT` for permissions | `file-mode` and `dir-mode` do nothing. An explicit setting warns once per deployment (`could not set file-mode ... server may reject SETSTAT`); a mirrored local mode is silent. |
+| `SETSTAT` for timestamps | `preserve-times` does nothing, and warns once per deployment. |
+| `rmdir` | directories left empty by a `sync` deletion stay behind. Failures are ignored and never fail the run. |
+
+**Atomic overwrite in detail.** easySFTP uploads to a temporary sibling file
+and then replaces the target with it, preferring the
+`posix-rename@openssh.com` extension because that replacement is atomic: a
+reader of your site sees either the old file or the new one, never a partial
+one. Servers announce the extensions they implement when the SFTP session
+starts, and easySFTP uses that announcement to tell two different failures
+apart:
+
+- The server **did not announce** the extension, or answers
+  `SSH_FX_OP_UNSUPPORTED`: it does not have it. easySFTP removes the target
+  and renames the temporary file into place instead. Non-atomic, and
+  unavoidable on such a server.
+- The server **announced** it and still refuses the rename: that is a refusal
+  (a permission or policy rejection), not a missing feature. The run fails with
+  `replacing "<path>": ...` and the file already on the server is left exactly
+  as it was. easySFTP does not remove a live file to retry a rename the server
+  has already declined.
+
+**Large directories.** `sync` and `clean` list the whole target tree to work
+out what to delete. Servers that page or cap directory listings can therefore
+report fewer entries than are really there. `dry-run: true` prints the plan the
+listing produced, which is the cheapest way to see whether it matches what you
+expect.
 
 ## Hetzner Storage Box
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,7 +6,9 @@ with the log of a `dry-run: true` run.
 
 Ports, chrooted paths and "SSH has to be enabled first" are usually not
 errors but provider quirks: see [Provider notes](providers.md), which also
-explains how to find your own port, path and host key in three commands.
+explains how to find your own port, path and host key in three commands, and
+lists [what easySFTP needs from a server](providers.md#what-easysftp-needs-from-a-server)
+if yours is not OpenSSH.
 
 ## Action startup problems
 
@@ -135,6 +137,14 @@ and renames it over the target (atomic on servers supporting the
 otherwise). A hard kill mid-upload (a cancelled workflow past its grace
 period, a job timeout, a reclaimed runner) can leave such a file behind; it
 is safe to delete manually.
+
+If **every** overwrite fails this way while new files upload fine, the server
+is refusing the rename rather than lacking the extension: easySFTP only falls
+back to remove+rename on a server that does not offer atomic rename, and never
+removes a live file to retry a rename the server has already declined. Check
+write permissions on the existing target files and any policy on the server
+that forbids replacing them. See
+[what easySFTP needs from a server](providers.md#what-easysftp-needs-from-a-server).
 
 Later deploys clean these up automatically: before uploading, every run
 sweeps the directories receiving files in that run, plus the deployment's

--- a/internal/uploader/atomic_test.go
+++ b/internal/uploader/atomic_test.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"testing"
+
+	"github.com/pkg/sftp"
 
 	"github.com/eiserv/easySFTP/internal/config"
 )
@@ -17,18 +20,7 @@ func TestAtomicReplaceLeavesNoTempFile(t *testing.T) {
 	srv := startTestServer(t)
 
 	// Pre-existing live file that the upload must replace.
-	client := srv.verifyClient(t)
-	if err := client.MkdirAll("/www"); err != nil {
-		t.Fatal(err)
-	}
-	f, err := client.Create("/www/index.html")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := f.Write([]byte("old")); err != nil {
-		t.Fatal(err)
-	}
-	f.Close()
+	seedRemoteFile(t, srv, "/www", "index.html", "old")
 
 	local := t.TempDir()
 	writeTree(t, local, map[string]string{"index.html": "new"})
@@ -52,19 +44,7 @@ func TestAtomicReplaceLeavesNoTempFile(t *testing.T) {
 // left untouched (never replaced by a half-swapped upload).
 func TestRenameFailureCleansUpAndKeepsOriginal(t *testing.T) {
 	srv := startTestServer(t, withFailRename())
-
-	client := srv.verifyClient(t)
-	if err := client.MkdirAll("/www"); err != nil {
-		t.Fatal(err)
-	}
-	f, err := client.Create("/www/index.html")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := f.Write([]byte("original")); err != nil {
-		t.Fatal(err)
-	}
-	f.Close()
+	seedRemoteFile(t, srv, "/www", "index.html", "original")
 
 	local := t.TempDir()
 	writeTree(t, local, map[string]string{"index.html": "replacement"})
@@ -72,7 +52,7 @@ func TestRenameFailureCleansUpAndKeepsOriginal(t *testing.T) {
 	cfg := baseConfig(srv)
 	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
 
-	_, err = Run(context.Background(), cfg, testLogger{t})
+	_, err := Run(context.Background(), cfg, testLogger{t})
 	if err == nil || !strings.Contains(err.Error(), "replacing") {
 		t.Fatalf("expected a rename/replace error, got %v", err)
 	}
@@ -81,6 +61,137 @@ func TestRenameFailureCleansUpAndKeepsOriginal(t *testing.T) {
 	}
 	if remoteHasTmpFile(t, srv, "/www", "index.html") {
 		t.Error("temporary file was not cleaned up after the failed rename")
+	}
+}
+
+// seedRemoteFile writes content to a remote path (creating its directory),
+// standing in for a file an earlier deploy left on the server.
+func seedRemoteFile(t *testing.T, srv *testServer, dir, name, content string) {
+	t.Helper()
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	f, err := client.Create(path.Join(dir, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+}
+
+// TestPosixRenameUnsupportedFallsBack verifies the remove+rename fallback is
+// taken on a server that lacks posix-rename@openssh.com, for both answers such
+// a server gives: the protocol's SSH_FX_OP_UNSUPPORTED, and the generic
+// SSH_FX_FAILURE that non-OpenSSH implementations answer an unknown extended
+// request with. In the generic case the fallback is justified only by the
+// server not announcing the extension, so that server does not announce it
+// (issue #152).
+func TestPosixRenameUnsupportedFallsBack(t *testing.T) {
+	cases := []struct {
+		name       string
+		code       error
+		unannounce bool
+	}{
+		{"op unsupported", sftp.ErrSSHFxOpUnsupported, false},
+		{"generic failure, extension not announced", sftp.ErrSSHFxFailure, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.unannounce {
+				unadvertisePosixRename(t)
+			}
+			srv := startTestServer(t, withFailPosixRename(c.code))
+			seedRemoteFile(t, srv, "/www", "index.html", "old")
+
+			local := t.TempDir()
+			writeTree(t, local, map[string]string{"index.html": "new"})
+
+			cfg := baseConfig(srv)
+			cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+			if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+				t.Fatalf("upload failed without posix-rename: %v", err)
+			}
+			if got := readRemote(t, srv, "/www/index.html"); got != "new" {
+				t.Errorf("content not replaced: %q", got)
+			}
+			if remoteHasTmpFile(t, srv, "/www", "index.html") {
+				t.Error("temporary upload file was left behind")
+			}
+		})
+	}
+}
+
+// TestPosixRenameRefusalIsNotOverridden verifies the opposite half of the same
+// rule: a server that announces posix-rename@openssh.com and then refuses one
+// rename is refusing it, not missing the extension. Falling back there would
+// remove a live file the server was never going to let us replace, so the run
+// must fail with the target untouched. SSH_FX_FAILURE is the ambiguous code
+// (SSH_FX_PERMISSION_DENIED is unambiguous, and the client library rewrites it
+// into os.ErrPermission before renameReplace ever sees a status).
+func TestPosixRenameRefusalIsNotOverridden(t *testing.T) {
+	srv := startTestServer(t, withFailPosixRename(sftp.ErrSSHFxFailure))
+	seedRemoteFile(t, srv, "/www", "index.html", "original")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "replacement"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err == nil {
+		t.Fatal("expected the refused rename to fail the run, got nil")
+	}
+	if got := readRemote(t, srv, "/www/index.html"); got != "original" {
+		t.Errorf("live file was removed by a fallback that should not have run: %q", got)
+	}
+	if remoteHasTmpFile(t, srv, "/www", "index.html") {
+		t.Error("temporary file was not cleaned up after the refused rename")
+	}
+}
+
+// statusErr builds the error a pkg/sftp client surfaces for one SFTP status
+// code, which is the shape renameReplace has to classify.
+func statusErr(code uint32) error { return &sftp.StatusError{Code: code} }
+
+// TestPosixRenameUnsupportedClassification pins the decision itself, over
+// every status code that can reach it and both announcement states.
+func TestPosixRenameUnsupportedClassification(t *testing.T) {
+	var (
+		unsupported = statusErr(uint32(sftp.ErrSSHFxOpUnsupported))
+		failure     = statusErr(uint32(sftp.ErrSSHFxFailure))
+		badMessage  = statusErr(uint32(sftp.ErrSSHFxBadMessage))
+		connLost    = statusErr(uint32(sftp.ErrSSHFxConnectionLost))
+		noConn      = statusErr(uint32(sftp.ErrSSHFxNoConnection))
+	)
+
+	cases := []struct {
+		name      string
+		err       error
+		announced bool
+		want      bool
+	}{
+		{"op unsupported, announced", unsupported, true, true},
+		{"op unsupported, not announced", unsupported, false, true},
+		{"failure, announced", failure, true, false},
+		{"failure, not announced", failure, false, true},
+		{"bad message, announced", badMessage, true, false},
+		{"bad message, not announced", badMessage, false, true},
+		{"connection lost, not announced", connLost, false, false},
+		{"no connection, not announced", noConn, false, false},
+		// The client translates these two away before renameReplace sees them.
+		{"permission denied", os.ErrPermission, false, false},
+		{"not exist", os.ErrNotExist, false, false},
+		{"transport error", errors.New("connection lost"), false, false},
+		{"wrapped op unsupported", fmt.Errorf("rename: %w", unsupported), true, true},
+	}
+	for _, c := range cases {
+		if got := posixRenameUnsupported(c.err, c.announced); got != c.want {
+			t.Errorf("%s: posixRenameUnsupported = %v, want %v", c.name, got, c.want)
+		}
 	}
 }
 

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -403,6 +403,49 @@ func (f *faultyRename) PosixRename(r *sftp.Request) error {
 	return errors.New("injected rename failure")
 }
 
+// faultyPosixRename wraps a FileCmder and answers every posix-rename request
+// with one fixed error while leaving plain "Rename" working, simulating a
+// server that does not implement posix-rename@openssh.com. The request server
+// maps a returned sftp.ErrSSHFx* value onto exactly that status code, so a
+// test can pick which answer a non-OpenSSH server gives (issue #152).
+type faultyPosixRename struct {
+	inner sftp.FileCmder
+	code  error
+}
+
+func withFailPosixRename(code error) serverOption {
+	return func(s *testServer) {
+		s.handlers.FileCmd = &faultyPosixRename{inner: s.handlers.FileCmd, code: code}
+	}
+}
+
+func (f *faultyPosixRename) Filecmd(r *sftp.Request) error {
+	return f.inner.Filecmd(r)
+}
+
+func (f *faultyPosixRename) PosixRename(r *sftp.Request) error {
+	return f.code
+}
+
+// unadvertisePosixRename drops posix-rename@openssh.com from the extension
+// list servers announce in their SSH_FXP_VERSION packet, which is how a client
+// learns the extension is missing. pkg/sftp keeps that list in a package-level
+// variable, so this is process-global: only call it from a test that does not
+// run in parallel (no test in this package does), and note that the extension
+// is still *served* either way, so a test also needs withFailPosixRename to
+// simulate a server that really lacks it.
+func unadvertisePosixRename(t *testing.T) {
+	t.Helper()
+	if err := sftp.SetSFTPExtensions("hardlink@openssh.com", "statvfs@openssh.com"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := sftp.SetSFTPExtensions("hardlink@openssh.com", "posix-rename@openssh.com", "statvfs@openssh.com"); err != nil {
+			t.Errorf("restoring the advertised SFTP extensions: %v", err)
+		}
+	})
+}
+
 // faultySetstat wraps a FileCmder and fails every chmod (Setstat) request,
 // simulating a server that rejects SETSTAT, delegating everything else to the
 // real in-memory handler.

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -248,6 +248,11 @@ func uploadFile(ctx context.Context, env *transferEnv, f fileItem, index int, mo
 	return n, nil
 }
 
+// posixRenameExt is the OpenSSH extension that makes a rename replace an
+// existing target atomically. Servers announce the extensions they implement
+// in their SSH_FXP_VERSION packet, which pkg/sftp records per connection.
+const posixRenameExt = "posix-rename@openssh.com"
+
 // renameReplace atomically moves tmp onto final. It prefers the
 // posix-rename@openssh.com extension (a true atomic overwrite) and falls back
 // to a plain remove+rename for servers that do not support it.
@@ -256,14 +261,49 @@ func renameReplace(client *sftp.Client, tmp, final string) error {
 	if err == nil {
 		return nil
 	}
-	var se *sftp.StatusError
-	if !errors.As(err, &se) || se.FxCode() != sftp.ErrSSHFxOpUnsupported {
+	_, announced := client.HasExtension(posixRenameExt)
+	if !posixRenameUnsupported(err, announced) {
 		return err
 	}
 	// note: non-atomic fallback, a brief window where final is missing.
 	// Only reached on servers lacking posix-rename; unavoidable there.
 	_ = client.Remove(final)
 	return client.Rename(tmp, final)
+}
+
+// posixRenameUnsupported reports whether a failed posix-rename@openssh.com
+// request means "this server does not implement the extension" rather than
+// "the server refused this particular rename". Only the first justifies the
+// non-atomic remove+rename fallback: falling back on a refusal would remove a
+// live file the server was never going to let us replace (issue #152).
+//
+// SSH_FX_OP_UNSUPPORTED is the answer the protocol asks for, and OpenSSH gives
+// it. Other implementations answer an unknown extended request with the
+// generic SSH_FX_FAILURE (or, when they reject the packet itself,
+// SSH_FX_BAD_MESSAGE), which on its own is indistinguishable from a policy or
+// permission rejection. The server's own extension announcement breaks the
+// tie: a server that never announced posix-rename was never asked a question
+// it advertised being able to answer, so a generic failure there is the
+// extension missing. A server that did announce it and then fails generically
+// is refusing the rename, and that error is returned unchanged.
+//
+// Codes the client library translates away (SSH_FX_NO_SUCH_FILE and
+// SSH_FX_PERMISSION_DENIED become os.ErrNotExist / os.ErrPermission and carry
+// no *sftp.StatusError) therefore never reach the fallback either, which is
+// what we want: both name a rename the server understood and declined.
+func posixRenameUnsupported(err error, announced bool) bool {
+	var se *sftp.StatusError
+	if !errors.As(err, &se) {
+		return false
+	}
+	switch se.FxCode() {
+	case sftp.ErrSSHFxOpUnsupported:
+		return true
+	case sftp.ErrSSHFxFailure, sftp.ErrSSHFxBadMessage:
+		return !announced
+	default:
+		return false
+	}
 }
 
 // cleanupTmp best-effort removes a leftover temp file, warning (but not


### PR DESCRIPTION
Closes #152 for the first two of its three suggested steps: the documentation, and the `renameReplace` fallback plus tests. The third (a non-OpenSSH container in CI) is deliberately not in here; see the last section.

## The bug

`renameReplace` (`internal/uploader/transfer.go`) prefers `posix-rename@openssh.com` and fell back to remove+rename only when the server answered `SSH_FX_OP_UNSUPPORTED`. That is the answer the protocol asks for and the one OpenSSH gives, but other implementations answer an unknown extended request with the generic `SSH_FX_FAILURE`. On such a server every overwrite of an existing file failed with `replacing "<path>": ...`, so first deploys worked and every later one broke. That is the interop break the issue calls the most likely one, and it hits the atomic overwrite that is the point of the whole upload path.

## The fix

Broadening the fallback to any failure would be worse than the bug: remove+rename is not atomic, and a generic failure can equally mean the server refused this particular rename on permission or policy grounds. Falling back there would delete a live file the server was never going to let us replace.

The server's own extension announcement breaks the tie. Servers list the extensions they implement in their `SSH_FXP_VERSION` packet, and pkg/sftp records that per connection (`client.HasExtension`). So:

| Answer | Extension announced | Behaviour |
| --- | --- | --- |
| `SSH_FX_OP_UNSUPPORTED` | either | fall back to remove+rename (unchanged) |
| `SSH_FX_FAILURE` / `SSH_FX_BAD_MESSAGE` | no | fall back: the server was never asked a question it advertised being able to answer |
| `SSH_FX_FAILURE` / `SSH_FX_BAD_MESSAGE` | yes | **new**: a refusal, not a missing feature. Run fails, target untouched |
| anything else | either | returned unchanged |

`SSH_FX_NO_SUCH_FILE` and `SSH_FX_PERMISSION_DENIED` never reach the decision at all: pkg/sftp translates them into `os.ErrNotExist` / `os.ErrPermission`, which carry no `*sftp.StatusError`. Both name a rename the server understood and declined, so dropping out is the right outcome anyway; the code says so rather than relying on it silently.

The decision lives in `posixRenameUnsupported(err, announced)`, a pure function, so all of it is pinned by a table test.

## Tests

Simulating a non-OpenSSH server needs two new pieces, because pkg/sftp's fake server serves the extension whether or not it announces it:

- `withFailPosixRename(code)` answers posix-rename with one exact SFTP status while leaving plain `Rename` working, so the fallback can actually complete.
- `unadvertisePosixRename(t)` drops the extension from the announced list. It mutates a pkg/sftp package-level variable, so it is process-global and restores itself in `t.Cleanup`; no test in this package runs in parallel, which is what makes that safe. Documented in `AGENTS.md` / `CLAUDE.md` next to the other fault injectors.

With those:

- `TestPosixRenameUnsupportedFallsBack` (two subtests): the overwrite succeeds and leaves no temp file, both for `SSH_FX_OP_UNSUPPORTED` and for a generic failure from a server that does not announce the extension. The second subtest fails on `main` with exactly the error from the issue.
- `TestPosixRenameRefusalIsNotOverridden`: an announcing server that refuses the rename fails the run and leaves the existing file byte-for-byte as it was. This is the guard against "fix it by broadening blindly" later.
- `TestPosixRenameUnsupportedClassification`: the decision itself over every status code that can reach it, both announcement states, plus wrapped and translated errors.

`go test ./...` is green. `-race` could not run locally (no C toolchain: "-race requires cgo"), so the race pass is on CI.

## Docs

New section in `docs/providers.md`, "What easySFTP needs from a server": the protocol operations a deploy cannot work without, the ones that are best effort with the exact symptom when each is missing (permissions and timestamps warn once per deployment, `rmdir` failures are ignored), the atomic-overwrite rule above spelled out, and a note that `sync` / `clean` list the whole target tree. It describes easySFTP's own behaviour only and names no product, so the evidence-only rule for provider entries is untouched.

Linked from `docs/troubleshooting.md` (the `replacing "<path>"` entry now distinguishes "server has no atomic rename" from "server is refusing the rename", which is the one a user can act on), from the permissions section of `docs/configuration.md`, and from the docs index.

## Not in here

The third suggested step, a `ProFTPD mod_sftp` container in the self-test, is left out on purpose. The protocol-level tests above cover the concrete break at the level it happens, and a second container is only worth its maintenance if it catches something they cannot. Worth deciding separately, with #152 kept open for it if wanted.
