### PR TITLE
perf(uploader): decouple sync hashing from upload concurrency

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,7 +220,7 @@ sync:
 | `retries` | `2` | Retries per file on transient errors, and the reconnect budget for dropped connections. Failures the server reports with a permanent status code are never retried; see [which upload failures are retried](troubleshooting.md#which-upload-failures-easysftp-retries). `0` disables. |
 | `timeout` | `30` | Connection timeout in seconds. `0` disables. |
 | `stall_timeout` | `0` (off) | Abort when active remote operations make no progress for this many seconds. |
-| `concurrency` | `auto` (4) | Files uploaded in parallel. Also bounds the sync hashing worker pool. `auto` uses the built-in default. |
+| `concurrency` | `auto` (4) | Files uploaded in parallel. `auto` uses the built-in default. Sync hashing uses the runner's available Go CPU parallelism independently. |
 | `request_concurrency` | `auto` (16) | Max in-flight SFTP requests per file (pipelining within one transfer). |
 | `connections` | `1` | SSH connections the parallel uploads spread over. Never more than `concurrency`. See below. |
 | `skip_unchanged` | `false` | For `overlay`, skip a file whose remote counterpart has the same size (coarse; `sync` compares content hashes). |

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -74,8 +74,9 @@ Notes:
 - A run that fails partway still records what it actually changed in the
   manifest (best effort), so a retried deploy resumes where it left off
   instead of re-uploading files that already made it.
-- Local files are hashed in parallel through a worker pool bounded by
-  `advanced.concurrency`, so planning a large tree uses the available runner CPU.
+- Local files are hashed in parallel using the runner's available Go CPU
+  parallelism. This is independent of `advanced.concurrency`, which can be
+  lowered for an SFTP server without serializing local hashing.
 - Remote directories are only created (or confirmed) for files actually being
   uploaded, so a sync with nothing to do costs just the manifest read and
   rewrite, no per-directory round-trips. Exception: with `permissions.directories`

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime"
 	"sort"
 
 	"github.com/pkg/sftp"
@@ -77,7 +78,11 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 		cached = old.Files
 	}
 	endHash := metrics.Phase("hash")
-	err = hashPlanFiles(ctx, p.files, cfg.Concurrency, cached)
+	// Hashing is local CPU and disk work, so its worker count follows the
+	// runner rather than the server-facing upload limit. A user may reduce
+	// advanced.concurrency because their SFTP server rejects parallel writes;
+	// that must not serialize an unrelated local phase (issue #155).
+	err = hashPlanFiles(ctx, p.files, runtime.GOMAXPROCS(0), cached)
 	endHash()
 	if err != nil {
 		return fmt.Errorf("hashing local files under %q: %w", p.pair.Local, err)


### PR DESCRIPTION
## What

Decouple the sync hashing worker pool from `advanced.concurrency`.

Sync now hashes local files with `runtime.GOMAXPROCS(0)`, while `advanced.concurrency` continues to bound parallel SFTP file uploads. The configuration documentation now describes those independent limits.

Fixes #155.

## Why

The upload pool is limited by the remote server and network. The hashing pool is limited by the runner CPU and local storage. Reusing one setting made `concurrency: 1`, a sensible choice for a fragile SFTP server, serialize local SHA-256 work that never contacts that server.

The benchmark added in #206 measured the effect directly. On the recorded Windows runner, the 1 GiB payload improved from 620 ms at one worker to 43.1 ms at `GOMAXPROCS`, while the real SFTP matrix confirmed that changing the upload setting changed the local hash phase.

No new configuration knob is added. The runner already exposes the appropriate CPU-derived limit through `GOMAXPROCS`.

## Verification

- `go test ./internal/uploader`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `git diff --check`

`go test -race ./...` cannot run on this Windows machine because cgo is disabled (`-race requires cgo`). CI owns the race pass.
