### PR TITLE
perf(uploader): parallelize remote scans and deletes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,10 +118,12 @@ granularity is a separate, later decision; don't build it speculatively.
   makes that safe.
 - A run may hold more than one connection (`advanced.connections`, issue
   #158). Only the per-file upload path spreads over them, by file index;
-  `session.do` and therefore everything else always uses the first one. A
-  connection the server refuses is not an error: that pool slot falls back to
-  the first connection after one warning. The reconnect budget stays run-wide
-  and the stall watchdog closes every connection.
+  `session.do` and therefore everything else always uses the first one. Remote
+  scans, file deletes and same-depth directory deletes may call `session.do`
+  concurrently, bounded by `advanced.concurrency`; they still open no extra
+  connections. A connection the server refuses is not an error: that pool slot
+  falls back to the first connection after one warning. The reconnect budget
+  stays run-wide and the stall watchdog closes every connection.
 - Every remote operation outside the per-file upload path must go through
   `session.do` (see `internal/uploader/session.go`): it redials on
   connection-class errors sharing the `retries` reconnect budget and marks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,10 +118,12 @@ granularity is a separate, later decision; don't build it speculatively.
   makes that safe.
 - A run may hold more than one connection (`advanced.connections`, issue
   #158). Only the per-file upload path spreads over them, by file index;
-  `session.do` and therefore everything else always uses the first one. A
-  connection the server refuses is not an error: that pool slot falls back to
-  the first connection after one warning. The reconnect budget stays run-wide
-  and the stall watchdog closes every connection.
+  `session.do` and therefore everything else always uses the first one. Remote
+  scans, file deletes and same-depth directory deletes may call `session.do`
+  concurrently, bounded by `advanced.concurrency`; they still open no extra
+  connections. A connection the server refuses is not an error: that pool slot
+  falls back to the first connection after one warning. The reconnect budget
+  stays run-wide and the stall watchdog closes every connection.
 - Every remote operation outside the per-file upload path must go through
   `session.do` (see `internal/uploader/session.go`): it redials on
   connection-class errors sharing the `retries` reconnect budget and marks

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,8 +233,10 @@ high `concurrency` and `request_concurrency` are. On a long-distance link that
 window is what caps throughput, and neither knob can lift it.
 
 `connections: 4` opens up to four connections and spreads the parallel uploads
-over them. Everything else (remote scans, deletes, the sync manifest) stays on
-the first one.
+over them. Remote scans and deletes issue up to `concurrency` independent
+requests over the first connection; the sync manifest stays there too. This
+keeps the server-facing parallelism under one limit without paying for extra
+SSH handshakes during metadata-only work.
 
 It is off by default because it is not free:
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -138,6 +138,12 @@ Deletes **everything** inside the remote target directory first, then uploads
 all local files. Use it when you want a guaranteed-fresh deploy and nothing in
 the target directory needs to survive.
 
+The recursive scan and file deletions run with up to `advanced.concurrency`
+independent SFTP requests. Empty directories are removed deepest-first, with
+siblings at the same depth handled in parallel. `sync` uses the same bounded
+delete pool. The guards below are evaluated against the complete file list
+before any delete worker starts.
+
 ## Delete guards
 
 Two safety nets apply before `sync` or `clean` delete anything:

--- a/internal/uploader/delete.go
+++ b/internal/uploader/delete.go
@@ -1,0 +1,106 @@
+package uploader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/pkg/sftp"
+
+	"github.com/eiserv/easySFTP/internal/config"
+	"github.com/eiserv/easySFTP/internal/metrics"
+)
+
+// deleteRemoteFiles removes paths through a bounded worker pool. The returned
+// slice is aligned with paths and records every delete that completed, even
+// when another worker failed. Sync uses that exact accounting for its recovery
+// manifest, and clean uses it for partial-progress statistics.
+func deleteRemoteFiles(ctx context.Context, cfg *config.Config, sess *session, paths []string, watch *stallWatchdog, log Logger) ([]bool, error) {
+	deleted := make([]bool, len(paths))
+	if cfg.DryRun {
+		for i, remotePath := range paths {
+			if cfg.LogPerFile() {
+				log.Infof("%sdelete %s", planVerb(cfg), remotePath)
+			}
+			deleted[i] = true
+		}
+		return deleted, nil
+	}
+
+	err := runBounded(ctx, cfg.Concurrency, len(paths), func(groupCtx context.Context, i int) error {
+		remotePath := paths[i]
+		if cfg.LogPerFile() {
+			log.Infof("delete %s", remotePath)
+		}
+		err := sess.do(groupCtx, watch, func(client *sftp.Client) error {
+			// Already-gone counts as deleted: a retried delete may have
+			// landed before the connection died.
+			done := metrics.Op("sftp_remove")
+			err := client.Remove(remotePath)
+			done(err)
+			watch.tick()
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("deleting %q: %w", remotePath, err)
+		}
+		deleted[i] = true
+		return nil
+	})
+	return deleted, err
+}
+
+func countDeleted(deleted []bool) int {
+	n := 0
+	for _, ok := range deleted {
+		if ok {
+			n++
+		}
+	}
+	return n
+}
+
+// removeRemoteDirs removes independent directories at the same depth in
+// parallel, while keeping the real child-before-parent dependency between
+// depths. Directory removal is best effort, matching the previous behavior:
+// a non-empty or unreadable directory is left in place.
+func removeRemoteDirs(ctx context.Context, cfg *config.Config, sess *session, watch *stallWatchdog, dirs []string) {
+	if cfg.DryRun || len(dirs) == 0 {
+		return
+	}
+	byDepth := make(map[int][]string)
+	var depths []int
+	for _, dir := range dirs {
+		depth := strings.Count(path.Clean(dir), "/")
+		if _, ok := byDepth[depth]; !ok {
+			depths = append(depths, depth)
+		}
+		byDepth[depth] = append(byDepth[depth], dir)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(depths)))
+	workers := cfg.Concurrency
+	if workers < 1 {
+		workers = 1
+	}
+	for _, depth := range depths {
+		level := byDepth[depth]
+		_ = runBounded(ctx, workers, len(level), func(groupCtx context.Context, i int) error {
+			dir := level[i]
+			_ = sess.do(groupCtx, watch, func(client *sftp.Client) error {
+				done := metrics.Op("sftp_rmdir")
+				err := client.RemoveDirectory(dir)
+				done(err)
+				watch.tick()
+				return err
+			})
+			return nil
+		})
+	}
+}

--- a/internal/uploader/parallel.go
+++ b/internal/uploader/parallel.go
@@ -1,0 +1,28 @@
+package uploader
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// runBounded runs fn for indexes [0, count), with at most limit calls active.
+// The first error cancels work that has not started; calls already in flight
+// finish, which is why their callers must account for partial progress.
+func runBounded(ctx context.Context, limit, count int, fn func(context.Context, int) error) error {
+	if limit < 1 {
+		limit = 1
+	}
+	g, groupCtx := errgroup.WithContext(ctx)
+	g.SetLimit(limit)
+	for i := 0; i < count; i++ {
+		i := i
+		g.Go(func() error {
+			if err := groupCtx.Err(); err != nil {
+				return err
+			}
+			return fn(groupCtx, i)
+		})
+	}
+	return g.Wait()
+}

--- a/internal/uploader/parallelremote_test.go
+++ b/internal/uploader/parallelremote_test.go
@@ -1,0 +1,169 @@
+package uploader
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+func TestRunBoundedEnforcesWorkerLimit(t *testing.T) {
+	const limit = 4
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	started := make(chan struct{}, limit+1)
+	finished := make(chan error, 1)
+	var active, maximum atomic.Int64
+
+	go func() {
+		finished <- runBounded(context.Background(), limit, 8, func(context.Context, int) error {
+			now := active.Add(1)
+			for {
+				old := maximum.Load()
+				if now <= old || maximum.CompareAndSwap(old, now) {
+					break
+				}
+			}
+			started <- struct{}{}
+			<-release
+			active.Add(-1)
+			return nil
+		})
+	}()
+
+	for i := 0; i < limit; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("worker pool did not fill to its limit")
+		}
+	}
+	select {
+	case <-started:
+		t.Fatal("worker pool started more calls than its limit")
+	case <-time.After(50 * time.Millisecond):
+	}
+	releaseOnce.Do(func() { close(release) })
+	if err := <-finished; err != nil {
+		t.Fatal(err)
+	}
+	if got := maximum.Load(); got != limit {
+		t.Fatalf("maximum active calls = %d, want %d", got, limit)
+	}
+}
+
+func TestCleanScansAndPrunesWideDeepTree(t *testing.T) {
+	srv := startTestServer(t)
+	remote := map[string]string{
+		"/www/flat.txt":       "stale",
+		"/www/a/b/c.txt":      "stale",
+		"/www/a/d.txt":        "stale",
+		"/www/e/f/g/h.txt":    "stale",
+		"/www/sibling/x.txt":  "stale",
+		"/www/sibling2/y.txt": "stale",
+	}
+	writeRemoteFiles(t, srv, remote)
+
+	cfg := cleanConfig(srv, t.TempDir())
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesDeleted != len(remote) {
+		t.Fatalf("deleted %d files, want %d", stats.FilesDeleted, len(remote))
+	}
+	for _, dir := range []string{"/www/a/b", "/www/a", "/www/e/f/g", "/www/e/f", "/www/e", "/www/sibling", "/www/sibling2"} {
+		if remoteExists(t, srv, dir) {
+			t.Errorf("stale directory %s still exists", dir)
+		}
+	}
+}
+
+func TestParallelDeletesTickWatchdogOnProgress(t *testing.T) {
+	slow := &slowCmd{method: "Remove", delay: 150 * time.Millisecond}
+	srv := startTestServer(t, withSlowCmd(slow))
+	remote := make(map[string]string)
+	for i := 0; i < 8; i++ {
+		remote[fmt.Sprintf("/www/stale-%d.txt", i)] = "stale"
+	}
+	writeRemoteFiles(t, srv, remote)
+
+	cfg := cleanConfig(srv, t.TempDir())
+	cfg.StallTimeout = 400 * time.Millisecond
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatalf("steady delete progress must not trip stall-timeout: %v", err)
+	}
+	if stats.FilesDeleted != len(remote) {
+		t.Fatalf("deleted %d files, want %d", stats.FilesDeleted, len(remote))
+	}
+}
+
+// A parallel sync sweep may finish several in-flight deletes after one worker
+// fails. The recovery manifest and partial-progress stats must describe the
+// paths that actually disappeared, regardless of completion order.
+func TestSyncParallelDeleteFailureRecordsExactProgress(t *testing.T) {
+	fault := &faultyNthCmd{method: "Remove", failAt: 3}
+	srv := startTestServer(t, withFaultyNthCmd(fault))
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"a.txt": "a",
+		"b.txt": "b",
+		"c.txt": "c",
+		"d.txt": "d",
+		"e.txt": "e",
+	})
+	cfg := syncConfig(srv, local)
+	cfg.Concurrency = 4
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := []string{"b.txt", "c.txt", "d.txt", "e.txt"}
+	for _, name := range stale {
+		if err := os.Remove(filepath.Join(local, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fault.seen.Store(0)
+	fault.enabled.Store(true)
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "injected failure") {
+		t.Fatalf("expected an injected deletion failure, got %v", err)
+	}
+
+	manifest := readRemoteManifest(t, srv)
+	actuallyDeleted := 0
+	for _, name := range stale {
+		exists := remoteExists(t, srv, "/www/"+name)
+		_, recorded := manifest.Files[name]
+		if exists != recorded {
+			t.Errorf("%s: remote exists = %t, recovery manifest contains entry = %t", name, exists, recorded)
+		}
+		if !exists {
+			actuallyDeleted++
+		}
+	}
+	if stats.FilesDeleted != actuallyDeleted {
+		t.Errorf("partial deletion stats = %d, actually deleted = %d", stats.FilesDeleted, actuallyDeleted)
+	}
+	if actuallyDeleted < 2 {
+		t.Fatalf("actually deleted %d files before the third request failed, want at least 2", actuallyDeleted)
+	}
+}
+
+func cleanConfig(srv *testServer, local string) *config.Config {
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 4
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategyClean}}
+	return cfg
+}

