### PR TITLE
ci: run the benchmark analysis self-checks on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,70 @@ jobs:
       - name: Test
         run: go test -race ./...
 
+  # The optional Python analysis layer (benchmarks/analysis/) has self-checks
+  # of its own, and nothing here ran them per pull request: the only place they
+  # ran was once per release, when the figures are drawn (benchmark-analysis.yml,
+  # PR #206), so a change that broke plot.py or benchdata.py stayed green until
+  # the next release. They load every result committed under benchmarks/, which
+  # makes this also the place where a stored document the analysis layer cannot
+  # read surfaces: on the day it is stored, not on the day someone needs the
+  # picture.
+  analysis-tests:
+    name: Benchmark analysis self-checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Two commits is all the scope check below needs: on a pull request
+          # the checked-out commit is the merge commit, whose first parent is
+          # the base branch.
+          fetch-depth: 2
+
+      # A path filter, but a job-level one, because "on: pull_request: paths:"
+      # would gate the whole workflow. The job itself always runs and always
+      # reports, so it can be a required check; only the install and the checks
+      # are skipped. Anything undecidable runs the checks: a scope test that
+      # silently skips is worse than one that spends a minute.
+      - name: Decide whether this run touches the analysis layer
+        id: scope
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "Not a pull request; running the self-checks."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! changed=$(git diff --name-only HEAD^1 HEAD 2>/dev/null); then
+            echo "Could not diff against the base; running the self-checks."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s\n' "$changed" | grep -Eq '^(benchmarks/|\.github/workflows/ci\.yml$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Nothing under benchmarks/ changed; skipping the self-checks."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: steps.scope.outputs.run == 'true'
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: benchmarks/analysis/requirements.txt
+
+      # matplotlib is the only dependency, pinned there so a plot made today
+      # can be remade next year.
+      - name: Install the analysis dependencies
+        if: steps.scope.outputs.run == 'true'
+        run: pip install -r benchmarks/analysis/requirements.txt
+
+      - name: Run the analysis self-checks
+        if: steps.scope.outputs.run == 'true'
+        run: python -m unittest discover -s benchmarks/analysis
+
   self-test:
     name: Self-test against a real SFTP server
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,9 +308,12 @@ several schema versions, and every figure prints its provenance plus the
 caveats the stored file justifies (an unshaped link profile, failed repeats,
 refused connections). Its self-checks load *every* result committed under
 `benchmarks/`, so a reader that only understands the newest schema fails
-instead of silently dropping the older files. `out/` is ignored except for the
-gallery `benchmarks/analysis/README.md` refers to; regenerate those files with
-the commands printed under each image when a new sweep or release lands.
+instead of silently dropping the older files. CI runs them in ci.yml's
+`analysis-tests` job whenever a pull request touches `benchmarks/`, so a
+change here (or a stored document the layer cannot read) fails on the PR that
+makes it. `out/` is ignored except for the gallery
+`benchmarks/analysis/README.md` refers to; regenerate those files with the
+commands printed under each image when a new sweep or release lands.
 
 ## Behavior worth knowing before you change it
 

--- a/benchmarks/analysis/README.md
+++ b/benchmarks/analysis/README.md
@@ -221,6 +221,11 @@ silently dropping the older files; and every command is drawn into a temporary
 directory, so a plot that raises on a field that moved fails here rather than
 on the day someone needs the picture.
 
+CI runs them too, in the `analysis-tests` job of `.github/workflows/ci.yml`,
+on every pull request that touches `benchmarks/` and on every push to main.
+Pull requests that touch nothing here skip the job's steps, because these
+checks have nothing to say about a change to the uploader.
+
 ## Adding to this
 
 Keep it reproducible and keep it optional: read only the canonical files, pin


### PR DESCRIPTION
## What

Adds an `analysis-tests` job to `.github/workflows/ci.yml` that installs
`benchmarks/analysis/requirements.txt` (matplotlib, the only dependency) and
runs `python -m unittest discover -s benchmarks/analysis` on `ubuntu-latest`.

## Why

The optional Python analysis layer has self-checks, and nothing in CI ran
them per pull request. The only place they run today is once per release,
when the figures are drawn (`benchmark-analysis.yml`, PR #206), so a change
that broke `plot.py` or `benchdata.py` stayed green until the next release.

The checks load *every* result committed under `benchmarks/`, so this is also
where the "a stored document the analysis layer cannot read fails loudly"
property gets enforced: on the pull request that stores it, rather than on the
day someone needs the picture.

They are cheap: 20 tests, ~3 seconds locally, no benchmark run and no server
contacted.

## The path filter

Job-level, not `on: pull_request: paths:`, which would gate the whole workflow.
Consequences of that choice:

- The job always runs and always reports, so it can be a required check. Only
  the install and the checks are skipped.
- The scope step diffs the pull request against its base (`HEAD^1..HEAD` on the
  merge commit, which is what `fetch-depth: 2` is for) and looks for
  `benchmarks/` or `.github/workflows/ci.yml`.
- Anything undecidable runs the checks: a push to main, or a diff that cannot
  be taken. A scope test that silently skips is worse than one that spends a
  minute.

`actions/setup-python` is pinned by commit SHA with the readable tag as a
trailing comment, like every other action in this repository
(`5fda3b95a4ea91299a34e894583c3862153e4b97` is v7.0.0, verified against the
tag).

## Also

A paragraph in `benchmarks/analysis/README.md` and a sentence in `CLAUDE.md`
saying where the checks now run.

## Verification

- `python -m unittest discover -s benchmarks/analysis` passes on this
  checkout: 20 tests, OK.
- `ci.yml` parses as YAML and the new job's steps and `if:` guards are what
  they should be.
- The scope step's matcher was exercised against sample path lists:
  `benchmarks/analysis/plot.py`, `benchmarks/index.json` and
  `.github/workflows/ci.yml` match; `internal/uploader/session.go`,
  `docs/configuration.md`, `notbenchmarks/analysis/plot.py`,
  `.github/workflows/ci.yml.bak` and `site/benchmarks/x.json` do not.
- The job itself first runs on this pull request, which touches `ci.yml` and
  so is in scope by its own filter.

Note on merge order: this only adds to `ci.yml` and does not touch
`benchmark-analysis.yml`, so it is independent of #206 either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
