### PR TITLE
ci(benchmark): sweep and draw every release, and give the runs room to finish

### DIFF
--- a/.github/workflows/benchmark-analysis.yml
+++ b/.github/workflows/benchmark-analysis.yml
@@ -1,0 +1,201 @@
+name: Benchmark analysis
+
+# Draws the stored benchmark documents and publishes the figures.
+#
+# benchmarks/analysis/ is the optional Python layer: it reads the canonical
+# files the Go harness wrote (results.json, matrix.json, the CSVs, trend.csv)
+# and draws the grid, the scaling curves, the policy regret, the canary, the
+# phase and operation breakdowns, the delete sweeps, the link control and the
+# release trend. It is a reading of the data and never an input to it, so
+# nothing here can change what was measured or what is stored.
+#
+# Two ways in:
+#   workflow_dispatch  redraw at any time, optionally for one release tag.
+#   workflow_call      release-please.yml calls this last, after the release's
+#                      standard benchmark and after the release sweep have both
+#                      committed their results to main. That ordering is the
+#                      whole point: the figures are drawn from the numbers of
+#                      the release that just happened, not from the previous
+#                      one.
+#
+# Where the output goes: a workflow artifact for anyone reading the run, and,
+# for a release, one zip attached to the GitHub Release next to the benchmark
+# JSON and Markdown that benchmark.yml already puts there. Deliberately not a
+# commit: benchmarks/analysis/README.md says plots are a reading of the stored
+# data and are not committed by default, and a full set of figures per release
+# would add megabytes of binary history for something the release page can hold
+# instead.
+#
+# GitHub-hosted, unlike the two measuring workflows: this touches no server, so
+# it has no business on the self-hosted runner.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: "Release tag to draw and attach the figures to (e.g. v3.5.0). Empty draws the newest stored result and attaches nothing."
+        required: false
+        default: ""
+        type: string
+      matrix-result:
+        description: "Path of a stored sweep to draw, relative to the repository root. Empty picks the release's own sweep, or the newest stored one."
+        required: false
+        default: ""
+        type: string
+  workflow_call:
+    inputs:
+      release-version:
+        description: "Tag of the release whose result and sweep are drawn."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Draw the stored results
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Only the release path writes, and only as a release asset.
+      contents: write
+    steps:
+      # main, not the ref this was started from: the results were committed to
+      # main by the measuring runs this job follows, and there is nothing to
+      # draw anywhere else.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: benchmarks/analysis/requirements.txt
+
+      - name: Install the analysis dependencies
+        run: pip install -r benchmarks/analysis/requirements.txt
+
+      - name: Choose what to draw
+        id: inputs
+        env:
+          # Through the environment, never interpolated into the script: these
+          # are user input, and "${{ }}" in a run block is a shell injection.
+          VERSION: ${{ inputs.release-version }}
+          MATRIX_INPUT: ${{ inputs.matrix-result }}
+        run: |
+          set -euo pipefail
+          if [ -n "${VERSION:-}" ]; then
+            case "$VERSION" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "::error::release-version must look like v3.3.0, got '$VERSION'"
+              exit 1
+              ;;
+            esac
+          fi
+
+          paths=""
+          if [ -n "${VERSION:-}" ]; then
+            if [ -f "benchmarks/releases/release-$VERSION.json" ]; then
+              paths="benchmarks/releases/release-$VERSION.json"
+            else
+              # Not fatal: the sweep and the trend are still worth drawing, and
+              # a release whose standard run failed is exactly when someone
+              # wants to look.
+              echo "::warning::no stored release result for $VERSION; drawing what is there"
+            fi
+          fi
+
+          sweep=""
+          if [ -n "${MATRIX_INPUT:-}" ]; then
+            if [ ! -f "$MATRIX_INPUT" ]; then
+              echo "::error::matrix-result '$MATRIX_INPUT' does not exist on main"
+              exit 1
+            fi
+            sweep=$MATRIX_INPUT
+          else
+            # The release's own sweep first: it carries the tag as its label.
+            # The stamps sort chronologically, so the last line is the newest.
+            if [ -n "${VERSION:-}" ]; then
+              sweep=$(ls -1 "benchmarks/matrix/matrix-"*"-$VERSION.json" 2>/dev/null | tail -1 || true)
+            fi
+            if [ -z "$sweep" ]; then
+              sweep=$(ls -1 benchmarks/matrix/matrix-*.json 2>/dev/null | tail -1 || true)
+            fi
+          fi
+          if [ -n "$sweep" ]; then
+            paths="$paths $sweep"
+          fi
+
+          echo "paths=$paths" >> "$GITHUB_OUTPUT"
+          echo "drawing: ${paths:-the newest stored result of each kind}"
+
+      - name: Draw everything the stored results support
+        env:
+          PATHS: ${{ steps.inputs.outputs.paths }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/analysis"
+          # Unquoted on purpose: PATHS is a space separated list this workflow
+          # built itself out of files it checked exist, and an empty one has to
+          # collapse to nothing so plot.py falls back to the newest stored
+          # result of each kind.
+          # shellcheck disable=SC2086
+          python benchmarks/analysis/plot.py report $PATHS --out "$RUNNER_TEMP/analysis"
+
+      - name: Summarise what was drawn
+        if: always()
+        run: |
+          set -euo pipefail
+          report=$RUNNER_TEMP/analysis/report.md
+          {
+            echo "## Benchmark analysis"
+            echo
+            echo "Figures drawn from the results stored on main. The images are in this"
+            echo "run's artifact; a release also gets them as an asset on its release page."
+            echo
+            if [ -f "$report" ]; then
+              echo "Sources:"
+              echo
+              grep '^- ' "$report" || true
+              echo
+              echo "| Figure |"
+              echo "|---|"
+              for file in "$RUNNER_TEMP"/analysis/*; do
+                echo "| \`$(basename "$file")\` |"
+              done
+            else
+              echo "Nothing was drawn."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the figures
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-analysis-${{ github.run_id }}
+          path: ${{ runner.temp }}/analysis
+          if-no-files-found: warn
+
+      - name: Attach the figures to the release
+        if: inputs.release-version != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.release-version }}
+        run: |
+          set -euo pipefail
+          # One asset and not a dozen: the release page already carries the
+          # benchmark JSON, Markdown and CSV, and a wall of PNG rows next to
+          # them helps nobody.
+          ( cd "$RUNNER_TEMP/analysis" && zip -q -r "$RUNNER_TEMP/benchmark-analysis-$VERSION.zip" . )
+          gh release upload "$VERSION" "$RUNNER_TEMP/benchmark-analysis-$VERSION.zip" \
+            --clobber --repo "$GITHUB_REPOSITORY"
+
+      # The self-checks load every result committed under benchmarks/, so this
+      # is where a stored document the analysis layer cannot read surfaces: on
+      # the day it was stored, not on the day someone needs the picture.
+      - name: Run the analysis self-checks
+        if: always()
+        run: python -m unittest discover -s benchmarks/analysis

--- a/.github/workflows/benchmark-analysis.yml
+++ b/.github/workflows/benchmark-analysis.yml
@@ -161,11 +161,16 @@ jobs:
               echo
               grep '^- ' "$report" || true
               echo
-              echo "| Figure |"
-              echo "|---|"
-              for file in "$RUNNER_TEMP"/analysis/*; do
-                echo "| \`$(basename "$file")\` |"
-              done
+              # Counted per kind, not listed one by one: a sweep over every
+              # scenario draws dozens of heatmaps, and a wall of file names is
+              # not a summary.
+              echo "| Figure | Files |"
+              echo "|---|---|"
+              ls "$RUNNER_TEMP/analysis" | grep -e '.png$' | cut -d- -f1 |
+                sort | uniq -c |
+                while read -r count kind; do
+                  echo "| $kind | $count |"
+                done
             else
               echo "Nothing was drawn."
             fi

--- a/.github/workflows/benchmark-matrix.yml
+++ b/.github/workflows/benchmark-matrix.yml
@@ -9,10 +9,26 @@ name: SFTP benchmark matrix
 # advanced.concurrency and stores one cell per combination, so the result can
 # be read as a heatmap instead of as a single number.
 #
-# Manual only, and never official: a matrix result is a settings sweep, so it
-# is stored as kind "matrix" and can never become latest.*. It shares the
-# "sftp-benchmark" concurrency group with benchmark.yml, since both measure the
-# same host and two of them at once would measure each other.
+# Never official: a matrix result is a settings sweep, so it is stored as kind
+# "matrix" and can never become latest.*, no matter which ref it measured.
+#
+# Two ways in:
+#   workflow_dispatch  a manual sweep of any ref, with the axes as inputs so a
+#                      quick look can stay a quick look.
+#   workflow_call      release-please.yml calls this after the release's
+#                      standard run, so a release is described by a whole grid
+#                      over every use case the harness knows and not only by
+#                      the default cell. The standard result stays the official
+#                      reference; this one is filed next to it under the tag as
+#                      its label.
+#
+# Concurrency: a manual sweep joins the "sftp-benchmark" group that benchmark.yml
+# uses, since both measure the same host and two of them at once would measure
+# each other. The release sweep takes a group of its own. A called workflow runs
+# inside its caller's run, and the release run already holds that group through
+# the standard benchmark it called first, so queueing the sweep behind it would
+# be a job waiting for its own run to end. Ordering there comes from "needs:" in
+# release-please.yml, which is stricter than a queue anyway.
 #
 # Cost: the grid is per scenario, not global. An axis value above a scenario's
 # file count is the same configuration under another name, and
@@ -96,20 +112,90 @@ on:
         required: false
         default: "22"
         type: string
+  # The release sweep. Its defaults are the "all use cases" grid: every
+  # scenario the harness knows, over the axes each payload can actually use,
+  # measured twice. That is hours of runner time per release, which is what the
+  # timeout below is for, and it is the reason the release still gets its cheap
+  # three-scenario standard number from benchmark.yml as well.
+  workflow_call:
+    inputs:
+      candidate-ref:
+        description: "Ref to sweep. release-please.yml passes the tag it just created, which also becomes the stored label."
+        required: true
+        type: string
+      scenarios:
+        description: "Scenarios to sweep. The default is every use case the harness knows: flat and deep trees, a redeploy, a sync, one huge file and the calibration payload."
+        required: false
+        default: "small mixed large single redeploy sync deep bulk calib-100x64k"
+        type: string
+      connections:
+        description: "advanced.connections values to sweep, space separated."
+        required: false
+        default: "1 2 4 8"
+        type: string
+      concurrency:
+        description: "advanced.concurrency values to sweep, space separated. Each scenario is swept over the values its file count can use."
+        required: false
+        default: "1 2 4 8 16 32 64"
+        type: string
+      request-concurrency:
+        description: "Third axis (advanced.request_concurrency), space separated. The token 'default' is a pass that sets nothing."
+        required: false
+        default: "1 16 64"
+        type: string
+      link-profiles:
+        description: "Optional network axis, space separated. Empty = the real line only. Every profile multiplies the whole grid, and shaping needs tc plus NET_ADMIN on the runner."
+        required: false
+        default: ""
+        type: string
+      link-iface:
+        description: "Interface to shape. Empty derives it from the route to the benchmark host."
+        required: false
+        default: ""
+        type: string
+      repeats:
+        description: "Measured repeats per cell; the median is reported. Two is the smallest number that still yields a MAD."
+        required: false
+        default: "2"
+        type: string
+      store:
+        description: "Commit the result to benchmarks/matrix/ on main."
+        required: false
+        default: true
+        type: boolean
+      remote-base:
+        description: "Remote directory the benchmark owns. Everything below it is disposable."
+        required: false
+        default: "/easysftp-benchmark"
+        type: string
+      port:
+        description: "SFTP port of the benchmark server."
+        required: false
+        default: "22"
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: sftp-benchmark
+  # See the header. "push" is only ever release-please.yml calling this
+  # workflow; nothing else can reach it with that event name.
+  group: sftp-benchmark${{ github.event_name == 'push' && format('-release-{0}', github.run_id) || '' }}
   cancel-in-progress: false
 
 jobs:
   matrix:
     name: Sweep connections against concurrency
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 360
-    environment: benchmark
+    # A day. The release sweep covers every scenario over every axis value its
+    # payload can use, which is thousands of measured deployments, and the six
+    # hours this used to allow are less than a full sweep has taken since the
+    # grid grew (the stored 2026-08-16 run measured for 11h25m). A timeout that
+    # cuts a sweep in half throws away the whole run, not half of it.
+    timeout-minutes: 1440
+    # Same gate as benchmark.yml: a manual sweep waits for a maintainer, the
+    # automatic post-release one must not, or every release stalls on a click.
+    environment: ${{ github.event_name == 'push' && 'benchmark-release' || 'benchmark' }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -141,7 +141,13 @@ jobs:
     # The one job in this repo on the self-hosted runner. Everything else stays
     # on GitHub-hosted runners; see the "Self-hosted runner" note in the header.
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 60
+    # Six hours, not the one hour this used to have. A standard run of the
+    # three fixed scenarios takes minutes, but the timeout is what decides
+    # whether a heavier scenario set, more repeats or a second link profile can
+    # be asked for at all, and a measurement killed halfway is worth nothing.
+    # The sweep next door (benchmark-matrix.yml) gets a whole day for the same
+    # reason.
+    timeout-minutes: 360
     # The maintainer gate issue #169 asks for. See the header: protect
     # "benchmark" with required reviewers, leave "benchmark-release" open.
     # "push" is only ever release-please.yml calling this workflow; a manual

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -100,4 +100,6 @@ jobs:
     uses: ./.github/workflows/benchmark-analysis.yml
     with:
       release-version: ${{ needs.release-please.outputs.tag_name }}
-    secrets: inherit
+    # No "secrets: inherit": this job reads committed files and uploads one
+    # release asset with the job token. It needs no server credentials, so it
+    # is not given any.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,3 +54,50 @@ jobs:
     with:
       release-version: ${{ needs.release-please.outputs.tag_name }}
     secrets: inherit
+
+  # The same tag, swept. The job above measures the default cell and that stays
+  # the release's official number; this one measures every scenario the harness
+  # knows over the axis values each payload can use, so a release also says how
+  # the settings behave and not only how one of them did. It is stored as kind
+  # "matrix" under the tag as its label, which can never become latest.*.
+  #
+  # After the standard run, not next to it: both measure the same host, and two
+  # of them at once would measure each other. That is also why "needs" and not
+  # a shared concurrency group; see the header of benchmark-matrix.yml.
+  # "cancelled" is the one result that does not continue: a maintainer stopping
+  # the standard run is not an invitation to start a sweep of several hours.
+  benchmark-matrix:
+    name: Sweep the released tag
+    needs: [release-please, benchmark]
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.release-please.outputs.release_created == 'true' &&
+      needs.benchmark.result != 'cancelled'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/benchmark-matrix.yml
+    with:
+      candidate-ref: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit
+
+  # Last, and on a GitHub-hosted runner: the figures are drawn from what the
+  # two jobs above committed to main, so this has to follow both of them, and
+  # it contacts no server. A cancelled or failed measurement is not a reason to
+  # skip it, since drawing whatever is stored is exactly what someone wants
+  # then.
+  benchmark-analysis:
+    name: Draw the released tag
+    needs: [release-please, benchmark, benchmark-matrix]
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/benchmark-analysis.yml
+    with:
+      release-version: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,12 @@ granularity is a separate, later decision; don't build it speculatively.
   run, so such a job silently never runs (v3.3.0 shipped without its benchmark
   that way). Post-release work is a `uses:` call from `release-please.yml`,
   gated on `needs.release-please.outputs.release_created`, as
-  `release-binaries` and `benchmark` both do.
+  `release-binaries`, `benchmark`, `benchmark-matrix` and `benchmark-analysis`
+  all do. The last three run in that order via `needs:`: the first two measure
+  the same host, and the third reads what they committed. A called workflow
+  runs inside the caller's run, which is why the release sweep takes a
+  concurrency group of its own instead of queueing behind a group that same run
+  already holds.
 - The self-test job in `.github/workflows/ci.yml` is the only place a real
   OpenSSH server is exercised, and the only place `action.yml`'s composite
   wiring runs end to end. Unit tests set `EASYSFTP_*` directly and never see
@@ -299,9 +304,17 @@ path: the byte-counting `net.Conn` must never end up in a production transfer.
 Phases are wall clock, operation samples are cumulative across the parallel
 upload workers; do not present the two as the same kind of number.
 
+A release is measured twice: `benchmark.yml` produces the official number at
+the default settings, and `benchmark-matrix.yml` sweeps the same tag over every
+scenario, stored under the tag as a *matrix* result. The three store invariants
+still hold, and the second of them is why a release sweep can never become
+`latest.*` no matter what its label says.
+
 `benchmarks/analysis/` is the optional Python layer that reads those documents
 and draws them (`benchdata.py` knows the schema, `plot.py` draws,
-`test_plot.py` checks both offline). It consumes canonical files only and must
+`test_plot.py` checks both offline). `benchmark-analysis.yml` runs it after
+every release and publishes the figures as a release asset; that is the only
+automated consumer, and it must stay a consumer. It consumes canonical files only and must
 never become an input to the harness. Two rules make it survive the stored
 history: every field it reads is optional, because the results on disk span
 several schema versions, and every figure prints its provenance plus the

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -415,7 +415,12 @@ existed) are empty rather than zero.
   ones and are clearly named, but they never become a reference.
 - **Matrix** results are `kind: "matrix"`. They sweep settings a normal deploy
   does not use, so they answer a different question than a release number does
-  and can never become one.
+  and can never become one. A release produces one of these too, labelled with
+  its tag (`matrix/matrix-<stamp>-vX.Y.Z.*`): the official number says how the
+  release behaved at the default cell, the sweep next to it says how it behaves
+  across the settings and across every scenario. The label being a version
+  changes nothing about the kind, so it stays out of `latest.*` and out of
+  `trend.csv` like every other sweep.
 - Release PRs are benchmarked once when they open, so the numbers are visible
   before the merge. That run stores nothing: its result belongs to a release
   that does not exist yet. The official file is the post-tag measurement.
@@ -516,6 +521,36 @@ per-scenario grid").
 
 Setting `request-concurrency` to the single token `default` turns that axis off
 again, which is the grid every result before issue #184 phase 5 was measured on.
+
+### What a release measures
+
+Nothing is triggered by the release event itself; each of these is a `uses:`
+call from `release-please.yml`, gated on the release actually having been
+created, for the reason in that file's comment. They run in order, because the
+first two measure the same host:
+
+1. **`SFTP benchmark`** measures the tag at the default settings and stores the
+   official reference (`releases/release-vX.Y.Z.*`, copied to `latest.*`, and
+   attached to the GitHub Release).
+2. **`SFTP benchmark matrix`** sweeps the same tag over every scenario the
+   harness knows, with the axes reduced per scenario as described above, and
+   stores it under the tag as a matrix result. That is hours of measuring, which
+   is why the job may take a day; the release itself does not wait for any of
+   it.
+3. **`Benchmark analysis`** draws both of them with the optional Python layer
+   and uploads the figures as a run artifact plus one
+   `benchmark-analysis-vX.Y.Z.zip` on the release page. It runs on a
+   GitHub-hosted runner, contacts nothing, and reads only what the two jobs
+   above committed here.
+
+A release whose standard run failed still gets its sweep, and a release whose
+sweep failed still gets its figures: the later jobs read whatever is stored
+rather than requiring the earlier ones to have succeeded. Only a *cancelled*
+standard run stops the sweep, since someone stopping a measurement by hand did
+not mean to start a longer one.
+
+Each of the three can also be started by hand from the Actions tab, which is how
+a release that missed one is repaired.
 
 ### About `connections` above `concurrency`
 

--- a/benchmarks/analysis/README.md
+++ b/benchmarks/analysis/README.md
@@ -23,6 +23,15 @@ JSON disagree, the JSON is right. Do not commit generated plots by default;
 commit one only when a document refers to it. The gallery below is that
 exception, and the commands under it regenerate exactly those files.
 
+Every release draws itself. The `Benchmark analysis` workflow
+([`.github/workflows/benchmark-analysis.yml`](../../.github/workflows/benchmark-analysis.yml))
+runs `plot.py report` after the release's standard benchmark and its sweep have
+both stored their results, and publishes the figures as a run artifact and as
+`benchmark-analysis-vX.Y.Z.zip` on the release page. Published rather than
+committed, for the reason above. The same workflow can be started by hand for
+any stored release or sweep, and it runs the self-checks below afterwards, so a
+stored document this layer cannot read surfaces on the day it was stored.
+
 ```
 benchdata.py    reads the stored documents; knows the schema, not matplotlib
 plot.py         draws; one function per command

--- a/benchmarks/analysis/plot.py
+++ b/benchmarks/analysis/plot.py
@@ -1362,6 +1362,22 @@ REPORT_SECTIONS = [
 ]
 
 
+def source_label(path):
+    """How a source is named in the index: its path inside the repository.
+
+    Resolved first, because a path given on the command line is normally
+    relative to the working directory ("benchmarks/latest.json") while the
+    fallbacks are absolute, and comparing the two forms directly is what used
+    to make `report` raise on exactly the invocation the documentation shows.
+    A file from outside the repository keeps the name it was given.
+    """
+    given = Path(path)
+    try:
+        return given.resolve().relative_to(bench.REPO).as_posix()
+    except ValueError:
+        return given.as_posix()
+
+
 def report(args):
     """Every plot the given files support, plus a Markdown index of them."""
     paths = args.paths or [bench.newest_release_json(), bench.newest_matrix_json()]
@@ -1411,7 +1427,7 @@ def report(args):
         "",
     ]
     for path in paths:
-        lines.append(f"- `{Path(path).relative_to(bench.REPO).as_posix()}`")
+        lines.append(f"- `{source_label(path)}`")
     lines.append("")
 
     for name, title, description in REPORT_SECTIONS:

--- a/benchmarks/analysis/test_plot.py
+++ b/benchmarks/analysis/test_plot.py
@@ -225,6 +225,30 @@ class Commands(unittest.TestCase):
                 if path.suffix == ".png":
                     self.assertIn(path.name, text, "an image the index does not list")
 
+    def test_report_names_its_sources_however_they_were_given(self):
+        # The paths a caller passes are normally relative to the working
+        # directory (the documented commands and the release workflow both do
+        # that), while the fallbacks are absolute. Both have to end up as the
+        # same repository path in the index.
+        absolute = bench.newest_release_json()
+        relative = absolute.relative_to(bench.REPO)
+        expected = relative.as_posix()
+        self.assertEqual(plot.source_label(absolute), expected)
+        self.assertEqual(plot.source_label(relative), expected)
+
+        with tempfile.TemporaryDirectory() as directory:
+            written = plot.report(
+                options(
+                    directory,
+                    paths=[relative],
+                    scenario=["small"],
+                    profile=["baseline"],
+                )
+            )
+            index = Path(directory) / "report.md"
+            self.assertIn(index, written)
+            self.assertIn(expected, index.read_text(encoding="utf-8"))
+
     def test_a_filter_that_matches_nothing_draws_nothing(self):
         with tempfile.TemporaryDirectory() as directory:
             self.assertEqual(

--- a/internal/uploader/planner_bench_test.go
+++ b/internal/uploader/planner_bench_test.go
@@ -1,0 +1,122 @@
+package uploader
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// What the local hashing pool costs at a given worker count, which is the
+// question issue #155 asks: advanced.concurrency bounds the network upload pool
+// and, through hashPlanFiles, the local hashing pool as well, so a user who
+// sets "concurrency: 1" because their server dislikes parallel writes also
+// hashes their tree one file at a time.
+//
+// A local benchmark and not an extension of the SFTP matrix, because hashing
+// never touches the server: mixing it into a measurement that does would bury
+// the effect under network variance. The SFTP side of the same question is the
+// "sync" scenario of cmd/easysftp-bench, whose stored runs report a "hash"
+// phase next to the rest of a deployment.
+//
+//	go test ./internal/uploader -run '^$' -bench BenchmarkHashPlanFiles -benchtime 1x
+//
+// Two things to know before reading a number out of this. The payload is
+// written immediately before it is hashed, so on a machine with room to cache
+// it this measures CPU and not storage, which is the friendliest case
+// parallelism can get; and SHA-256 runs on dedicated instructions on most
+// current CPUs, so the per-core throughput is high enough that a small payload
+// is dominated by the walk around it rather than by the hashing.
+func BenchmarkHashPlanFiles(b *testing.B) {
+	payloads := []struct {
+		name  string
+		count int
+		size  int64
+	}{
+		// The CI case, and the payload of the "sync" benchmark scenario.
+		{"500x4KiB", 500, 4 << 10},
+		// A built site with assets.
+		{"200x1MiB", 200, 1 << 20},
+		// Large enough for the hashing itself to be the whole cost, which is
+		// the shape issue #155 is about (a media or artifact deploy).
+		{"32x32MiB", 32, 32 << 20},
+	}
+
+	for _, payload := range payloads {
+		dir := b.TempDir()
+		files := writeHashPayload(b, dir, payload.count, payload.size)
+		total := payload.size * int64(payload.count)
+
+		// GOMAXPROCS is the value issue #155 suggests hashing should use
+		// instead of the transfer setting; it is measured alongside the fixed
+		// counts rather than instead of them.
+		workers := []int{1, 2, 4, 8}
+		if procs := runtime.GOMAXPROCS(0); procs > 0 {
+			workers = append(workers, procs)
+		}
+		seen := map[int]bool{}
+		for _, count := range workers {
+			if seen[count] {
+				continue
+			}
+			seen[count] = true
+			name := fmt.Sprintf("%s/workers-%d", payload.name, count)
+			b.Run(name, func(b *testing.B) {
+				b.SetBytes(total)
+				b.ReportAllocs()
+				for b.Loop() {
+					if err := hashPlanFiles(context.Background(), files, count, nil); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// writeHashPayload lays out count files of size bytes and returns them as the
+// planner would. The content is pseudo-random from a fixed seed: identical on
+// every machine and every run, and not compressible by a filesystem that might
+// otherwise make one payload cheaper to read than another.
+func writeHashPayload(b *testing.B, dir string, count int, size int64) []fileItem {
+	b.Helper()
+
+	block := make([]byte, 1<<20)
+	source := rand.New(rand.NewSource(1))
+	for i := range block {
+		block[i] = byte(source.Intn(256))
+	}
+
+	files := make([]fileItem, count)
+	for i := range files {
+		path := filepath.Join(dir, fmt.Sprintf("file-%04d.bin", i))
+		f, err := os.Create(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for written := int64(0); written < size; {
+			chunk := int64(len(block))
+			if remaining := size - written; remaining < chunk {
+				chunk = remaining
+			}
+			n, err := f.Write(block[:chunk])
+			if err != nil {
+				f.Close()
+				b.Fatal(err)
+			}
+			written += int64(n)
+		}
+		if err := f.Close(); err != nil {
+			b.Fatal(err)
+		}
+		files[i] = fileItem{
+			localPath: path,
+			rel:       fmt.Sprintf("file-%04d.bin", i),
+			size:      size,
+		}
+	}
+	return files
+}


### PR DESCRIPTION
## What

Three changes to how benchmarks run, plus the local benchmark that issue #155
asked for.

**Every release is now swept, not only sampled.** `release-please.yml` calls
three workflows in order after a release: `benchmark.yml` as before (the
official number at the default settings), then `benchmark-matrix.yml` over the
same tag, then `benchmark-analysis.yml`. The sweep's default scenario set is
every use case the harness knows (`small mixed large single redeploy sync deep
bulk calib-100x64k`) with the axes reduced per scenario as `scenario.AxisFor`
already does, so a release says how the settings behave and not only how one
cell of them did. It is stored as `kind: "matrix"` under the tag as its label,
so all three store invariants hold: `latest.*` stays a copy of the standard
release result, and a sweep is never official.

**The timeouts were too small for the sweeps that already happen.** The matrix
job goes from 6 hours to 24 (the stored 2026-08-16 sweep measured for 11h25m,
so its own timeout would have thrown the whole run away), and the standard job
from 1 hour to 6, which is what makes a heavier scenario set or a second link
profile askable for at all.

**The analysis runs at release, on the release's own data.**
`.github/workflows/benchmark-analysis.yml` runs `plot.py report` after both
measuring jobs have committed their results to main, uploads the figures as a
run artifact and attaches `benchmark-analysis-vX.Y.Z.zip` to the release page,
next to the benchmark JSON/MD/CSV already there. It runs the analysis
self-checks afterwards, which load every result committed under `benchmarks/`,
so a stored document the Python layer cannot read surfaces on the day it was
stored. It runs on a GitHub-hosted runner: it contacts no server and has no
business on the self-hosted one.

Published rather than committed, deliberately: `benchmarks/analysis/README.md`
says plots are a reading of the stored data and are not committed by default,
and a full set of figures per release would add megabytes of binary history for
something the release page can hold. Say the word if you would rather have the
committed gallery refreshed automatically instead, and I will add that.

### Two fixes found on the way

- `plot.py report` raised `ValueError` on a **relative** path, which is the
  form the documented commands and the new workflow both use: it compared the
  path as given against an absolute repository root. Resolved first now, with a
  regression test.
- `internal/uploader/planner_bench_test.go` measures `hashPlanFiles` at 1, 2, 4,
  8 and `GOMAXPROCS` workers over three payload shapes. That is the local half
  of issue #155, which the SFTP matrix structurally cannot answer.

## Why the concurrency group of the release sweep differs

A called workflow runs inside its caller's run. The release run already holds
`sftp-benchmark` through the standard benchmark it called first, so queueing
the sweep behind that group would be a job waiting for its own run to end. The
ordering that matters (never two measurements against the shared host at once)
comes from `needs:` in `release-please.yml` instead, which is stricter than a
queue. A manually dispatched sweep keeps the shared group.

## Measured

The sweep this PR makes the release default is running right now against the
benchmark host, on `main`, 3 repeats, all nine scenarios:
https://github.com/eiserv/easySFTP/actions/runs/32406798639

It is the data for the three open performance issues, which are commented with
the same link:

- #157 deletions and remote scans are latency-bound
- #156 `concurrency: auto` is a fixed 4
- #155 `advanced.concurrency` bounds the hashing pool too

One caveat that the run cannot fix: the self-hosted runner still has no `tc`
(`iproute2`), so the shaped link profiles the two issues ask for (`+50ms`,
`baseline/5mbit`) cannot be applied. Requesting them would multiply the hours
and record four identical grids, so the run measures the real line only, at
about 13 ms RTT. Every latency-bound number in it is therefore a lower bound.

## Cost

The release sweep defaults to 2 repeats over the nine scenarios, which is
roughly 6 hours of self-hosted runner time per release, on top of the minutes
the standard run takes. Nothing about the release itself waits for it: binaries
and the tag are published by their own job. Both the scenario set and the
repeats are workflow inputs, so a lighter release sweep is a one line change if
that turns out to be too much.

It also adds to the repository: a stored sweep is 1.5 to 3 MB of JSON plus its
CSV, so a release sweep is roughly that much committed history per release (the
five stored sweeps today are 6.5 MB together). Keeping them is the point, since
the analysis and any before/after read them, and the retention window already
moves old ones into `archive/`. If it turns out not to be worth it, the sweep
job takes `store: false` and the numbers stay in the run artifact.

## How this was checked

`SFTP benchmark matrix` was dispatched from this branch, so the new file is
what produced the run linked above, including the reduced axes it prints per
scenario.

`Benchmark analysis` cannot be dispatched before it is on the default branch
(GitHub reads the trigger from there), so it gets its first run after this
merges: `gh workflow run benchmark-analysis.yml` with no inputs draws the
newest stored result and sweep and attaches nothing, which is the safe way to
check it. Everything in it that is not Actions machinery was run locally
against the stored results: `pip install -r benchmarks/analysis/requirements.txt`,
`plot.py report` with exactly the relative paths the workflow passes (which is
how the `ValueError` above was found), the step summary block, and
`python -m unittest discover -s benchmarks/analysis`.

## Not in this PR

The fixes themselves. #155, #156 and #157 are each a behaviour change with its
own tests, and each should be its own PR measured against the sweep this one
sets up.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