--- a/internal/uploader/phasereconnect_test.go
+++ b/internal/uploader/phasereconnect_test.go
@@ -50,6 +50,9 @@ func TestCleanReconnectsDuringDeletePhase(t *testing.T) {
 	if !loggedReconnect(log) {
 		t.Errorf("expected a reconnect warning, got %v", log.warnings)
 	}
+	if got := reconnectWarnings(log); got != 1 {
+		t.Errorf("reconnect warnings: got %d, want one collapsed redial; warnings: %v", got, log.warnings)
+	}
 }
 
 // A connection drop during the clean strategy's remote scan must redial and
@@ -152,10 +155,15 @@ func TestStallTimeoutCoversDeletePhase(t *testing.T) {
 
 // loggedReconnect reports whether the run logged a reconnect warning.
 func loggedReconnect(log *recordingLogger) bool {
+	return reconnectWarnings(log) > 0
+}
+
+func reconnectWarnings(log *recordingLogger) int {
+	count := 0
 	for _, w := range log.warnings {
 		if strings.Contains(w, "reconnecting") {
-			return true
+			count++
 		}
 	}
-	return false
+	return count
 }

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -1,6 +1,7 @@
 package uploader
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
@@ -103,34 +104,58 @@ func checkMaxDeletes(n int, cfg *config.Config) error {
 	return nil
 }
 
-// listRemoteContents returns every regular file and directory under dir
-// (recursively, dir itself excluded), directories parents-first. A missing
-// dir yields empty lists and no error. Each completed directory listing ticks
-// the stall watchdog, so a deep but progressing scan is not read as a stall.
-func listRemoteContents(client *sftp.Client, dir string, watch *stallWatchdog) (files, dirs []string, err error) {
-	done := metrics.Op("sftp_readdir")
-	entries, err := client.ReadDir(dir)
-	done(err)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil, nil
-		}
-		return nil, nil, err
+// listRemoteContents returns every regular file and directory under root
+// (root itself excluded), directories parents-first. Directories at the same
+// depth are listed concurrently: their requests are independent, while the
+// breadth-first boundary keeps a deterministic parent-before-child result.
+// Each ReadDir has its own sess.do call, so a dropped connection retries only
+// that idempotent listing instead of replaying the whole scan.
+func listRemoteContents(ctx context.Context, sess *session, root string, concurrency int, watch *stallWatchdog) (files, dirs []string, err error) {
+	if concurrency < 1 {
+		concurrency = 1
 	}
-	watch.tick()
-	for _, e := range entries {
-		full := path.Join(dir, e.Name())
-		if e.IsDir() {
-			dirs = append(dirs, full)
-			subFiles, subDirs, err := listRemoteContents(client, full, watch)
+	level := []string{root}
+	for len(level) > 0 {
+		entries := make([][]fs.FileInfo, len(level))
+		err := runBounded(ctx, concurrency, len(level), func(groupCtx context.Context, i int) error {
+			dir := level[i]
+			err := sess.do(groupCtx, watch, func(client *sftp.Client) error {
+				done := metrics.Op("sftp_readdir")
+				listed, err := client.ReadDir(dir)
+				done(err)
+				if err != nil {
+					if os.IsNotExist(err) {
+						return nil
+					}
+					return err
+				}
+				entries[i] = listed
+				watch.tick()
+				return nil
+			})
 			if err != nil {
-				return nil, nil, err
+				return fmt.Errorf("listing %q: %w", dir, err)
 			}
-			files = append(files, subFiles...)
-			dirs = append(dirs, subDirs...)
-			continue
+			return nil
+		})
+		if err != nil {
+			return nil, nil, err
 		}
-		files = append(files, full)
+
+		var next []string
+		for i, dir := range level {
+			for _, entry := range entries[i] {
+				full := path.Join(dir, entry.Name())
+				if entry.IsDir() {
+					dirs = append(dirs, full)
+					next = append(next, full)
+					continue
+				}
+				files = append(files, full)
+			}
+		}
+		sort.Strings(next)
+		level = next
 	}
 	return files, dirs, nil
 }

--- a/internal/uploader/session.go
+++ b/internal/uploader/session.go
@@ -33,9 +33,9 @@ type conn struct {
 // that number is one connection's ceiling: one TCP congestion window and one
 // cipher stream carry the whole run, which neither concurrency nor
 // request_concurrency can lift (issue #158). Parallel uploads spread over the
-// pool; every other remote operation (remote scans, delete sweeps, manifest
-// writes, directory setup) stays on the first connection, where its reconnect
-// behavior is exactly what it was before the pool existed.
+// pool. Remote scans and delete sweeps may issue concurrent requests, but keep
+// them on the first connection; manifest writes and directory setup do too.
+// Their reconnect behavior therefore stays independent of the upload pool.
 type session struct {
 	cfg *config.Config
 	log Logger
@@ -267,7 +267,9 @@ func (s *session) closeSSH() {
 // do runs op against the first connection, redialing on a connection-class
 // failure so the retried op runs against a fresh client instead of the dead one.
 // Everything outside the per-file upload path goes through here, which keeps
-// remote scans, delete sweeps and manifest writes on one connection.
+// remote scans, delete sweeps and manifest writes on the first connection.
+// Several callers may use do concurrently; acquire/reconnect uses the failed
+// connection generation to collapse their simultaneous redials into one.
 // Reconnects share the run-wide budget (the retries input) with the upload
 // path; past that budget the original failure is returned. Non-connection
 // errors are returned as-is, untouched.

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -134,35 +134,24 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 		return err
 	}
 
-	var deleted []string // relative paths actually removed, for the recovery manifest
-	endSweep := metrics.Phase("delete_sweep")
-	for _, rel := range toDelete {
-		full := path.Join(base, rel)
-		if cfg.LogPerFile() {
-			log.Infof("%sdelete %s", verb, full)
-		}
-		if !cfg.DryRun {
-			err := sess.do(ctx, watch, func(client *sftp.Client) error {
-				// Already-gone counts as deleted: a retried delete may have
-				// landed before the connection died.
-				done := metrics.Op("sftp_remove")
-				err := client.Remove(full)
-				done(err)
-				if err != nil && !errors.Is(err, os.ErrNotExist) {
-					return err
-				}
-				return nil
-			})
-			if err != nil {
-				endSweep()
-				writeRecoveryManifest(ctx, cfg, sess, watch, base, mergedManifest(old, upload, completed, deleted), log)
-				return fmt.Errorf("deleting %q: %w", full, err)
-			}
-		}
-		stats.FilesDeleted++
-		deleted = append(deleted, rel)
+	deletePaths := make([]string, len(toDelete))
+	for i, rel := range toDelete {
+		deletePaths[i] = path.Join(base, rel)
 	}
+	endSweep := metrics.Phase("delete_sweep")
+	deleteResults, deleteErr := deleteRemoteFiles(ctx, cfg, sess, deletePaths, watch, log)
+	var deleted []string // relative paths actually removed, for the recovery manifest
+	for i, ok := range deleteResults {
+		if ok {
+			deleted = append(deleted, toDelete[i])
+		}
+	}
+	stats.FilesDeleted += len(deleted)
 	endSweep()
+	if deleteErr != nil {
+		writeRecoveryManifest(ctx, cfg, sess, watch, base, mergedManifest(old, upload, completed, deleted), log)
+		return deleteErr
+	}
 	stats.FilesSkipped += len(p.files) - len(upload)
 
 	if cfg.DryRun {
@@ -173,7 +162,7 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 	for i, rel := range deleted {
 		deletedFull[i] = path.Join(base, rel)
 	}
-	pruneEmptyDirs(ctx, sess, watch, base, deletedFull)
+	pruneEmptyDirs(ctx, cfg, sess, watch, base, deletedFull)
 	endWrite := metrics.Phase("manifest_write")
 	err = sess.do(ctx, watch, func(client *sftp.Client) error {
 		return writeManifest(client, base, cfg.SyncManifestName(), manifest{Version: manifestVersion, Files: local})
@@ -331,7 +320,7 @@ func writeManifest(client *sftp.Client, dir, name string, m manifest) error {
 // deepest first, walking up to (but not including) base. Each removal runs
 // through sess.do: the outcome stays best-effort, but a dropped connection is
 // redialed rather than silently failing every remaining removal.
-func pruneEmptyDirs(ctx context.Context, sess *session, watch *stallWatchdog, base string, deleted []string) {
+func pruneEmptyDirs(ctx context.Context, cfg *config.Config, sess *session, watch *stallWatchdog, base string, deleted []string) {
 	seen := map[string]struct{}{}
 	var candidates []string
 	for _, f := range deleted {
@@ -343,17 +332,8 @@ func pruneEmptyDirs(ctx context.Context, sess *session, watch *stallWatchdog, ba
 			candidates = append(candidates, dir)
 		}
 	}
-	// Deepest paths sort last; remove them first so parents can then empty out.
-	sort.Sort(sort.Reverse(sort.StringSlice(candidates)))
 	defer metrics.Phase("prune_dirs")()
-	for _, dir := range candidates {
-		_ = sess.do(ctx, watch, func(client *sftp.Client) error {
-			done := metrics.Op("sftp_rmdir")
-			err := client.RemoveDirectory(dir)
-			done(err)
-			return err
-		})
-	}
+	removeRemoteDirs(ctx, cfg, sess, watch, candidates)
 }
 
 // hashFile returns the sha256 hex digest of a local file's contents.

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -639,6 +639,7 @@ func TestSyncPartialDeleteFailureWritesRecoveryManifest(t *testing.T) {
 	writeTree(t, local, map[string]string{"a.txt": "a", "b.txt": "b", "c.txt": "c"})
 
 	cfg := syncConfig(srv, local)
+	cfg.Concurrency = 1 // keep this older ordered-progress check deterministic
 	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -502,6 +502,61 @@ type faultyPathCmd struct {
 	enabled atomic.Bool
 }
 
+// faultyNthCmd fails the nth matching command while enabled. The commands
+// before it still reach the in-memory filesystem, which makes partial-progress
+// accounting tests independent of goroutine completion order.
+type faultyNthCmd struct {
+	inner   sftp.FileCmder
+	method  string
+	failAt  int64
+	seen    atomic.Int64
+	enabled atomic.Bool
+}
+
+func withFaultyNthCmd(f *faultyNthCmd) serverOption {
+	return func(s *testServer) {
+		f.inner = s.handlers.FileCmd
+		s.handlers.FileCmd = f
+	}
+}
+
+func (f *faultyNthCmd) Filecmd(r *sftp.Request) error {
+	if f.enabled.Load() && r.Method == f.method && f.seen.Add(1) == f.failAt {
+		return fmt.Errorf("injected failure on %s request %d", f.method, f.failAt)
+	}
+	return f.inner.Filecmd(r)
+}
+
+func (f *faultyNthCmd) PosixRename(r *sftp.Request) error {
+	return posixRenamePassthrough(f.inner, r)
+}
+
+// slowCmd delays matching commands but lets them succeed, simulating a server
+// that makes steady progress more slowly than a whole parallel phase lasts.
+type slowCmd struct {
+	inner  sftp.FileCmder
+	method string
+	delay  time.Duration
+}
+
+func withSlowCmd(slow *slowCmd) serverOption {
+	return func(s *testServer) {
+		slow.inner = s.handlers.FileCmd
+		s.handlers.FileCmd = slow
+	}
+}
+
+func (s *slowCmd) Filecmd(r *sftp.Request) error {
+	if r.Method == s.method {
+		time.Sleep(s.delay)
+	}
+	return s.inner.Filecmd(r)
+}
+
+func (s *slowCmd) PosixRename(r *sftp.Request) error {
+	return posixRenamePassthrough(s.inner, r)
+}
+
 // withFaultyPath installs f as the FileCmd handler (wrapping the real one).
 func withFaultyPath(f *faultyPathCmd) serverOption {
 	return func(s *testServer) {

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -13,12 +13,9 @@ package uploader
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
 	"time"
 
-	"github.com/pkg/sftp"
 	ignore "github.com/sabhiram/go-gitignore"
 
 	"github.com/eiserv/easySFTP/internal/config"
@@ -203,17 +200,9 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 		if err := checkRemoteRoot(p.pair.Remote); err != nil {
 			return err
 		}
-		// The whole sweep runs through sess.do, so a connection drop mid-scan
-		// or mid-delete redials (within the shared reconnect budget) instead
-		// of failing the run; see issue #107. The scan is idempotent and
-		// simply reruns on a fresh client.
 		var files, dirs []string
 		endRemoteScan := metrics.Phase("remote_scan")
-		err := sess.do(ctx, watch, func(client *sftp.Client) error {
-			var err error
-			files, dirs, err = listRemoteContents(client, base, watch)
-			return err
-		})
+		files, dirs, err := listRemoteContents(ctx, sess, base, cfg.Concurrency, watch)
 		endRemoteScan()
 		if err != nil {
 			return fmt.Errorf("scanning remote directory %q: %w", p.pair.Remote, err)
@@ -221,49 +210,17 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 		if err := checkMaxDeletes(len(files), cfg); err != nil {
 			return err
 		}
-		// The sweep is its own function literal only so the phase timer ends
-		// with it, instead of running on into the upload phase below.
-		if err := func() error {
-			defer metrics.Phase("delete_sweep")()
-			for _, f := range files {
-				if cfg.LogPerFile() {
-					log.Infof("%sdelete %s", verb, f)
-				}
-				if !cfg.DryRun {
-					err := sess.do(ctx, watch, func(client *sftp.Client) error {
-						// Already-gone counts as deleted: a retried delete may
-						// have landed before the connection died.
-						done := metrics.Op("sftp_remove")
-						err := client.Remove(f)
-						done(err)
-						if err != nil && !errors.Is(err, os.ErrNotExist) {
-							return err
-						}
-						return nil
-					})
-					if err != nil {
-						return fmt.Errorf("deleting %q: %w", f, err)
-					}
-				}
-				stats.FilesDeleted++
-			}
-			// Remove the now-empty directories, deepest first. Best effort: a
-			// directory that is not empty (e.g. an unreadable entry) is left be.
-			for i := len(dirs) - 1; i >= 0; i-- {
-				if !cfg.DryRun {
-					dir := dirs[i]
-					_ = sess.do(ctx, watch, func(client *sftp.Client) error {
-						done := metrics.Op("sftp_rmdir")
-						err := client.RemoveDirectory(dir)
-						done(err)
-						return err
-					})
-				}
-			}
-			return nil
-		}(); err != nil {
+		endSweep := metrics.Phase("delete_sweep")
+		deleted, err := deleteRemoteFiles(ctx, cfg, sess, files, watch, log)
+		stats.FilesDeleted += countDeleted(deleted)
+		if err != nil {
+			endSweep()
 			return err
 		}
+		// Best effort, but parallel within a depth: siblings are independent;
+		// parents still wait for every child level to finish.
+		removeRemoteDirs(ctx, cfg, sess, watch, dirs)
+		endSweep()
 	}
 
 	skipUnchanged := cfg.SkipUnchanged && p.strategy == config.StrategyOverlay

--- a/schema/easysftp.schema.json
+++ b/schema/easysftp.schema.json
@@ -153,7 +153,7 @@
           "minimum": 0
         },
         "concurrency": {
-          "description": "Number of files uploaded in parallel, or \"auto\" for the built-in default.",
+          "description": "Maximum parallel file uploads and independent remote scan, file delete, and same-depth directory delete requests, or \"auto\" for the built-in default.",
           "$ref": "#/$defs/autoInt"
         },
         "request_concurrency": {


### PR DESCRIPTION
## What

Parallelize the latency-bound remote metadata phases behind the existing `advanced.concurrency` limit.

- Clean-mode remote scans now walk breadth-first and list independent directories at the same depth concurrently.
- Clean and sync file deletions run through a bounded worker pool.
- Empty directories remain child-before-parent, but independent siblings at the same depth are removed concurrently.
- Every remote operation still uses `session.do` on the first connection, so generation-based reconnect collapsing, the run-wide retry budget, and stall handling remain in force.
- No new configuration field or connection is introduced.

Fixes #157.

## Safety and failure semantics

The destructive guards are unchanged and still run before the first delete worker starts:

- remote-root refusal runs first
- `safety.max_deletes` sees the complete scan or manifest-derived delete set
- an already-missing path still counts as successfully deleted, preserving idempotent reconnect retries

Parallel sync deletion uses an index-aligned completion bitmap. If one worker fails, in-flight operations finish, statistics count only successful removals, and the recovery manifest drops exactly the paths that are actually gone. A retry therefore resumes from the real remote state, independent of completion order.

Directory removal is still best effort. Work is grouped by depth and processed deepest-first, so a parent never races its child.

Each completed `ReadDir`, `Remove`, and `Rmdir` round trip ticks the shared watchdog. This prevents a large slow sweep that is making steady progress from being mistaken for a stall after all workers have started.

## Why this shape

The stored matrix from run 32406798639 confirmed the serial baseline on the roughly 13 ms RTT benchmark link:

- 2,000-file bulk sweeps took 36.5 to 43.0 seconds and stayed flat across the existing grid
- 300-file sweeps took 6.0 to 6.8 seconds
- the deep scenario spent about 18.2 seconds scanning 256 directories at the default cell

The same server-facing limit already describes how much parallel work the user permits. Reusing it avoids a second knob. Metadata requests stay on the first SFTP connection, so `advanced.connections` retains its existing upload-only meaning and no additional SSH handshakes are paid.

The in-process pkg/sftp test server intentionally serializes non-read/write handlers per connection, so it cannot produce a meaningful network-latency speedup measurement. The tests instead pin the bounded scheduler deterministically and use the SFTP integration layer for the invariants that matter on failure. The existing matrix `deletes[]` and `deep` phases remain the correct before/after measurement on the real benchmark host.

## Verification

- `go test ./internal/uploader -count=2`
- reconnect, watchdog, and recovery cases repeated with `-count=3`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `git diff --check`

`go test -race ./...` cannot run on this Windows machine because cgo is disabled (`-race requires cgo`). CI owns the race pass.
