### PR TITLE
feat(uploader): make auto a real adaptive transport policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,8 +448,25 @@ jobs:
                    and ((.operations | map(select(.name == "sftp_open")) | first | .count) == 300)
                    and .process.max_rss_bytes > 0
                    and .process.user_cpu_ms > 0
-                   and .process.net_write_bytes > 0
-                   and .counters.connections_opened == 1' "$OUT_DIR/results.json"
+                   and .process.net_write_bytes > 0' "$OUT_DIR/results.json"
+          # The adaptive settings (issue #209) against a real server, which is
+          # the only place the link probe and the connection pool run at all.
+          # The standard benchmark is an inline run, so all three settings are
+          # at auto: the policy must have read the workload, measured the link
+          # and stayed inside its own bounds.
+          jq -e '.results[] | select(.label == "candidate" and .scenario == "small")
+                 | (.operations | map(select(.name == "sftp_realpath")) | first | .count) >= 3
+                   and .counters.workload_files == 300
+                   and .counters.workload_probes == 0
+                   and .counters.link_rtt_us > 0
+                   and .counters.link_handshake_us > 0
+                   and .counters.auto_initial_connections >= 1
+                   and .counters.config_connections >= .counters.auto_initial_connections
+                   and .counters.config_connections <= 8
+                   and .counters.config_concurrency == 64
+                   and .counters.config_request_concurrency == 16
+                   and .counters.connections_opened <= 8
+                   and ((.counters.connections_refused // 0) == 0)' "$OUT_DIR/results.json"
 
       # A two-by-two grid of the matrix sweep: enough to prove the plumbing
       # (config generation for both axes, per-cell aggregation, the CSV) without

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,9 +33,9 @@ jobs:
         run: |
           mkdir -p _site/content
           cp -r site/. _site/
-          cp docs/configuration.md docs/strategies.md docs/examples.md \
-             docs/security.md docs/troubleshooting.md docs/providers.md \
-             docs/migration-v3.md _site/content/
+          cp docs/configuration.md docs/tuning.md docs/strategies.md \
+             docs/examples.md docs/security.md docs/troubleshooting.md \
+             docs/providers.md docs/migration-v3.md _site/content/
           cp CONTRIBUTING.md _site/content/contributing.md
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,66 @@ whole workflow into a config file. Each setting still has exactly one home
 *per mode*, which is what keeps "no precedence question" true. Per-deployment
 granularity is a separate, later decision; don't build it speculatively.
 
+## The adaptive transport settings (`auto`)
+
+`advanced.connections`, `advanced.concurrency` and `advanced.request_concurrency`
+default to `auto`, and since issue #209 `auto` is a real policy rather than a
+synonym for a fixed 1/4/16. `internal/autotune` is that policy: a cost model
+with no clock, no I/O and no state, plus a small runtime controller. Read its
+package comment before changing anything here; the short version:
+
+- `concurrency` is the number of independent items the phase has, capped at 64.
+  There is no trade-off (a worker with nothing to do never starts), which is
+  why nothing measures it and why the runtime controller never moves it.
+- `request_concurrency` follows the largest file (it counts 32 KiB write
+  packets in flight for *one* file) and is capped by the SSH channel window,
+  which is 64 packets. It is fixed when an SFTP client is created, so it is
+  resolved once, run-wide, before the first connection.
+- `connections` is the only interesting one. `T(k) = W/k + (k-1)*H` is smallest
+  at `k = sqrt(W/H)`: open another connection while it saves more than its
+  handshake costs. Everything else in the package exists to estimate `W`.
+
+Three rules that are load-bearing:
+
+1. **A number in the config file is never touched**, at any stage.
+   `config.AutoSettings` records which of the three the user left to easySFTP;
+   the int fields keep the old fixed defaults as a fallback. A `config.Config`
+   built directly (every uploader test) therefore has all three *pinned*, which
+   is why the pre-existing tests still measure what they measured.
+2. **The pool only grows.** `session.conns` is allocated once to the ceiling
+   and `session.spread` is what moves; slots are dialed on first use, so
+   widening costs nothing until a worker lands on a fresh slot. A refused
+   connection latches `session.refused`, pulls the spread back and stops the
+   run asking again.
+3. **Never derive parallelism from `runtime.NumCPU()`.** The constraint is the
+   server and the path, not the runner (issue #156 says so explicitly). The one
+   place the runner's CPU count belongs is sync hashing, which is local work
+   (issue #155).
+
+The three stages and where they run:
+
+| Stage | Where | What it adds |
+|---|---|---|
+| 1, workload | `uploader.Run` (run-wide) and `uploadFiles` (per deployment) | the plan: files, bytes, largest file, metadata round-trips |
+| 2, link | `newSession` via `probeLink` | the handshake it just paid, and an RTT from three `SSH_FXP_REALPATH` round-trips |
+| 3, runtime | `startTuningController` inside `uploadFiles` | the throughput the transfer is actually achieving |
+
+An overlay deployment with `advanced.skip_unchanged` is the case stage 1 cannot
+settle: the upload set is decided file by file while the run goes. It is
+planned as metadata only (`Workload.Unknown`), which is what keeps a redeploy
+that changed three files from paying for a pool, and stage 3 widens it if the
+observed ratio says most files really are being sent.
+
+`internal/autotune/regret_test.go` is the acceptance test issue #209 asks for:
+it replays the policy over every sweep committed under `benchmarks/matrix/`
+with at least three repeats and fails when the regret against the best measured
+cell goes over 15% (a gap under 300 ms passes on its absolute size, which is
+what the issue allows for sub-two-second runs). A sibling test asserts that the
+old fixed 1/4/16 would *fail* it, so the replay cannot quietly stop
+discriminating. **Changing a constant in `internal/autotune` means running that
+test**, and a new stored sweep that fails it means the policy needs refitting,
+not that the test needs relaxing.
+
 ## Testing quirks
 
 - `internal/uploader/testserver_test.go` runs an in-process SSH/SFTP server
@@ -117,13 +177,15 @@ granularity is a separate, later decision; don't build it speculatively.
   via `t.Cleanup`; no test in this package runs in parallel, which is what
   makes that safe.
 - A run may hold more than one connection (`advanced.connections`, issue
-  #158). Only the per-file upload path spreads over them, by file index;
-  `session.do` and therefore everything else always uses the first one. Remote
-  scans, file deletes and same-depth directory deletes may call `session.do`
-  concurrently, bounded by `advanced.concurrency`; they still open no extra
-  connections. A connection the server refuses is not an error: that pool slot
-  falls back to the first connection after one warning. The reconnect budget
-  stays run-wide and the stall watchdog closes every connection.
+  #158; how many is the policy's, issue #209). Only the per-file upload path
+  spreads over them, by file index modulo `session.spread`; `session.do` and
+  therefore everything else always uses the first one. Remote scans, file
+  deletes and same-depth directory deletes may call `session.do` concurrently,
+  bounded by `session.workers(items)`; they still open no extra connections. A
+  connection the server refuses is not an error: that pool slot falls back to
+  the first connection after one warning, and the run stops asking. The
+  reconnect budget stays run-wide and the stall watchdog closes every
+  connection.
 - Every remote operation outside the per-file upload path must go through
   `session.do` (see `internal/uploader/session.go`): it redials on
   connection-class errors sharing the `retries` reconnect budget and marks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,66 @@ whole workflow into a config file. Each setting still has exactly one home
 *per mode*, which is what keeps "no precedence question" true. Per-deployment
 granularity is a separate, later decision; don't build it speculatively.
 
+## The adaptive transport settings (`auto`)
+
+`advanced.connections`, `advanced.concurrency` and `advanced.request_concurrency`
+default to `auto`, and since issue #209 `auto` is a real policy rather than a
+synonym for a fixed 1/4/16. `internal/autotune` is that policy: a cost model
+with no clock, no I/O and no state, plus a small runtime controller. Read its
+package comment before changing anything here; the short version:
+
+- `concurrency` is the number of independent items the phase has, capped at 64.
+  There is no trade-off (a worker with nothing to do never starts), which is
+  why nothing measures it and why the runtime controller never moves it.
+- `request_concurrency` follows the largest file (it counts 32 KiB write
+  packets in flight for *one* file) and is capped by the SSH channel window,
+  which is 64 packets. It is fixed when an SFTP client is created, so it is
+  resolved once, run-wide, before the first connection.
+- `connections` is the only interesting one. `T(k) = W/k + (k-1)*H` is smallest
+  at `k = sqrt(W/H)`: open another connection while it saves more than its
+  handshake costs. Everything else in the package exists to estimate `W`.
+
+Three rules that are load-bearing:
+
+1. **A number in the config file is never touched**, at any stage.
+   `config.AutoSettings` records which of the three the user left to easySFTP;
+   the int fields keep the old fixed defaults as a fallback. A `config.Config`
+   built directly (every uploader test) therefore has all three *pinned*, which
+   is why the pre-existing tests still measure what they measured.
+2. **The pool only grows.** `session.conns` is allocated once to the ceiling
+   and `session.spread` is what moves; slots are dialed on first use, so
+   widening costs nothing until a worker lands on a fresh slot. A refused
+   connection latches `session.refused`, pulls the spread back and stops the
+   run asking again.
+3. **Never derive parallelism from `runtime.NumCPU()`.** The constraint is the
+   server and the path, not the runner (issue #156 says so explicitly). The one
+   place the runner's CPU count belongs is sync hashing, which is local work
+   (issue #155).
+
+The three stages and where they run:
+
+| Stage | Where | What it adds |
+|---|---|---|
+| 1, workload | `uploader.Run` (run-wide) and `uploadFiles` (per deployment) | the plan: files, bytes, largest file, metadata round-trips |
+| 2, link | `newSession` via `probeLink` | the handshake it just paid, and an RTT from three `SSH_FXP_REALPATH` round-trips |
+| 3, runtime | `startTuningController` inside `uploadFiles` | the throughput the transfer is actually achieving |
+
+An overlay deployment with `advanced.skip_unchanged` is the case stage 1 cannot
+settle: the upload set is decided file by file while the run goes. It is
+planned as metadata only (`Workload.Unknown`), which is what keeps a redeploy
+that changed three files from paying for a pool, and stage 3 widens it if the
+observed ratio says most files really are being sent.
+
+`internal/autotune/regret_test.go` is the acceptance test issue #209 asks for:
+it replays the policy over every sweep committed under `benchmarks/matrix/`
+with at least three repeats and fails when the regret against the best measured
+cell goes over 15% (a gap under 300 ms passes on its absolute size, which is
+what the issue allows for sub-two-second runs). A sibling test asserts that the
+old fixed 1/4/16 would *fail* it, so the replay cannot quietly stop
+discriminating. **Changing a constant in `internal/autotune` means running that
+test**, and a new stored sweep that fails it means the policy needs refitting,
+not that the test needs relaxing.
+
 ## Testing quirks
 
 - `internal/uploader/testserver_test.go` runs an in-process SSH/SFTP server
@@ -117,13 +177,15 @@ granularity is a separate, later decision; don't build it speculatively.
   via `t.Cleanup`; no test in this package runs in parallel, which is what
   makes that safe.
 - A run may hold more than one connection (`advanced.connections`, issue
-  #158). Only the per-file upload path spreads over them, by file index;
-  `session.do` and therefore everything else always uses the first one. Remote
-  scans, file deletes and same-depth directory deletes may call `session.do`
-  concurrently, bounded by `advanced.concurrency`; they still open no extra
-  connections. A connection the server refuses is not an error: that pool slot
-  falls back to the first connection after one warning. The reconnect budget
-  stays run-wide and the stall watchdog closes every connection.
+  #158; how many is the policy's, issue #209). Only the per-file upload path
+  spreads over them, by file index modulo `session.spread`; `session.do` and
+  therefore everything else always uses the first one. Remote scans, file
+  deletes and same-depth directory deletes may call `session.do` concurrently,
+  bounded by `session.workers(items)`; they still open no extra connections. A
+  connection the server refuses is not an error: that pool slot falls back to
+  the first connection after one warning, and the run stops asking. The
+  reconnect budget stays run-wide and the stall watchdog closes every
+  connection.
 - Every remote operation outside the per-file upload path must go through
   `session.do` (see `internal/uploader/session.go`): it redials on
   connection-class errors sharing the `retries` reconnect budget and marks

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -103,7 +103,7 @@ Markdown:
 | `results[].process` | CPU time, peak RSS, Go allocations, GC count and pause, peak goroutines, disk and network bytes |
 | `results[].phases[]` | wall clock per phase (connect, local_scan, remote_scan, hash, create_dirs, sweep_stale_temps, upload, delete_sweep, manifest_read, manifest_write, prune_dirs, cleanup) |
 | `results[].operations[]` | per round-trip: count, cumulative total, average, p50/p90/p99, max, errors |
-| `results[].counters` | connections opened/used/refused, reconnects, retries, stalls, errors |
+| `results[].counters` | connections opened/used/refused, reconnects, retries, stalls, errors, the settings the run used (`config_*`), what the policy first picked (`auto_initial_*`, `auto_changes`), the features it read (`workload_*`) and the link it measured (`link_rtt_us`, `link_handshake_us`) |
 | `comparison[]` | each build against the reference build: `delta_ms`, `delta_percent`, and `within_noise` (is the delta smaller than the reference's MAD?) |
 | `deletes[]` | the delete sweeps, one row per (build, scenario, link profile); see "The delete sweeps" below |
 | `runs[]` | every individual repeat, verbatim, including its own metrics document |
@@ -189,13 +189,22 @@ candidate build, and scores it against the grid:
 
 | Field | What it is |
 |---|---|
-| `chosen` | the `connections`, `concurrency` and `request_concurrency` the run used, read from its own counters rather than assumed |
+| `chosen` | the `connections`, `concurrency` and `request_concurrency` the run ended up using, read from its own counters rather than assumed |
+| `chosen.initial_*`, `chosen.changes` | what the policy picked before the transfer taught it anything, and how many times it widened the pool while the transfer ran; equal to `chosen` on a run the runtime stage left alone |
+| `workload` | the features the policy was looking at: `files`, `bytes`, `largest_bytes`, `probes`, and the `rtt_ms` / `handshake_ms` the run measured itself |
 | `median_ms`, `min_ms`, `max_ms`, `mad_ms`, `durations_ms`, `mib_per_s`, `files_per_s` | the same statistics a cell carries |
 | `best` | the fastest candidate cell of that scenario and profile |
 | `regret_ms`, `regret_percent` | the gap: how much slower the policy is than the settings a sweep would have picked |
 | `chosen_in_grid`, `chosen_cell_median_ms` | the same coordinates measured as an ordinary cell, when the grid contains them |
 
-Three things about it:
+`workload` and the `initial_*` fields are null in every result stored before
+issue #209, where `auto` was a fixed 1/4/16 and there was nothing to record.
+`workload.rtt_ms` is easySFTP's own probe, taken on its first connection, and is
+a different measurement from `link.probes[]`, which comes from `cmd/linkprobe`
+and never goes through the uploader. Both are kept, because the interesting case
+is the one where they disagree.
+
+Four things about it:
 
 - **It is not a cell.** `auto` does not sit at a coordinate, it chooses one, so
   it stays out of `cells[]`, `scaling[]`, `comparison[]` and the CSV. A build
@@ -209,9 +218,15 @@ Three things about it:
   (see "The link profile"), and a policy that is only good on the benchmark
   host's line is the failure class of #62 all over again. A policy within ~15%
   of optimum on every profile is defensible; one that only wins here is not.
-  This is the number the auto-config work of #156 has to beat, and today it
-  scores a hardcoded default, which is exactly what #156 says `auto` currently
-  is.
+- **The grid cannot score the runtime stage.** A cell is a fixed configuration
+  measured from its first byte, so there is nothing in it for the controller to
+  react to. What `chosen.changes` records is that the controller acted; whether
+  it acted well shows up in `median_ms` and nowhere else.
+
+The policy itself lives in `internal/autotune` (issue #209), and its own test
+replays it against every sweep committed here and fails when the regret goes
+over the target. That test is the fast feedback loop; the sweep is the
+measurement it is fitted to.
 
 ### The canary
 

--- a/benchmarks/analysis/benchdata.py
+++ b/benchmarks/analysis/benchdata.py
@@ -59,6 +59,7 @@ OPERATION_ORDER = [
     "sftp_mkdirall",
     "sftp_stat",
     "sftp_readdir",
+    "sftp_realpath",
     "ssh_connect",
 ]
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 | Document | What's in it |
 |---|---|
 | [Configuration reference](configuration.md) | Every input, output, exclude patterns and the YAML config file. |
+| [Transfer tuning](tuning.md) | What `auto` does for `connections`, `concurrency` and `request_concurrency`, and when to override it. |
 | [Strategies](strategies.md) | `overlay` vs. `sync` vs. `clean`, the sync manifest, delete guards, dry runs. |
 | [Examples & use cases](examples.md) | Copy-paste recipes: static sites, mirroring, multi-target deploys, PR previews, outputs. |
 | [Security guide](security.md) | Host key pinning, credential handling, least privilege, supply-chain safety. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,9 +162,9 @@ advanced:
   retries: 2
   timeout: 30
   stall_timeout: 0
-  concurrency: auto            # or a number
+  concurrency: auto            # or a number; see docs/tuning.md
   request_concurrency: auto
-  connections: 1               # SSH connections uploads spread over
+  connections: auto            # SSH connections uploads spread over
   skip_unchanged: false
 
 permissions:
@@ -220,17 +220,17 @@ sync:
 | `retries` | `2` | Retries per file on transient errors, and the reconnect budget for dropped connections. Failures the server reports with a permanent status code are never retried; see [which upload failures are retried](troubleshooting.md#which-upload-failures-easysftp-retries). `0` disables. |
 | `timeout` | `30` | Connection timeout in seconds. `0` disables. |
 | `stall_timeout` | `0` (off) | Abort when active remote operations make no progress for this many seconds. |
-| `concurrency` | `auto` (4) | Files uploaded in parallel. `auto` uses the built-in default. Sync hashing uses the runner's available Go CPU parallelism independently. |
-| `request_concurrency` | `auto` (16) | Max in-flight SFTP requests per file (pipelining within one transfer). |
-| `connections` | `1` | SSH connections the parallel uploads spread over. Never more than `concurrency`. See below. |
+| `concurrency` | `auto` | Files uploaded in parallel, and independent remote scan / delete requests. `auto` sizes it to the work (see [transfer tuning](tuning.md)). Sync hashing uses the runner's available Go CPU parallelism independently. |
+| `request_concurrency` | `auto` | Max in-flight SFTP requests per file (pipelining within one transfer). `auto` sizes it to the largest file. |
+| `connections` | `auto` | SSH connections the parallel uploads spread over. Never more than `concurrency`. `auto` opens another one only while it would save more time than its handshake costs. See below. |
 | `skip_unchanged` | `false` | For `overlay`, skip a file whose remote counterpart has the same size (coarse; `sync` compares content hashes). |
 
 ##### `connections`: more than one TCP flow
 
-By default a run does everything over a single SSH connection, so the whole
-deploy shares one TCP congestion window and one cipher stream, no matter how
-high `concurrency` and `request_concurrency` are. On a long-distance link that
-window is what caps throughput, and neither knob can lift it.
+A single SSH connection carries the whole deploy over one TCP congestion window
+and one cipher stream, no matter how high `concurrency` and
+`request_concurrency` are. On a long-distance link that window is what caps
+throughput, and neither knob can lift it.
 
 `connections: 4` opens up to four connections and spreads the parallel uploads
 over them. Remote scans and deletes issue up to `concurrency` independent
@@ -238,25 +238,27 @@ requests over the first connection; the sync manifest stays there too. This
 keeps the server-facing parallelism under one limit without paying for extra
 SSH handshakes during metadata-only work.
 
-It is off by default because it is not free:
+At `auto` (the default) easySFTP decides per deployment, because a connection
+is not free:
 
+- **Each connection repeats the handshake**, including host key verification.
+  A short run of a few files pays that for nothing, so `auto` opens another
+  connection only while the time it would save is larger than the handshake it
+  costs. A one-second redeploy gets one connection; a two-thousand-file upload
+  over a link with real latency gets several. [Transfer tuning](tuning.md)
+  explains the rule and how to read the log line it prints.
 - **Server limits are real.** sshd's `MaxStartups` and per-account connection
   limits on shared hosting will refuse the extra connections. easySFTP then
-  warns once per refused connection and finishes the deploy on the ones it
-  has, so a too-high value costs a warning, not a failed deploy.
-- **Each connection repeats the handshake**, including host key verification.
-  A short run of a few files pays that for nothing, which is why connections
-  past the first are only opened when a file actually needs one.
+  warns, finishes the deploy on the ones it has and stops asking for more, so a
+  too-high value costs a warning, not a failed deploy.
 - **The `retries` budget is shared.** Reconnects are counted per run, not per
   connection.
 - **The stall watchdog closes all of them.** `stall_timeout` only knows that
   the run stopped moving bytes, not which connection stalled.
 
-Worth trying when the server is far away or the link has real latency, and the
-transfer is clearly not saturating it. On a nearby server, or with many small
-files where per-file round-trips dominate, expect little or nothing: measure
-before you keep it. easySFTP's own numbers live in
-[`benchmarks/`](../benchmarks/README.md).
+Pin a number when your host has a connection limit you already know, or when
+you measured something better than what `auto` picks. easySFTP's own numbers
+live in [`benchmarks/`](../benchmarks/README.md).
 
 #### `permissions`
 

--- a/docs/easysftp.example.yml
+++ b/docs/easysftp.example.yml
@@ -67,16 +67,20 @@ safety:
   # Deleting the remote root ("/") is always refused, independent of this.
   max_deletes: 200
 
-# Transfer tuning; the defaults suit most deployments.
+# Transfer tuning. All three of these default to "auto", which means easySFTP
+# picks the value per deployment from what it is sending and from the link it
+# measured; see docs/tuning.md. A number is used verbatim and never tuned, and
+# each key is resolved on its own, so pinning one leaves the others adaptive.
 advanced:
   retries: 2 # per-file retries and reconnect budget; 0 disables
   timeout: 30 # connection timeout in seconds; 0 disables
   stall_timeout: 0 # abort after this many seconds without progress; 0 = off
-  concurrency: auto # files uploaded in parallel ("auto" = built-in default)
+  concurrency: auto # files uploaded in parallel
   request_concurrency: auto # in-flight SFTP requests per file
   # SSH connections uploads spread over. >1 lifts the single-TCP-flow ceiling
-  # on high-latency links; some servers limit connections per account.
-  connections: 1
+  # on high-latency links; some servers limit connections per account, so pin
+  # a number if yours does.
+  connections: auto
   skip_unchanged: false # overlay only: skip same-size remote files
 
 # Remote permission and timestamp handling (all best-effort).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,6 +57,24 @@ This is automatic and not configurable. If transfers still die mid-run, the
 connection itself is being reset (not just idled out); check for a very
 short server-side session/idle limit, or a flaky network path.
 
+### `the server would not open more than N SSH connection(s)`
+
+easySFTP sizes its connection pool itself (see [transfer tuning](tuning.md)),
+and this host allows fewer connections per account than it asked for. sshd's
+`MaxStartups` and the per-account limits of shared hosting are the usual
+reasons.
+
+It is a degradation, not a failure: the deploy finishes on the connections it
+has, and easySFTP stops asking for more for the rest of the run. If you see it
+on every deploy, pin the number your host allows and the warning goes away:
+
+```yaml
+advanced:
+  connections: 1
+```
+
+The other two settings stay adaptive; each one is resolved on its own.
+
 ### `connecting to <host>:22: ssh: handshake failed: ... unable to authenticate`
 
 The server rejected the credentials.

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,0 +1,175 @@
+# Transfer tuning
+
+easySFTP has three settings that decide how much work it does at once:
+
+| Setting | What it controls |
+|---|---|
+| `advanced.connections` | How many SSH connections the uploads spread over. |
+| `advanced.concurrency` | How many files are transferred in parallel, and how many independent remote scan / delete requests run at once. |
+| `advanced.request_concurrency` | How many SFTP write requests **one file** may have in flight (pipelining inside a single transfer). |
+
+All three default to `auto`, and `auto` means easySFTP works the value out for
+itself, per deployment, from what it is about to send and from the connection
+it just opened. **You do not have to set any of them.** This page explains what
+it does, so that when you do want to override something you know what you are
+overriding.
+
+> Before v3.6.0, `auto` was a synonym for a fixed `1` / `4` / `16`. It is not
+> any more. If you pinned numbers because the fixed defaults were slow for your
+> deploy, this is a good moment to try `auto` again.
+
+## The short version
+
+- **Many small files** get a lot of parallel workers and, on a link with real
+  latency, a handful of connections.
+- **A few large files** get one worker and one connection per file, and deeper
+  per-file pipelining.
+- **A redeploy that changes almost nothing** gets many workers (the "has this
+  changed?" checks are cheap and parallel well) and exactly one connection,
+  because a second SSH handshake would cost more than the whole deploy.
+- **A server one hop away** gets far less of everything than a server on
+  another continent, because the round-trips it is saving are worth less.
+
+## How the choice is made
+
+### 1. What is being deployed
+
+After the local scan, and again for each deployment right before its transfer,
+easySFTP knows the files it is about to send: how many, how large in total, the
+size of the biggest one, and how many pure metadata round-trips come with them
+(the one stat per file that `advanced.skip_unchanged` costs, the removals of a
+delete sweep).
+
+`concurrency` follows directly from that: as many workers as there are
+independent items, capped at 64. A worker with nothing to do never starts, so
+there is nothing to trade off.
+
+`request_concurrency` follows from the largest file. The setting counts 32 KiB
+write packets in flight for a single file, so a 4 KiB file cannot use a second
+one however high the number is; a 16 MiB file can use many. It stays at the
+long-standing 16 for a tree of small files and rises to at most 64 for large
+ones, which is where one SSH channel's 2 MiB window is full anyway.
+
+### 2. What the connection costs
+
+The first connection times its own handshake, then measures the round-trip time
+with three of the cheapest requests the protocol has (`SSH_FXP_REALPATH` of
+`.`, which reads nothing and writes nothing). Both feed the same model.
+
+An extra connection buys a second TCP flow, a second cipher stream and a second
+`sftp-server` process on the far side, and costs one full handshake. If a
+deploy would take `W` over one connection, `k` connections take roughly
+`W/k + (k-1)*H`, which is smallest at `k = sqrt(W/H)`: **open another
+connection while the time it saves is larger than the handshake it costs.**
+That is the whole rule. It is why a 2000-file deploy over a 13 ms line gets
+eight connections and a 1.3-second redeploy over the same line gets one.
+
+The pool is never larger than the number of files being uploaded (only the
+per-file upload path spreads over it), never larger than the worker count, and
+never larger than 8.
+
+### 3. What the transfer turns out to be like
+
+One thing cannot be known before any bytes move: how fast the link actually is.
+easySFTP starts from a deliberately conservative assumption and then measures.
+While a transfer runs, it watches the throughput it is really achieving and
+widens the connection pool if the work that is left still justifies another
+handshake. It grows at most one doubling at a time, and it stops for good the
+first time a step does not make things measurably faster.
+
+It also stops immediately if the server refuses a connection or if any upload
+has to be retried. A server that is already pushing back is not one to put more
+load on.
+
+The pool never shrinks (a handshake already paid is spent, and closing a
+connection would abort the files on it), and `concurrency` and
+`request_concurrency` never move at runtime: the first is already at the
+largest value that can be busy, and the second is fixed when an SFTP client is
+created.
+
+This runtime stage is what makes an overlay redeploy safe to start small. With
+`advanced.skip_unchanged` easySFTP cannot know in advance how many files really
+changed, so it sizes the run for the checks it is certain of. If it then turns
+out that most files *are* changing, the ratio it observes in the first second
+tells it, and the pool widens.
+
+## Overriding it
+
+Every setting is resolved on its own, so you can pin one and leave the rest
+adaptive:
+
+```yaml
+advanced:
+  connections: 2            # exactly 2, never more, never fewer
+  concurrency: auto         # chosen, knowing there are 2 connections
+  request_concurrency: 16   # exactly 16
+```
+
+A number you write is used verbatim and is never tuned, at any stage. The
+policy optimizes inside the constraints your numbers impose: with
+`connections: 2` above, the runtime stage is switched off entirely, because
+there is nothing it is allowed to change.
+
+Leaving a key out means the same as writing `auto`.
+
+### When to pin something
+
+- **Your server limits concurrent connections.** Shared hosting often does.
+  easySFTP degrades on its own (see below), but `connections: 1` avoids the
+  warning and the wasted handshake.
+- **Your server dislikes parallel writes.** Some SFTP servers behind a quota or
+  an antivirus hook serialize badly. `concurrency: 2` is a reasonable probe.
+- **You measured something better.** The numbers here are fitted against
+  [easySFTP's own benchmarks](../benchmarks/README.md) on one line. If you
+  measured a better configuration for your deploy, keep it.
+
+## What you will see in the log
+
+At the default log level a deployment that spreads over more than one
+connection says so once:
+
+```text
+auto tuning: spreading 2000 file(s) over up to 8 connections, 64 at a time
+```
+
+and a runtime change says what moved and on the strength of what measurement:
+
+```text
+auto tuning: 1.1 MiB/s over the connections in use; raising connections 2 -> 4 for the rest of this deployment
+```
+
+With `log-level: debug` every decision is printed in full, inputs first:
+
+```text
+auto tuning: files=2000 bytes=7.8 MiB largest=4.0 KiB probes=0 rtt=13ms handshake=384ms throughput=assumed 1.0 MiB/s -> connections=8 concurrency=64 request_concurrency=16
+```
+
+If the server will not open as many connections as easySFTP asked for, you get
+one warning and the run continues on what it has:
+
+```text
+the server would not open more than 2 SSH connection(s) (...); easySFTP had chosen more and continues with 2
+```
+
+That is a degradation, not a failure, and easySFTP stops asking for the rest of
+the run. If you see it on every deploy, pin `connections` to the number your
+host allows and the warning goes away.
+
+## Limits
+
+The policy is fitted against the sweeps under
+[`benchmarks/`](../benchmarks/README.md), which were measured over one line
+(around 13 ms round-trip, about 0.36 MiB/s per stream). Two consequences worth
+knowing:
+
+- The **hard caps** (8 connections, 64 workers, 64 requests per file) are
+  deliberate safety stops, not measured optima. The largest payload in the
+  sweeps was still getting faster at 8 connections.
+- On a link that is much faster than the one it was fitted on, easySFTP may
+  open a connection or two more than it needed to before its own measurement
+  corrects the assumption. The cost of that is bounded by the handshakes
+  themselves, which on a fast link are cheap.
+
+If your deploy is slower than you expect, `log-level: debug` prints the whole
+decision, and [troubleshooting](troubleshooting.md) covers the failure modes
+that are not about tuning at all.

--- a/internal/autotune/autotune.go
+++ b/internal/autotune/autotune.go
@@ -1,0 +1,420 @@
+// Package autotune resolves the transport settings a run left at "auto":
+// how many SSH connections it opens, how many files it uploads in parallel
+// and how many SFTP requests one file may have in flight.
+//
+// Nothing in here talks to a server or reads a clock. It is a cost model plus
+// the two decisions that fall out of it, so the whole policy can be replayed
+// against the stored benchmark grids (see regret_test.go) instead of being
+// argued about.
+//
+// # The three stages
+//
+// The policy runs in the three stages issue #209 describes, and each of them
+// only ever adds information to the same model:
+//
+//  1. Workload. After the local scan a run knows what it is about to send:
+//     how many files, how many bytes, the largest one, and how many pure
+//     metadata round-trips (skip stats, deletes) come with them. That is
+//     enough to size concurrency exactly and to bound the other two.
+//  2. Link. The first connection measures its own handshake, and a few cheap
+//     round-trips measure the RTT. Both go into Link and make the cost model
+//     concrete: an extra connection costs one handshake, and a round-trip
+//     costs one RTT.
+//  3. Runtime. What the model cannot know before the transfer is the link's
+//     throughput, so Plan starts from a deliberately conservative prior.
+//     Controller replaces that prior with the throughput the run is actually
+//     achieving and re-plans against the work that is left. See controller.go.
+//
+// # Why connections are the interesting knob
+//
+// Concurrency is free: a worker with no file to upload never starts, so the
+// useful value is the number of independent items the phase has, capped for
+// safety. Nothing about that needs measuring.
+//
+// A connection is not free. Every one past the first costs a full SSH
+// handshake (dialed on first use, and dialed under the session lock, so the
+// cost lands in the run's critical path), and it buys a second TCP flow, a
+// second cipher stream and a second sftp-server process on the far side. With
+// perfect scaling a run that takes W on one connection takes
+//
+//	T(k) = W/k + (k-1)*H
+//
+// on k of them, which is smallest at k = sqrt(W/H): open another connection
+// exactly while the time it saves is larger than the handshake it costs. That
+// single line is the whole connections policy; everything else in this file
+// exists to estimate W.
+//
+// # Where the constants come from
+//
+// The estimate of W is fitted against the sweeps under benchmarks/matrix/,
+// measured over a 13 ms line whose single stream carried about 0.36 MiB/s.
+// They are order-of-magnitude constants, not calibration: k depends on the
+// square root of W, so being wrong about W by a factor of four moves k by a
+// factor of two, and k is clamped hard at both ends anyway.
+package autotune
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+// Hard bounds on what the policy may choose. A user who writes a number gets
+// that number; these only ever bound "auto".
+const (
+	// MaxConnections is as far as the policy will go on its own. The stored
+	// sweeps still improve at 8 for the largest payload, so this is a safety
+	// stop rather than a measured optimum: sshd's MaxStartups and the
+	// per-account connection limits of shared hosting are real, and a policy
+	// that trips them for the last few percent is not a good default.
+	MaxConnections = 8
+
+	// MaxConcurrency bounds the files in flight. Past this the round-trips of
+	// one deploy stop being the limit and the server's own request handling
+	// starts to be, and the memory held by the in-flight write buffers grows
+	// with it (see maxInFlightPackets).
+	MaxConcurrency = 64
+
+	// MinRequestConcurrency is easySFTP's long-standing default and the floor
+	// the policy keeps: at 16 packets a file up to 512 KiB is fully
+	// pipelined, which covers most of what a web deploy contains.
+	MinRequestConcurrency = 16
+
+	// MaxRequestConcurrency is the SSH channel window expressed in packets.
+	// x/crypto/ssh (and OpenSSH) open a channel with a 2 MiB window and
+	// pkg/sftp writes 32 KiB packets, so 64 requests already fill the window
+	// one connection has. Asking for more cannot put more bytes on the wire.
+	MaxRequestConcurrency = 64
+)
+
+const (
+	// packetBytes is pkg/sftp's write packet size, which is what
+	// request_concurrency counts.
+	packetBytes = 32 * 1024
+
+	// maxInFlightPackets caps concurrency times request_concurrency. Each
+	// in-flight packet holds a 32 KiB buffer, so this is a 32 MiB ceiling on
+	// what the pipelining may cost in memory on a runner easySFTP does not
+	// own.
+	maxInFlightPackets = 1024
+
+	// uploadRoundTrips is how many remote round-trips one upload costs beyond
+	// its payload: open, write+close, chmod and rename.
+	uploadRoundTrips = 4
+
+	// uploadsInFlightPerConnection is how many upload chains one connection
+	// overlaps usefully. Fitted from the sweeps: a single connection tops out
+	// around 50 small files per second at a 13 ms RTT, which is a handful of
+	// chains rather than the dozens the worker count would suggest.
+	uploadsInFlightPerConnection = 4
+
+	// probesInFlightPerConnection is the same number for bare metadata
+	// round-trips (the skip stats of an overlay redeploy, deletes). They hold
+	// no file handle and carry no payload, so one connection pipelines far
+	// more of them: the stored redeploy sweep answers 500 stats in about
+	// 340 ms over one connection at a 13 ms RTT.
+	probesInFlightPerConnection = 16
+
+	// assumedStreamBytesPerSecond is the per-connection throughput Plan
+	// assumes while nothing has been measured yet. It is deliberately low.
+	// The number is only used to ask "is this run long enough to be worth
+	// another handshake", the answer is checked against the throughput the
+	// run really achieves as soon as it has one (see Controller), and the
+	// damage a wrong guess can do is bounded by MaxConnections handshakes.
+	assumedStreamBytesPerSecond = 1 << 20 // 1 MiB/s
+
+	// fallbackRTT and fallbackHandshake stand in when the probe could not
+	// measure the link at all (a server that refuses SSH_FXP_REALPATH, say).
+	// They describe an unremarkable internet path, so an unmeasurable link
+	// lands on a middling choice instead of an extreme one.
+	//
+	// Deriving the RTT from the handshake instead was tried and dropped: the
+	// ratio between the two is not a constant. The stored sweeps put an SSH
+	// handshake at 25 to 39 round-trips on one server, where the textbook
+	// answer is closer to six, so the derivation would have been a worse guess
+	// than the guess it replaced.
+	fallbackRTT       = 25 * time.Millisecond
+	fallbackHandshake = 300 * time.Millisecond
+)
+
+// Workload is what a run knows about the work in front of it. It is filled in
+// per deployment, from the plan, immediately before the transfer starts, so a
+// sync deployment describes the files it actually changed rather than the tree
+// it scanned.
+type Workload struct {
+	// Uploads is how many files will be sent, and UploadBytes their total
+	// size. LargestUpload is the biggest single one, which is the only file
+	// size request_concurrency can act on.
+	Uploads       int
+	UploadBytes   int64
+	LargestUpload int64
+
+	// Probes counts remote round-trips that are not uploads: the one stat per
+	// file that advanced.skip_unchanged costs, and the removals of a delete
+	// sweep. They are cheap individually and pipeline far better than an
+	// upload does, which is why they are counted apart.
+	Probes int
+
+	// Unknown marks a workload whose upload set is not settled yet: an
+	// overlay deployment with advanced.skip_unchanged decides file by file,
+	// while it runs, whether a file is sent at all. Plan then sizes the run
+	// for the stats it is sure of and leaves the rest to Controller, which
+	// sees the real ratio within the first second of the transfer.
+	Unknown bool
+}
+
+// Items is how many independent units of work the phase has, which is the
+// largest number of workers that can ever be busy at once.
+func (w Workload) Items() int {
+	return max(w.Uploads, w.Probes)
+}
+
+// Empty reports whether there is nothing to do.
+func (w Workload) Empty() bool { return w.Uploads == 0 && w.Probes == 0 }
+
+// Link is what a run knows about the path to its server. RTT and Handshake are
+// measured once, on the first connection; StreamBytesPerSecond is not
+// measurable before the transfer and stays zero until the run has moved enough
+// bytes to fill it in.
+type Link struct {
+	RTT       time.Duration
+	Handshake time.Duration
+
+	// StreamBytesPerSecond is what one connection has been observed to carry.
+	// Zero means "not measured yet" and makes Plan fall back to the
+	// conservative prior; see assumedStreamBytesPerSecond.
+	StreamBytesPerSecond float64
+}
+
+// rtt is the measured RTT, or a plain-internet stand-in when the probe could
+// not produce one. A link too fast for the platform clock is not this case:
+// the probe grows its batch until the clock can resolve it, so a successful
+// probe always reports something positive.
+func (l Link) rtt() time.Duration {
+	if l.RTT > 0 {
+		return l.RTT
+	}
+	return fallbackRTT
+}
+
+// handshake is the measured cost of one extra connection, or a stand-in.
+func (l Link) handshake() time.Duration {
+	if l.Handshake > 0 {
+		return l.Handshake
+	}
+	return fallbackHandshake
+}
+
+// streamBytesPerSecond is the measured per-connection throughput, or the prior.
+func (l Link) streamBytesPerSecond() float64 {
+	if l.StreamBytesPerSecond > 0 {
+		return l.StreamBytesPerSecond
+	}
+	return assumedStreamBytesPerSecond
+}
+
+// Measured reports whether the link carries an observed throughput rather than
+// the prior. Callers log the difference, because a decision taken on a guess
+// and one taken on a measurement deserve different confidence.
+func (l Link) Measured() bool { return l.StreamBytesPerSecond > 0 }
+
+// Fixed holds the values the user pinned in the config file. Zero means the
+// setting was left at "auto" and is the policy's to choose. Each field is
+// independent: a run may pin connections and let the other two be chosen.
+type Fixed struct {
+	Connections        int
+	Concurrency        int
+	RequestConcurrency int
+}
+
+// Any reports whether the user pinned anything at all.
+func (f Fixed) Any() bool {
+	return f.Connections > 0 || f.Concurrency > 0 || f.RequestConcurrency > 0
+}
+
+// All reports whether every setting is pinned, in which case there is nothing
+// to decide and no reason to probe the link.
+func (f Fixed) All() bool {
+	return f.Connections > 0 && f.Concurrency > 0 && f.RequestConcurrency > 0
+}
+
+// Settings is one resolved transport configuration.
+type Settings struct {
+	Connections        int
+	Concurrency        int
+	RequestConcurrency int
+}
+
+func (s Settings) String() string {
+	return fmt.Sprintf("connections=%d concurrency=%d request_concurrency=%d",
+		s.Connections, s.Concurrency, s.RequestConcurrency)
+}
+
+// Plan resolves every setting Fixed left at auto, honoring the ones it did
+// not: a pinned value is passed through untouched and constrains the rest, so
+// "connections: 2, concurrency: auto" chooses only the concurrency and does it
+// knowing there are two connections.
+func Plan(w Workload, l Link, f Fixed) Settings {
+	s := Settings{
+		Connections:        f.Connections,
+		Concurrency:        f.Concurrency,
+		RequestConcurrency: f.RequestConcurrency,
+	}
+	if s.Concurrency == 0 {
+		s.Concurrency = planConcurrency(w)
+	}
+	if s.RequestConcurrency == 0 {
+		s.RequestConcurrency = planRequestConcurrency(w, s.Concurrency)
+	}
+	if s.Connections == 0 {
+		s.Connections = planConnections(w, l, s.Concurrency)
+	}
+	return s
+}
+
+// planConcurrency sizes the parallel workers to the work: as many as there are
+// independent items, capped. A worker with nothing to do costs nothing (the
+// upload loop simply never starts it), so there is no trade-off to make here
+// and nothing for the runtime controller to discover later.
+func planConcurrency(w Workload) int {
+	items := w.Items()
+	if items < 1 {
+		return 1
+	}
+	return min(items, MaxConcurrency)
+}
+
+// planRequestConcurrency pipelines one file's writes as far as the file itself
+// can use, then as far as the memory budget allows.
+//
+// The setting is pkg/sftp's MaxConcurrentRequestsPerFile: how many 32 KiB write
+// packets of *one* file may be in flight. A 4 KiB file is a single packet and
+// cannot use a second request no matter what the value says, so raising it for
+// a tree of small files only reserves buffers. It is the large files that can
+// use it, and on a high-latency link they need it: with 16 packets in flight a
+// file moves at most 512 KiB per round-trip.
+func planRequestConcurrency(w Workload, concurrency int) int {
+	packets := 1
+	if w.LargestUpload > 0 {
+		packets = int(min((w.LargestUpload+packetBytes-1)/packetBytes, int64(MaxRequestConcurrency)))
+	}
+	want := max(packets, MinRequestConcurrency)
+
+	// Never let concurrency times request_concurrency reserve more than the
+	// in-flight budget, but never drop below the long-standing default doing
+	// so: a run with 64 files in flight is a run of small files, where the
+	// setting cannot do anything anyway.
+	budget := max(maxInFlightPackets/max(concurrency, 1), MinRequestConcurrency)
+	return min(want, budget, MaxRequestConcurrency)
+}
+
+// planConnections is the sqrt(W/H) rule from the package comment, clamped by
+// everything that makes an extra connection pointless rather than merely
+// unprofitable: there is no work for it (fewer files than connections), no
+// worker to put on it (concurrency), and no policy room above MaxConnections.
+func planConnections(w Workload, l Link, concurrency int) int {
+	if w.Uploads <= 1 {
+		// Only the per-file upload path spreads over the pool, so a
+		// deployment that sends one file (or none) can never use a second
+		// connection, however long it takes. This is the "one 32 MiB file"
+		// case of the stored sweeps, where every extra connection is a
+		// handshake for nothing.
+		return 1
+	}
+	work := SingleConnectionEstimate(w, l, concurrency)
+	handshake := l.handshake()
+	if work <= 0 || handshake <= 0 {
+		return 1
+	}
+	k := int(math.Round(math.Sqrt(float64(work) / float64(handshake))))
+	return min(max(k, 1), MaxConnections, w.Uploads, concurrency)
+}
+
+// SingleConnectionEstimate is W: how long this workload would take over one
+// connection at the given worker count. It is the only quantity the
+// connections decision rests on, so it is exported for the log line and for
+// the controller, which recomputes it for the work that is left.
+//
+// The three terms are the three things a transfer spends time on, and they are
+// added rather than maximised: a small-file upload really does pay its
+// round-trips and its bytes one after the other inside each chain.
+func SingleConnectionEstimate(w Workload, l Link, concurrency int) time.Duration {
+	rtt := l.rtt()
+	workers := max(concurrency, 1)
+
+	var total time.Duration
+	if w.Uploads > 0 {
+		chains := min(workers, uploadsInFlightPerConnection)
+		total += time.Duration(w.Uploads) * uploadRoundTrips * rtt / time.Duration(chains)
+	}
+	if w.Probes > 0 {
+		chains := min(workers, probesInFlightPerConnection)
+		total += time.Duration(w.Probes) * rtt / time.Duration(chains)
+	}
+	if w.UploadBytes > 0 {
+		total += time.Duration(float64(w.UploadBytes) / l.streamBytesPerSecond() * float64(time.Second))
+	}
+	return total
+}
+
+// Explain is the one line a run logs when it resolved something itself: what
+// the policy saw and what it decided, in that order, so a surprising choice
+// can be traced to the feature that caused it without rerunning anything.
+func Explain(w Workload, l Link, f Fixed, s Settings) string {
+	unknown := ""
+	if w.Unknown {
+		unknown = ", upload set not known yet"
+	}
+	rate := "assumed"
+	if l.Measured() {
+		rate = "measured"
+	}
+	return fmt.Sprintf(
+		"files=%d bytes=%s largest=%s probes=%d%s rtt=%s handshake=%s throughput=%s %s/s -> %s%s",
+		w.Uploads, humanBytes(w.UploadBytes), humanBytes(w.LargestUpload), w.Probes, unknown,
+		roundMS(l.rtt()), roundMS(l.handshake()),
+		rate, humanBytes(int64(l.streamBytesPerSecond())),
+		s, pinned(f))
+}
+
+// pinned names the settings the user fixed, so a log line never reads as if
+// easySFTP chose a number the workflow chose.
+func pinned(f Fixed) string {
+	var names []string
+	if f.Connections > 0 {
+		names = append(names, "connections")
+	}
+	if f.Concurrency > 0 {
+		names = append(names, "concurrency")
+	}
+	if f.RequestConcurrency > 0 {
+		names = append(names, "request_concurrency")
+	}
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return " (" + names[0] + " comes from the configuration, it was not chosen)"
+	default:
+		return " (" + strings.Join(names, ", ") + " come from the configuration, they were not chosen)"
+	}
+}
+
+func roundMS(d time.Duration) string { return d.Round(time.Millisecond).String() }
+
+// humanBytes renders IEC units the way the uploader's own log lines do. It is
+// spelled out here rather than imported because autotune must not depend on
+// the uploader: the dependency runs the other way.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for m := n / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/autotune/autotune_test.go
+++ b/internal/autotune/autotune_test.go
@@ -1,0 +1,236 @@
+package autotune_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
+)
+
+const (
+	KiB = 1 << 10
+	MiB = 1 << 20
+)
+
+// house is a round-numbered stand-in for the line the stored sweeps were
+// measured over: a 10 ms RTT and a 300 ms handshake. The real numbers are
+// 13 ms and ~360 ms; rounding them keeps the expectations below readable
+// without moving any of the decisions (regret_test.go replays the policy
+// against the measured values).
+var house = autotune.Link{RTT: 10 * time.Millisecond, Handshake: 300 * time.Millisecond}
+
+// TestPlanChoosesPerWorkload walks the shapes the benchmark scenarios are made
+// of. Each case names the measured optimum it is aiming at, so a constant that
+// drifts fails against the evidence rather than against a number somebody once
+// typed here.
+func TestPlanChoosesPerWorkload(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		w    autotune.Workload
+		want autotune.Settings
+		why  string
+	}{
+		{
+			name: "one large file cannot use a pool",
+			w:    autotune.Workload{Uploads: 1, UploadBytes: 32 * MiB, LargestUpload: 32 * MiB},
+			want: autotune.Settings{Connections: 1, Concurrency: 1, RequestConcurrency: 64},
+			why:  "only the per-file path spreads, so 32 MiB in one file is one connection however long it takes",
+		},
+		{
+			name: "two large files use one connection each",
+			w:    autotune.Workload{Uploads: 2, UploadBytes: 32 * MiB, LargestUpload: 16 * MiB},
+			want: autotune.Settings{Connections: 2, Concurrency: 2, RequestConcurrency: 64},
+			why:  "the stored 'large' sweep is fastest at 2/2 and cannot go above the file count",
+		},
+		{
+			name: "many small files",
+			w:    autotune.Workload{Uploads: 300, UploadBytes: 300 * 4 * KiB, LargestUpload: 4 * KiB},
+			want: autotune.Settings{Connections: 4, Concurrency: 64, RequestConcurrency: 16},
+			why:  "the stored 'small' sweep is fastest at 4 connections and flat past 32 workers",
+		},
+		{
+			name: "very many small files",
+			w:    autotune.Workload{Uploads: 2000, UploadBytes: 2000 * 4 * KiB, LargestUpload: 4 * KiB},
+			want: autotune.Settings{Connections: 8, Concurrency: 64, RequestConcurrency: 16},
+			why:  "the stored 'bulk' sweep still improves at the largest values swept",
+		},
+		{
+			name: "a redeploy that may skip everything",
+			w:    autotune.Workload{Probes: 500, LargestUpload: 4 * KiB, Unknown: true},
+			want: autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16},
+			why:  "500 stats are worth 64 workers and no second handshake; the stored 'redeploy' sweep is fastest at 1/64",
+		},
+		{
+			name: "a sync that changed three files",
+			w:    autotune.Workload{Uploads: 3, UploadBytes: 3 * 4 * KiB, LargestUpload: 4 * KiB},
+			want: autotune.Settings{Connections: 1, Concurrency: 3, RequestConcurrency: 16},
+			why:  "the whole transfer is shorter than one handshake",
+		},
+		{
+			name: "nothing to do",
+			w:    autotune.Workload{},
+			want: autotune.Settings{Connections: 1, Concurrency: 1, RequestConcurrency: 16},
+			why:  "an empty deployment must still resolve to something usable",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := autotune.Plan(tc.w, house, autotune.Fixed{}); got != tc.want {
+				t.Errorf("Plan() = %v, want %v\n%s", got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestPinnedSettingsAreNeverChanged is the promise the issue makes to anyone
+// who already tuned their deploy: a number in the config file is the number
+// the run uses, and the settings around it are chosen inside that constraint.
+func TestPinnedSettingsAreNeverChanged(t *testing.T) {
+	w := autotune.Workload{Uploads: 2000, UploadBytes: 2000 * 4 * KiB, LargestUpload: 4 * KiB}
+
+	got := autotune.Plan(w, house, autotune.Fixed{Connections: 2})
+	if got.Connections != 2 {
+		t.Errorf("a pinned connections=2 became %d", got.Connections)
+	}
+	if got.Concurrency != autotune.MaxConcurrency {
+		t.Errorf("concurrency = %d, want the workload's own value even next to a pinned pool", got.Concurrency)
+	}
+
+	got = autotune.Plan(w, house, autotune.Fixed{Concurrency: 3})
+	if got.Concurrency != 3 {
+		t.Errorf("a pinned concurrency=3 became %d", got.Concurrency)
+	}
+	if got.Connections > 3 {
+		t.Errorf("connections = %d, want at most the pinned worker count: a connection no worker picks is a handshake for nothing", got.Connections)
+	}
+
+	got = autotune.Plan(w, house, autotune.Fixed{RequestConcurrency: 7})
+	if got.RequestConcurrency != 7 {
+		t.Errorf("a pinned request_concurrency=7 became %d", got.RequestConcurrency)
+	}
+
+	all := autotune.Fixed{Connections: 5, Concurrency: 6, RequestConcurrency: 7}
+	if got := autotune.Plan(w, house, all); got != (autotune.Settings{Connections: 5, Concurrency: 6, RequestConcurrency: 7}) {
+		t.Errorf("a fully pinned configuration was rewritten to %v", got)
+	}
+	if !all.All() {
+		t.Error("Fixed.All() must report a fully pinned configuration, which is what switches the probe off")
+	}
+}
+
+// TestRequestConcurrencyFollowsFileSizeAndBudget: the setting is per-file
+// in-flight write packets, so only a file with several packets can use it, and
+// concurrency times request_concurrency is what it costs in buffers.
+func TestRequestConcurrencyFollowsFileSizeAndBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		w    autotune.Workload
+		want int
+	}{
+		{"a tree of 4 KiB files keeps the default", autotune.Workload{Uploads: 50, LargestUpload: 4 * KiB}, 16},
+		{"64 KiB files still keep the default", autotune.Workload{Uploads: 50, LargestUpload: 64 * KiB}, 16},
+		{"a 4 MiB file among few files pipelines fully", autotune.Workload{Uploads: 4, LargestUpload: 4 * MiB}, 64},
+		{"a 4 MiB file among many gives way to the budget", autotune.Workload{Uploads: 500, LargestUpload: 4 * MiB}, 16},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := autotune.Plan(tc.w, house, autotune.Fixed{}).RequestConcurrency; got != tc.want {
+				t.Errorf("request_concurrency = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPlanStaysInsideItsBounds is the safety net: whatever is thrown at the
+// policy, it must not ask for a value a server or a runner would choke on, and
+// it must never return zero, which every caller would read as "no limit".
+func TestPlanStaysInsideItsBounds(t *testing.T) {
+	links := []autotune.Link{
+		{}, // nothing measured
+		{RTT: time.Microsecond, Handshake: time.Microsecond},            // a local socket
+		{RTT: 2 * time.Second, Handshake: 20 * time.Second},             // a very bad path
+		{RTT: 10 * time.Millisecond, StreamBytesPerSecond: 1},           // a link measured as almost dead
+		{Handshake: 300 * time.Millisecond, StreamBytesPerSecond: 1e12}, // and one measured as absurdly fast
+	}
+	workloads := []autotune.Workload{
+		{},
+		{Uploads: 1_000_000, UploadBytes: 1 << 42, LargestUpload: 1 << 34},
+		{Probes: 1_000_000},
+		{Uploads: 1, UploadBytes: -1, LargestUpload: -1},
+	}
+	for _, l := range links {
+		for _, w := range workloads {
+			s := autotune.Plan(w, l, autotune.Fixed{})
+			switch {
+			case s.Connections < 1 || s.Connections > autotune.MaxConnections:
+				t.Errorf("connections %d out of bounds for %+v / %+v", s.Connections, w, l)
+			case s.Concurrency < 1 || s.Concurrency > autotune.MaxConcurrency:
+				t.Errorf("concurrency %d out of bounds for %+v / %+v", s.Concurrency, w, l)
+			case s.RequestConcurrency < autotune.MinRequestConcurrency || s.RequestConcurrency > autotune.MaxRequestConcurrency:
+				t.Errorf("request_concurrency %d out of bounds for %+v / %+v", s.RequestConcurrency, w, l)
+			case s.Connections > s.Concurrency:
+				t.Errorf("connections %d exceed concurrency %d for %+v / %+v", s.Connections, s.Concurrency, w, l)
+			}
+		}
+	}
+}
+
+// TestAnUnmeasuredLinkFallsBackInsteadOfDividingByZero: a server that refuses
+// SSH_FXP_REALPATH leaves the RTT at zero, and a Config built directly (a test,
+// or a caller that never probed) leaves the whole Link empty.
+func TestAnUnmeasuredLinkFallsBackInsteadOfDividingByZero(t *testing.T) {
+	w := autotune.Workload{Uploads: 200, UploadBytes: 200 * 8 * KiB, LargestUpload: 8 * KiB}
+	got := autotune.Plan(w, autotune.Link{}, autotune.Fixed{})
+	if got.Connections < 1 || got.Concurrency != 64 {
+		t.Fatalf("an unmeasured link produced %v", got)
+	}
+	if (autotune.Link{}).Measured() {
+		t.Error("an empty link must not claim a measured throughput")
+	}
+	if !(autotune.Link{StreamBytesPerSecond: 1}).Measured() {
+		t.Error("a link with an observed throughput must say so")
+	}
+}
+
+// TestMeasuredThroughputMovesTheDecision is the difference stage 3 makes: the
+// same files over a link that has been measured as slow are worth more
+// connections than the same files over the conservative prior are, and a link
+// measured as fast is worth fewer.
+func TestMeasuredThroughputMovesTheDecision(t *testing.T) {
+	w := autotune.Workload{Uploads: 60, UploadBytes: 12 * MiB, LargestUpload: 2 * MiB}
+
+	slow := house
+	slow.StreamBytesPerSecond = 300 * KiB
+	fast := house
+	fast.StreamBytesPerSecond = 50 * MiB
+
+	slowChoice := autotune.Plan(w, slow, autotune.Fixed{}).Connections
+	priorChoice := autotune.Plan(w, house, autotune.Fixed{}).Connections
+	fastChoice := autotune.Plan(w, fast, autotune.Fixed{}).Connections
+
+	if !(slowChoice > priorChoice && priorChoice > fastChoice) {
+		t.Errorf("connections should fall as the measured link gets faster, got slow=%d prior=%d fast=%d",
+			slowChoice, priorChoice, fastChoice)
+	}
+}
+
+// TestExplainNamesWhatWasNotChosen: the log line must never read as if
+// easySFTP picked a number the workflow picked.
+func TestExplainNamesWhatWasNotChosen(t *testing.T) {
+	w := autotune.Workload{Uploads: 10, UploadBytes: 40 * KiB, LargestUpload: 4 * KiB, Probes: 3}
+	f := autotune.Fixed{Concurrency: 4}
+	line := autotune.Explain(w, house, f, autotune.Plan(w, house, f))
+
+	for _, want := range []string{"files=10", "probes=3", "rtt=10ms", "handshake=300ms", "assumed", "concurrency=4", "concurrency comes from the configuration"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("the explanation is missing %q:\n%s", want, line)
+		}
+	}
+	if plain := autotune.Explain(w, house, autotune.Fixed{}, autotune.Plan(w, house, autotune.Fixed{})); strings.Contains(plain, "configuration") {
+		t.Errorf("a fully adaptive run must not claim anything came from the configuration:\n%s", plain)
+	}
+	unsettled := w
+	unsettled.Unknown = true
+	if line := autotune.Explain(unsettled, house, autotune.Fixed{}, autotune.Settings{}); !strings.Contains(line, "not known yet") {
+		t.Errorf("an unsettled upload set must say so:\n%s", line)
+	}
+}

--- a/internal/autotune/controller.go
+++ b/internal/autotune/controller.go
@@ -1,0 +1,259 @@
+package autotune
+
+import (
+	"fmt"
+	"time"
+)
+
+// Stage 3 of the policy: the part that runs while the transfer does.
+//
+// Plan has to guess one thing it cannot know before any bytes move, the link's
+// throughput, and it guesses low on purpose (see assumedStreamBytesPerSecond).
+// It also has to plan an overlay redeploy without knowing which of its files
+// advanced.skip_unchanged will actually send. Controller closes both gaps with
+// the only evidence that settles them: the transfer itself.
+//
+// What it may change, and what it deliberately may not:
+//
+//   - Connections grow. This is the whole point. The pool is dialed lazily, so
+//     raising the number costs one handshake per connection that a worker
+//     then really uses, and the same sqrt(W/H) rule decides whether the work
+//     that is *left* justifies it.
+//   - Connections never shrink. A handshake already paid is sunk, and closing
+//     a connection mid-transfer would abort the files on it.
+//   - Concurrency never moves. Plan already sizes it to the number of
+//     independent items, which is the largest value that can ever be busy;
+//     there is nothing for a hill climb to find.
+//   - request_concurrency never moves. It is pkg/sftp's
+//     MaxConcurrentRequestsPerFile, fixed when the client is created, so
+//     changing it would mean reconnecting.
+//
+// The controller is deliberately dull. It re-plans, it grows at most to double
+// the current pool per step, and it stops for good the first time a step fails
+// to pay off or the server pushes back. A deploy tool that oscillates its
+// connection count is worse than one that settles on a slightly wrong number.
+const (
+	// minObservation is how much transfer has to have happened before the
+	// first decision. Short enough that a run of a few seconds still gets one
+	// adjustment, long enough that the measurement is not one file's noise.
+	minObservation = 750 * time.Millisecond
+
+	// minSamples is the other half of that: a window that saw a single file
+	// finish says nothing about throughput.
+	minSamples = 4
+
+	// improvementBand is how much better a step has to make things before the
+	// controller believes it. Below this the two windows are the same
+	// measurement, and growing again would be reading noise as a signal.
+	improvementBand = 1.05
+
+	// growthFactor bounds one step. Doubling reaches MaxConnections from one
+	// connection in three steps, which is fast enough for a long run and slow
+	// enough that a wrong first reading cannot commit the whole pool.
+	growthFactor = 2
+)
+
+// Progress is what the upload phase reports to the controller. Everything is
+// cumulative since the phase started, except Elapsed, which is the phase's own
+// wall clock.
+type Progress struct {
+	Elapsed time.Duration
+
+	// Uploaded and Skipped are files that finished, Remaining the ones that
+	// have not. RemainingBytes is the planned size of those, which for an
+	// unsettled workload (skip_unchanged) is an upper bound rather than a
+	// promise.
+	Uploaded       int
+	Skipped        int
+	Remaining      int
+	RemainingBytes int64
+
+	// UploadedBytes is what actually went over the wire. It is the numerator
+	// of the throughput measurement, so it must count only real transfers and
+	// never a skipped file's size.
+	UploadedBytes int64
+
+	// Refused is set once the session could not open an extra connection, and
+	// Failures counts upload retries. Either one ends the growth: a server
+	// that is already refusing or erroring is not a server to ask for more.
+	Refused  bool
+	Failures int
+}
+
+// Controller refines a Plan while the upload phase runs. The zero value is not
+// usable; construct it with NewController. It is not safe for concurrent use,
+// and the uploader calls it from a single goroutine.
+type Controller struct {
+	fixed   Fixed
+	link    Link
+	current Settings
+
+	// stopped latches once there is nothing left to try.
+	stopped bool
+	reason  string
+
+	// last is the previous accepted observation, and pending records the
+	// throughput measured just before the most recent growth so the next
+	// observation can tell whether that growth paid off.
+	last        Progress
+	haveLast    bool
+	pendingRate float64
+}
+
+// NewController returns the controller for a deployment that Plan resolved to
+// start. It reports nothing to change while every setting it could move is
+// pinned by the user or already at its ceiling.
+func NewController(start Settings, l Link, f Fixed) *Controller {
+	c := &Controller{fixed: f, link: l, current: start}
+	switch {
+	case f.Connections > 0:
+		c.stop("connections come from the configuration")
+	case start.Connections >= MaxConnections:
+		c.stop("the pool is already at the policy maximum")
+	case start.Concurrency <= 1:
+		c.stop("only one file is in flight, so a second connection has nobody to serve")
+	}
+	return c
+}
+
+// Change is one accepted runtime adjustment, with the measurement behind it,
+// so the log line can say what moved and why in one sentence.
+type Change struct {
+	From, To Settings
+	// Rate is the aggregate throughput of the window that motivated the
+	// change, in bytes per second.
+	Rate float64
+}
+
+func (c Change) String() string {
+	return fmt.Sprintf("%s over the connections in use; raising connections %d -> %d for the rest of this deployment",
+		rateString(c.Rate), c.From.Connections, c.To.Connections)
+}
+
+// Settings is the configuration the controller currently stands behind.
+func (c *Controller) Settings() Settings { return c.current }
+
+// Stopped reports whether the controller has given up on further changes, and
+// why. The reason is a log line, not an error.
+func (c *Controller) Stopped() (bool, string) { return c.stopped, c.reason }
+
+func (c *Controller) stop(reason string) {
+	c.stopped, c.reason = true, reason
+}
+
+// Observe folds one progress report into the controller and reports the new
+// settings when it decided to change something. The bool is false whenever
+// nothing changed, which is the normal case: a controller that says nothing is
+// a controller that is content.
+func (c *Controller) Observe(p Progress) (Change, bool) {
+	none := Change{From: c.current, To: c.current}
+	if c.stopped {
+		return none, false
+	}
+	switch {
+	case p.Refused:
+		// The pool already hit a server-side limit. Asking again would only
+		// produce more refusals and more warnings.
+		c.stop("the server refused an extra connection")
+		return none, false
+	case p.Failures > 0:
+		c.stop("the transfer is retrying, so this is not the moment to add load")
+		return none, false
+	case p.Remaining <= c.current.Connections:
+		// Fewer files left than connections open: a new one would finish its
+		// handshake with nothing to carry.
+		return none, false
+	}
+	if p.Elapsed < minObservation || p.Uploaded+p.Skipped < minSamples {
+		return none, false
+	}
+
+	rate := c.throughput(p)
+	c.last, c.haveLast = p, true
+	if rate <= 0 {
+		// Nothing measurable moved in this window. A metadata-only phase (a
+		// redeploy that skips everything) lands here and is left alone, which
+		// is what the stored redeploy sweep says is right.
+		return none, false
+	}
+
+	// Did the previous growth pay for itself? Checked before planning the
+	// next one, so a pool that stopped scaling stops growing.
+	if c.pendingRate > 0 {
+		if rate < c.pendingRate*improvementBand {
+			c.stop(fmt.Sprintf("%s is no faster than the %s before the last connection was added, so the pool stays at %d",
+				rateString(rate), rateString(c.pendingRate), c.current.Connections))
+			return none, false
+		}
+		c.pendingRate = 0
+	}
+
+	want := Plan(c.remaining(p), c.measuredLink(p, rate), c.fixed)
+	grown := min(want.Connections, c.current.Connections*growthFactor, MaxConnections, c.current.Concurrency, p.Remaining)
+	if grown <= c.current.Connections {
+		return none, false
+	}
+	change := Change{From: c.current, To: c.current, Rate: rate}
+	c.pendingRate = rate
+	c.current.Connections = grown
+	change.To = c.current
+	if c.current.Connections >= MaxConnections {
+		c.stop("the pool reached the policy maximum")
+	}
+	return change, true
+}
+
+// throughput is the aggregate bytes per second of the window since the last
+// observation, falling back to the whole phase for the first one. A window is
+// used rather than the running average so a pool that just grew is judged on
+// what it did after growing.
+func (c *Controller) throughput(p Progress) float64 {
+	bytes, window := p.UploadedBytes, p.Elapsed
+	if c.haveLast {
+		bytes -= c.last.UploadedBytes
+		window -= c.last.Elapsed
+	}
+	if bytes <= 0 || window <= 0 {
+		return 0
+	}
+	return float64(bytes) / window.Seconds()
+}
+
+// measuredLink is the link with the prior replaced by what one connection is
+// really carrying. The aggregate is divided by the streams that were actually
+// serving files, not by the pool size: a pool whose tail no worker reached
+// would make every connection look slower than it is.
+func (c *Controller) measuredLink(p Progress, rate float64) Link {
+	streams := min(c.current.Connections, c.current.Concurrency, p.Uploaded+p.Remaining)
+	l := c.link
+	l.StreamBytesPerSecond = rate / float64(max(streams, 1))
+	return l
+}
+
+// remaining is the workload the run still has in front of it. For a settled
+// workload that is simply the files that have not finished. For an unsettled
+// one (advanced.skip_unchanged) the ratio observed so far is extrapolated: if
+// four in five files were skipped, a fifth of what is left will be uploaded,
+// and the bytes with it.
+func (c *Controller) remaining(p Progress) Workload {
+	done := p.Uploaded + p.Skipped
+	uploads, bytes := p.Remaining, p.RemainingBytes
+	probes := 0
+	if done > 0 && p.Skipped > 0 {
+		ratio := float64(p.Uploaded) / float64(done)
+		uploads = int(float64(p.Remaining) * ratio)
+		bytes = int64(float64(p.RemainingBytes) * ratio)
+		// Every remaining file still costs its stat, whether or not it is
+		// then sent.
+		probes = p.Remaining
+	}
+	largest := int64(0)
+	if uploads > 0 {
+		largest = bytes / int64(uploads)
+	}
+	return Workload{Uploads: uploads, UploadBytes: bytes, LargestUpload: largest, Probes: probes}
+}
+
+func rateString(bytesPerSecond float64) string {
+	return humanBytes(int64(bytesPerSecond)) + "/s"
+}

--- a/internal/autotune/controller_test.go
+++ b/internal/autotune/controller_test.go
@@ -1,0 +1,185 @@
+package autotune_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
+)
+
+// start is the configuration a byte-heavy deployment begins at: one
+// connection, because Plan had to assume the conservative throughput prior,
+// and enough workers for the files it has.
+var start = autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16}
+
+// TestControllerGrowsOnMeasuredThroughputThenStops is the whole of stage 3 in
+// one run: the transfer turns out to be far slower per stream than the prior
+// assumed, so the pool grows; it grows one doubling at a time; and the moment
+// a step stops paying for itself the controller settles instead of climbing on.
+func TestControllerGrowsOnMeasuredThroughputThenStops(t *testing.T) {
+	c := autotune.NewController(start, house, autotune.Fixed{})
+	if stopped, why := c.Stopped(); stopped {
+		t.Fatalf("a fresh controller with room to grow reported stopped: %s", why)
+	}
+
+	// One second in: 10 of 1000 files of 1 MiB each are through, so one stream
+	// carries about 10 MiB/s and the 990 MiB left would take a minute and a
+	// half on it. That is worth several handshakes.
+	first, ok := c.Observe(autotune.Progress{
+		Elapsed: time.Second, Uploaded: 10, Remaining: 990,
+		RemainingBytes: 990 * MiB, UploadedBytes: 10 * MiB,
+	})
+	if !ok {
+		t.Fatal("a stream measured far slower than the prior must widen the pool")
+	}
+	if first.From.Connections != 1 || first.To.Connections != 2 {
+		t.Fatalf("first step went %d -> %d, want one doubling from 1", first.From.Connections, first.To.Connections)
+	}
+	if !strings.Contains(first.String(), "raising connections 1 -> 2") {
+		t.Errorf("the change does not describe itself usefully: %s", first)
+	}
+
+	// The second connection tripled the throughput of the window, so the
+	// controller believes the step and takes the next one.
+	second, ok := c.Observe(autotune.Progress{
+		Elapsed: 2 * time.Second, Uploaded: 40, Remaining: 960,
+		RemainingBytes: 960 * MiB, UploadedBytes: 40 * MiB,
+	})
+	if !ok || second.To.Connections != 4 {
+		t.Fatalf("second step = %+v (changed: %v), want a doubling to 4", second, ok)
+	}
+
+	// This window is slower than the one before the growth, so the pool has
+	// stopped scaling and the controller stops with it.
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: 3 * time.Second, Uploaded: 45, Remaining: 955,
+		RemainingBytes: 955 * MiB, UploadedBytes: 45 * MiB,
+	}); ok {
+		t.Fatal("a step that did not pay off must not be followed by another")
+	}
+	stopped, why := c.Stopped()
+	if !stopped {
+		t.Fatal("the controller must settle once growing stops helping")
+	}
+	if !strings.Contains(why, "no faster") {
+		t.Errorf("the reason should say the measurement did not improve, got %q", why)
+	}
+	if c.Settings().Connections != 4 {
+		t.Errorf("settled at %d connections, want the last accepted 4", c.Settings().Connections)
+	}
+}
+
+// TestControllerLeavesShortAndMetadataOnlyPhasesAlone: the two cases the
+// stored sweeps say must not grow a pool are a run that finishes before a
+// handshake would pay for itself, and a redeploy whose files are all skipped.
+func TestControllerLeavesShortAndMetadataOnlyPhasesAlone(t *testing.T) {
+	t.Run("too early to say anything", func(t *testing.T) {
+		c := autotune.NewController(start, house, autotune.Fixed{})
+		if _, ok := c.Observe(autotune.Progress{
+			Elapsed: 100 * time.Millisecond, Uploaded: 1, Remaining: 999,
+			RemainingBytes: 999 * MiB, UploadedBytes: MiB,
+		}); ok {
+			t.Error("a 100 ms window is not a measurement")
+		}
+	})
+
+	t.Run("a redeploy that skips everything", func(t *testing.T) {
+		c := autotune.NewController(autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16}, house, autotune.Fixed{})
+		for i := 1; i <= 5; i++ {
+			p := autotune.Progress{
+				Elapsed:   time.Duration(i) * time.Second,
+				Skipped:   i * 100,
+				Remaining: 500 - i*100,
+			}
+			if _, ok := c.Observe(p); ok {
+				t.Fatalf("a phase that moved no bytes must not open connections (observation %d)", i)
+			}
+		}
+		if c.Settings().Connections != 1 {
+			t.Errorf("connections = %d, want to stay at 1", c.Settings().Connections)
+		}
+	})
+
+	t.Run("fewer files left than connections", func(t *testing.T) {
+		c := autotune.NewController(autotune.Settings{Connections: 4, Concurrency: 64, RequestConcurrency: 16}, house, autotune.Fixed{})
+		if _, ok := c.Observe(autotune.Progress{
+			Elapsed: 5 * time.Second, Uploaded: 996, Remaining: 4,
+			RemainingBytes: 4 * MiB, UploadedBytes: 996 * MiB,
+		}); ok {
+			t.Error("a fifth connection cannot help four remaining files")
+		}
+	})
+}
+
+// TestControllerStandsDownWhenTheServerPushesBack: a refused connection or a
+// retrying transfer means the far side is already at a limit. Adding load then
+// is the wrong instinct, and the reason has to be legible in the log.
+func TestControllerStandsDownWhenTheServerPushesBack(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		p    autotune.Progress
+		why  string
+	}{
+		{"a refused connection", autotune.Progress{Refused: true}, "refused"},
+		{"a retrying transfer", autotune.Progress{Failures: 1}, "retrying"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := autotune.NewController(start, house, autotune.Fixed{})
+			p := tc.p
+			p.Elapsed, p.Uploaded, p.Remaining = 2*time.Second, 100, 900
+			p.RemainingBytes, p.UploadedBytes = 900*MiB, 100*MiB
+			if _, ok := c.Observe(p); ok {
+				t.Fatal("the pool must not grow while the server is pushing back")
+			}
+			stopped, why := c.Stopped()
+			if !stopped || !strings.Contains(why, tc.why) {
+				t.Errorf("stopped=%v reason=%q, want a stop mentioning %q", stopped, why, tc.why)
+			}
+		})
+	}
+}
+
+// TestControllerNeverOverridesTheConfiguration: with advanced.connections
+// pinned there is nothing the runtime half is allowed to do, and it must not
+// even start.
+func TestControllerNeverOverridesTheConfiguration(t *testing.T) {
+	c := autotune.NewController(autotune.Settings{Connections: 2, Concurrency: 64, RequestConcurrency: 16},
+		house, autotune.Fixed{Connections: 2})
+	stopped, why := c.Stopped()
+	if !stopped || !strings.Contains(why, "configuration") {
+		t.Fatalf("a pinned pool must switch the controller off, got stopped=%v %q", stopped, why)
+	}
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: 10 * time.Second, Uploaded: 10, Remaining: 990,
+		RemainingBytes: 990 * MiB, UploadedBytes: MiB,
+	}); ok {
+		t.Error("a stopped controller changed something anyway")
+	}
+}
+
+// TestControllerStopsAtTheCeiling: once the pool is as wide as the policy
+// allows there is nothing left to decide, and the loop should not keep asking.
+func TestControllerStopsAtTheCeiling(t *testing.T) {
+	c := autotune.NewController(autotune.Settings{Connections: autotune.MaxConnections, Concurrency: 64}, house, autotune.Fixed{})
+	if stopped, why := c.Stopped(); !stopped || !strings.Contains(why, "maximum") {
+		t.Errorf("stopped=%v reason=%q, want a stop at the ceiling", stopped, why)
+	}
+}
+
+// TestControllerExtrapolatesAnUnsettledUploadSet is the case Plan cannot see:
+// an overlay redeploy with advanced.skip_unchanged starts sized for its stats,
+// and only the ratio of real uploads to skips, observed while it runs, says
+// whether it is a metadata sweep or a full deploy in disguise.
+func TestControllerExtrapolatesAnUnsettledUploadSet(t *testing.T) {
+	c := autotune.NewController(start, house, autotune.Fixed{})
+	// Half of the first 200 files turned out to be changed, at about 4 MiB/s
+	// on the one stream: the 800 that are left are another 400 uploads.
+	change, ok := c.Observe(autotune.Progress{
+		Elapsed: time.Second, Uploaded: 100, Skipped: 100, Remaining: 800,
+		RemainingBytes: 800 * MiB, UploadedBytes: 4 * MiB,
+	})
+	if !ok || change.To.Connections <= change.From.Connections {
+		t.Fatalf("a redeploy that is really uploading must widen the pool, got %+v (changed: %v)", change, ok)
+	}
+}

--- a/internal/autotune/regret_test.go
+++ b/internal/autotune/regret_test.go
@@ -1,0 +1,374 @@
+package autotune_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
+	"github.com/eiserv/easySFTP/internal/benchmark/scenario"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// This file is the acceptance test issue #209 asks for: replay the policy over
+// the settings sweeps that are committed under benchmarks/matrix/, and score
+// what it picks against the fastest cell those sweeps measured.
+//
+//	regret = auto_duration / best_matrix_duration - 1
+//
+// It is a real test rather than a note in a report because the alternative is
+// a policy whose constants nobody may touch without rerunning a multi-hour
+// sweep. Two things keep it honest and two keep it from being a tripwire:
+//
+//   - Honest: the workload comes from internal/benchmark/scenario, the same
+//     tables that built the payloads, so the features are the ones a run would
+//     really compute. The link comes from the sweep's own probes, so the RTT
+//     and the handshake are the ones that sweep saw.
+//   - Not a tripwire: only sweeps with at least three repeats per cell are
+//     read (a single-repeat grid is one sample per cell and its "best" is
+//     often noise), and a gap of a few hundred milliseconds on a run of one or
+//     two seconds passes on its absolute size. The issue allows exactly that:
+//     "accepting larger gaps only where setup cost/noise makes the absolute
+//     difference trivial".
+//
+// The replay can only score stages 1 and 2. A grid cell is a fixed
+// configuration measured from its first byte, so there is nothing in it for
+// the runtime controller to react to; what the controller adds is on top of
+// the numbers below, not in them.
+//
+// When this fails after a policy change, read the per-scenario table it
+// prints: it names the cell the policy chose, the cell that won, and the two
+// durations. When it fails after a *new sweep* is stored, the numbers moved
+// and the policy has to be refitted, which is the point.
+const (
+	// regretTarget is the issue's own acceptance threshold.
+	regretTarget = 0.15
+
+	// trivialGap is how small an absolute difference has to be before the
+	// percentage stops meaning anything. The stored sweeps' own canary spread
+	// (the same cell measured at the start, the middle and the end of a grid)
+	// is around 9%, and the scenarios that land here are 1.3 second runs.
+	trivialGap = 300 * time.Millisecond
+
+	// minRepeats is the smallest number of repeats a sweep must have before
+	// its best cell is treated as a measurement rather than a sample.
+	minRepeats = 3
+)
+
+func TestPolicyRegretAgainstStoredSweeps(t *testing.T) {
+	sweeps := storedSweeps(t)
+	if len(sweeps) == 0 {
+		t.Fatal("no sweep with enough repeats found under benchmarks/matrix; this test would pass vacuously")
+	}
+	for _, sweep := range sweeps {
+		t.Run(sweep.name, func(t *testing.T) {
+			link := sweep.link()
+			t.Logf("replaying against a %s / %s link", link.RTT.Round(time.Millisecond), link.Handshake.Round(time.Millisecond))
+			for _, group := range sweep.groups() {
+				w, err := workloadOf(group.scenario)
+				if err != nil {
+					t.Fatalf("%s: %v", group.scenario, err)
+				}
+				chosen := autotune.Plan(w, link, autotune.Fixed{})
+				at, ok := group.nearest(chosen)
+				if !ok {
+					// The policy picked coordinates this grid did not measure
+					// at all. Nothing to score, and silently dropping it would
+					// make the test look more complete than it is.
+					t.Logf("%-16s chose %v: not on this grid, skipped", group.scenario, chosen)
+					continue
+				}
+				best := group.best()
+				gap := time.Duration(at.MedianMS-best.MedianMS) * time.Millisecond
+				regret := at.MedianMS/best.MedianMS - 1
+
+				t.Logf("%-16s chose %d/%d/%s -> %s, best %d/%d/%s -> %s, regret %+.1f%%",
+					group.scenario, chosen.Connections, chosen.Concurrency, request(chosen.RequestConcurrency),
+					ms(at.MedianMS), best.Connections, best.Concurrency, requestOf(best.RequestConcurrency),
+					ms(best.MedianMS), regret*100)
+
+				if regret > regretTarget && gap > trivialGap {
+					t.Errorf("%s: the policy is %.1f%% (%s) behind the fastest cell, over the %.0f%% target",
+						group.scenario, regret*100, gap.Round(time.Millisecond), regretTarget*100)
+				}
+			}
+		})
+	}
+}
+
+// TestTheFixedDefaultsWouldFailThisTest is the control. 1/4/16 is what "auto"
+// resolved to before this package existed, and the point of the exercise is
+// that it is not defensible: if the replay above ever stopped separating the
+// two, it would have stopped measuring anything.
+func TestTheFixedDefaultsWouldFailThisTest(t *testing.T) {
+	old := autotune.Settings{Connections: 1, Concurrency: 4, RequestConcurrency: 16}
+	worst := 0.0
+	for _, sweep := range storedSweeps(t) {
+		for _, group := range sweep.groups() {
+			at, ok := group.nearest(old)
+			if !ok {
+				continue
+			}
+			worst = math.Max(worst, at.MedianMS/group.best().MedianMS-1)
+		}
+	}
+	if worst <= regretTarget {
+		t.Errorf("the pre-adaptive defaults come out %.1f%% behind the best cell, which is inside the %.0f%% target: "+
+			"this replay is no longer telling a good policy from a bad one", worst*100, regretTarget*100)
+	}
+	t.Logf("the pre-adaptive fixed 1/4/16 is up to %.0f%% behind the best cell", worst*100)
+}
+
+// workloadOf rebuilds the features a run would compute for one benchmark
+// scenario, from the tables that generated its payload.
+//
+// The shape matters as much as the payload. A prepopulated overlay scenario is
+// measured with advanced.skip_unchanged, so its upload set is not settled when
+// the policy runs and every file costs a stat; a prepopulated sync scenario has
+// already read its manifest, so it knows it is sending scenario.ChangedFiles
+// files and nothing else.
+func workloadOf(name string) (autotune.Workload, error) {
+	groups, err := scenario.Spec(name)
+	if err != nil {
+		return autotune.Workload{}, err
+	}
+	shape := scenario.ShapeOf(name)
+
+	var files int
+	var bytes, largest int64
+	for _, g := range groups {
+		files += g.Count
+		bytes += int64(g.Count) * int64(g.KiB) * KiB
+		largest = max(largest, int64(g.KiB)*KiB)
+	}
+
+	switch {
+	case shape.Prepopulate && shape.Mode == "sync":
+		changed := min(scenario.ChangedFiles, files)
+		return autotune.Workload{
+			Uploads:       changed,
+			UploadBytes:   bytes / int64(max(files, 1)) * int64(changed),
+			LargestUpload: largest,
+		}, nil
+	case shape.Prepopulate:
+		return autotune.Workload{Probes: files, LargestUpload: largest, Unknown: true}, nil
+	default:
+		return autotune.Workload{Uploads: files, UploadBytes: bytes, LargestUpload: largest}, nil
+	}
+}
+
+// sweep is one stored matrix result, reduced to what the replay needs.
+type sweep struct {
+	name   string
+	matrix schema.Matrix
+}
+
+// storedSweeps reads every committed matrix result with enough repeats to be
+// worth scoring against.
+func storedSweeps(t *testing.T) []sweep {
+	t.Helper()
+	dir, err := filepath.Abs(filepath.Join("..", "..", "benchmarks", "matrix"))
+	if err != nil {
+		t.Fatalf("locating benchmarks/matrix: %v", err)
+	}
+	paths, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		t.Fatalf("listing benchmarks/matrix: %v", err)
+	}
+	var out []sweep
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		var env schema.Envelope
+		if err := json.Unmarshal(data, &env); err != nil {
+			t.Fatalf("decoding %s: %v", path, err)
+		}
+		var m schema.Matrix
+		if err := json.Unmarshal(env.Benchmark, &m); err != nil {
+			t.Fatalf("decoding the measurement in %s: %v", path, err)
+		}
+		if m.Repeats < minRepeats || len(m.Cells) == 0 {
+			continue
+		}
+		if m.Link == nil || len(m.Link.Probes) == 0 {
+			// Without the sweep's own probes there is no link to replay
+			// against, and inventing one would score the policy on a path
+			// nobody measured.
+			continue
+		}
+		out = append(out, sweep{name: strings.TrimSuffix(filepath.Base(path), ".json"), matrix: m})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+	return out
+}
+
+// link is the path that sweep was measured over: the median of its own probes.
+// Those come from cmd/linkprobe, which never goes through the uploader, so
+// they are exactly the numbers a run's own probe would try to reproduce.
+func (s sweep) link() autotune.Link {
+	var rtts, handshakes []float64
+	if s.matrix.Link != nil {
+		for _, p := range s.matrix.Link.Probes {
+			if p.RTTMS != nil && p.RTTMS.P50 != nil {
+				rtts = append(rtts, *p.RTTMS.P50)
+			}
+			if p.HandshakeMS != nil {
+				handshakes = append(handshakes, *p.HandshakeMS)
+			}
+		}
+	}
+	return autotune.Link{
+		RTT:       millis(median(rtts)),
+		Handshake: millis(median(handshakes)),
+	}
+}
+
+// cellGroup is every cell of one scenario on one link profile, which is the
+// set a single decision is scored inside.
+type cellGroup struct {
+	scenario, profile string
+	cells             []schema.Cell
+}
+
+// groups collects the candidate build's cells. A baseline build's grid belongs
+// to a different product and a regret against it would compare two things.
+func (s sweep) groups() []cellGroup {
+	byKey := map[string]*cellGroup{}
+	var order []string
+	for _, c := range s.matrix.Cells {
+		if c.Label != "candidate" {
+			continue
+		}
+		key := c.Scenario + "/" + c.LinkProfile
+		g, ok := byKey[key]
+		if !ok {
+			g = &cellGroup{scenario: c.Scenario, profile: c.LinkProfile}
+			byKey[key] = g
+			order = append(order, key)
+		}
+		g.cells = append(g.cells, c)
+	}
+	sort.Strings(order)
+	out := make([]cellGroup, 0, len(order))
+	for _, key := range order {
+		out = append(out, *byKey[key])
+	}
+	return out
+}
+
+func (g cellGroup) best() schema.Cell {
+	best := g.cells[0]
+	for _, c := range g.cells[1:] {
+		if c.MedianMS < best.MedianMS {
+			best = c
+		}
+	}
+	return best
+}
+
+// nearest is the measured cell closest to what the policy chose, per axis,
+// ties going to the larger value. A grid is a handful of powers of two, so the
+// exact choice usually is not on it; the nearest measured neighbour is the
+// closest this replay can get to what the run would have done.
+func (g cellGroup) nearest(s autotune.Settings) (schema.Cell, bool) {
+	conns := axis(g.cells, func(c schema.Cell) int { return c.Connections })
+	concs := axis(g.cells, func(c schema.Cell) int { return c.Concurrency })
+	var requests []int
+	for _, c := range g.cells {
+		if c.RequestConcurrency != nil {
+			requests = append(requests, *c.RequestConcurrency)
+		}
+	}
+	requests = dedup(requests)
+
+	wantConn, wantConc := snap(conns, s.Connections), snap(concs, s.Concurrency)
+	var wantRequest *int
+	if len(requests) > 0 {
+		r := snap(requests, s.RequestConcurrency)
+		wantRequest = &r
+	}
+	for _, c := range g.cells {
+		if c.Connections != wantConn || c.Concurrency != wantConc {
+			continue
+		}
+		if (c.RequestConcurrency == nil) != (wantRequest == nil) {
+			continue
+		}
+		if wantRequest != nil && *c.RequestConcurrency != *wantRequest {
+			continue
+		}
+		return c, true
+	}
+	return schema.Cell{}, false
+}
+
+func axis(cells []schema.Cell, of func(schema.Cell) int) []int {
+	values := make([]int, 0, len(cells))
+	for _, c := range cells {
+		values = append(values, of(c))
+	}
+	return dedup(values)
+}
+
+func dedup(values []int) []int {
+	seen := map[int]bool{}
+	out := values[:0:0]
+	for _, v := range values {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	sort.Ints(out)
+	return out
+}
+
+func snap(values []int, want int) int {
+	best := values[0]
+	for _, v := range values[1:] {
+		switch d, bd := abs(v-want), abs(best-want); {
+		case d < bd, d == bd && v > best:
+			best = v
+		}
+	}
+	return best
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func median(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sort.Float64s(values)
+	return values[len(values)/2]
+}
+
+func millis(v float64) time.Duration { return time.Duration(v * float64(time.Millisecond)) }
+
+func ms(v float64) string { return fmt.Sprintf("%.0f ms", v) }
+
+// request renders a chosen request_concurrency, and requestOf the one a cell
+// was measured at: a grid pass that set nothing is "default", which is not the
+// same as any measured number.
+func request(v int) string { return fmt.Sprint(v) }
+
+func requestOf(p *int) string {
+	if p == nil {
+		return "default"
+	}
+	return fmt.Sprint(*p)
+}

--- a/internal/benchmark/driver/driver_test.go
+++ b/internal/benchmark/driver/driver_test.go
@@ -241,8 +241,9 @@ func TestMatrix(t *testing.T) {
 	}
 
 	// The policy measurement of issue #184 phase 5. The stub resolves "auto" to
-	// easySFTP's own defaults (1/4/16) and gets faster with more parallelism,
-	// so the best cell of "small" is 2/4 and auto must come out behind it.
+	// a fixed 1/4/16 (see the comment in stub_test.go) and gets faster with
+	// more parallelism, so the best cell of "small" is 2/4 and auto must come
+	// out behind it.
 	if len(result.Auto) != 2 {
 		t.Errorf("measured auto %d time(s), want once per scenario and profile", len(result.Auto))
 	}

--- a/internal/benchmark/driver/stub_test.go
+++ b/internal/benchmark/driver/stub_test.go
@@ -79,10 +79,12 @@ func stubMain() {
 		source = stubQuoted(text, "    source:")
 		target = stubQuoted(text, "    target:")
 		mode = stubBare(text, "    mode:")
-		// "auto" resolves to easySFTP's own defaults here, exactly as autoInt.or
-		// does in internal/config/configfile.go: an auto run has to come out
-		// somewhere on the grid, otherwise the regret arithmetic has nothing to
-		// compare.
+		// "auto" resolves to a fixed 1/4/16 here, which is what a real build
+		// did before internal/autotune existed. The stub deliberately does not
+		// reimplement the policy: what these tests check is that an auto run
+		// is measured, kept off the grid and scored against it, and for that
+		// the run only has to land somewhere on the grid. Whether the policy
+		// lands well is internal/autotune's own regret test.
 		connections = stubSetting(text, "  connections:", 1)
 		concurrency = stubSetting(text, "  concurrency:", 4)
 		requests = stubSetting(text, "  request_concurrency:", 16)

--- a/internal/benchmark/matrix.go
+++ b/internal/benchmark/matrix.go
@@ -317,7 +317,16 @@ func matrixAuto(runs []RunRecord, cells []schema.Cell) []schema.Auto {
 			Connections:        stats.Median(counterValues(ms, "config_connections")),
 			Concurrency:        stats.Median(counterValues(ms, "config_concurrency")),
 			RequestConcurrency: stats.Median(counterValues(ms, "config_request_concurrency")),
+
+			// What the policy picked up front, next to what the run ended
+			// with: the gap between the two is the runtime controller's doing
+			// (issue #209).
+			InitialConnections:        stats.Median(counterValues(ms, "auto_initial_connections")),
+			InitialConcurrency:        stats.Median(counterValues(ms, "auto_initial_concurrency")),
+			InitialRequestConcurrency: stats.Median(counterValues(ms, "auto_initial_request_concurrency")),
+			Changes:                   stats.Median(counterValues(ms, "auto_changes")),
 		}
+		workload := autoWorkload(ms)
 
 		auto := schema.Auto{
 			Scenario:    group[0].Scenario,
@@ -334,6 +343,7 @@ func matrixAuto(runs []RunRecord, cells []schema.Cell) []schema.Auto {
 			MaxMS:       stats.Or(stats.Max(stats.Nums(durations)), 0),
 			MadMS:       stats.Mad(durations),
 			Chosen:      chosen,
+			Workload:    workload,
 			MiBPerS:     stats.MiBPerS(bytes, median),
 			FilesPerS:   stats.Ratio(files, median),
 		}
@@ -358,6 +368,34 @@ func matrixAuto(runs []RunRecord, cells []schema.Cell) []schema.Auto {
 		return stats.Key{a.LinkProfile, a.Scenario}
 	})
 	return out
+}
+
+// autoWorkload reads back the features the policy saw. A build that does not
+// report them (every one before issue #209) leaves the whole block out rather
+// than filling it with zeros, which would read as "measured nothing".
+func autoWorkload(ms []*schema.Metrics) *schema.AutoWorkload {
+	w := schema.AutoWorkload{
+		Files:        stats.Median(counterValues(ms, "workload_files")),
+		Bytes:        stats.Median(counterValues(ms, "workload_bytes")),
+		LargestBytes: stats.Median(counterValues(ms, "workload_largest_bytes")),
+		Probes:       stats.Median(counterValues(ms, "workload_probes")),
+		RTTMS:        micros(stats.Median(counterValues(ms, "link_rtt_us"))),
+		HandshakeMS:  micros(stats.Median(counterValues(ms, "link_handshake_us"))),
+	}
+	if w == (schema.AutoWorkload{}) {
+		return nil
+	}
+	return &w
+}
+
+// micros converts a counter kept in microseconds (counters are integers, and a
+// 13 ms RTT rounds to nothing in whole milliseconds) into the milliseconds
+// every other duration in these documents is in.
+func micros(v *float64) *float64 {
+	if v == nil {
+		return nil
+	}
+	return stats.Ptr(*v / 1000)
 }
 
 func bestCandidateCell(cells []schema.Cell, scenario, profile string) *schema.Cell {

--- a/internal/benchmark/report/matrix.go
+++ b/internal/benchmark/report/matrix.go
@@ -273,10 +273,10 @@ func (m Matrix) autoCost(b *buf) {
 	b.line("")
 	// Through "%s": the sentence carries a literal per cent sign, and vet reads
 	// a bare string here as a format.
-	b.line("%s", "One run per scenario and profile with `connections`, `concurrency` and `request_concurrency` all set to `auto`, on the candidate build, measured next to the cells it is scored against. `Picked` is read out of the run's own counters, so it is what easySFTP did and not what this script assumes; `Best` is the fastest cell of the same scenario and profile. `Regret` is the gap between them: how much slower the policy is than the settings a sweep would have chosen. A policy within ~15% on every profile is defensible, one that only wins on the house line is not (issue #184, phase 5; the policy itself is #156).")
+	b.line("%s", "One run per scenario and profile with `connections`, `concurrency` and `request_concurrency` all set to `auto`, on the candidate build, measured next to the cells it is scored against. `Picked` is read out of the run's own counters, so it is what easySFTP did and not what this script assumes; `Best` is the fastest cell of the same scenario and profile. `Regret` is the gap between them: how much slower the policy is than the settings a sweep would have chosen. A policy within ~15% on every profile is defensible, one that only wins on the house line is not (issue #184, phase 5; the policy itself is #209).")
 	b.line("")
-	b.line("| Scenario | Profile | Picked (conn/conc/req) | auto | Best cell | Best | Regret | Same cell in grid |")
-	b.line("|---|---|---|---|---|---|---|---|")
+	b.line("| Scenario | Profile | Picked (conn/conc/req) | Started at | Changes | auto | Best cell | Best | Regret | Same cell in grid |")
+	b.line("|---|---|---|---|---|---|---|---|---|---|")
 	for _, a := range m.Result.Auto {
 		best := "-"
 		bestMS := "-"
@@ -289,13 +289,49 @@ func (m Matrix) autoCost(b *buf) {
 		if a.ChosenInGrid {
 			inGrid = raw(a.ChosenCellMedianMS) + " ms"
 		}
-		b.line("| %s | %s | %s/%s/%s | %s ms | %s | %s | %s | %s |",
+		b.line("| %s | %s | %s/%s/%s | %s/%s/%s | %s | %s ms | %s | %s | %s | %s |",
 			a.Scenario, a.LinkProfile,
 			raw(a.Chosen.Connections), raw(a.Chosen.Concurrency), raw(a.Chosen.RequestConcurrency),
+			raw(a.Chosen.InitialConnections), raw(a.Chosen.InitialConcurrency), raw(a.Chosen.InitialRequestConcurrency),
+			raw(a.Chosen.Changes),
 			num(a.MedianMS), best, bestMS, percent(a.RegretPercent), inGrid)
 	}
 	b.line("")
-	b.line("The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the `auto` column means the two runs saw different conditions, and then the regret next to it is drift rather than policy. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all.")
+	b.line("`Started at` is what the policy chose before the transfer taught it anything, and `Changes` how many times it widened the connection pool while the transfer ran; when the two coordinate columns agree, the run was decided entirely up front. The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the `auto` column means the two runs saw different conditions, and then the regret next to it is drift rather than policy. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all.")
+	m.autoWorkload(b)
+}
+
+// autoWorkload prints the input side of each decision. The regret table says
+// what the policy chose; this says what it was looking at, which is what makes
+// a surprising choice readable without rerunning the sweep (issue #209).
+func (m Matrix) autoWorkload(b *buf) {
+	rows := 0
+	for _, a := range m.Result.Auto {
+		if a.Workload != nil {
+			rows++
+		}
+	}
+	if rows == 0 {
+		return
+	}
+	b.line("")
+	b.line("<details><summary>What the policy was looking at</summary>")
+	b.line("")
+	b.line("| Scenario | Profile | Files | Bytes | Largest file | Probes | RTT | Handshake |")
+	b.line("|---|---|---|---|---|---|---|---|")
+	for _, a := range m.Result.Auto {
+		w := a.Workload
+		if w == nil {
+			continue
+		}
+		b.line("| %s | %s | %s | %s | %s | %s | %s ms | %s ms |",
+			a.Scenario, a.LinkProfile, raw(w.Files), raw(w.Bytes), raw(w.LargestBytes), raw(w.Probes),
+			raw(w.RTTMS), raw(w.HandshakeMS))
+	}
+	b.line("")
+	b.line("`Probes` are the remote round-trips that are not uploads, which is what an `advanced.skip_unchanged` redeploy is made of. The RTT and handshake here are easySFTP's own measurement, taken on its first connection; `The link` above is the same path measured by `cmd/linkprobe`, which does not go through the uploader. The two should agree, and where they do not, one of them is measuring something else.")
+	b.line("")
+	b.line("</details>")
 }
 
 func (m Matrix) canary(b *buf) {

--- a/internal/benchmark/schema/matrix.go
+++ b/internal/benchmark/schema/matrix.go
@@ -180,6 +180,11 @@ type Auto struct {
 	// did rather than what the script believes it does.
 	Chosen Chosen `json:"chosen"`
 
+	// Workload is what the policy was looking at when it chose (issue #209).
+	// Null for the sweeps stored before the policy existed, where "auto" was a
+	// fixed 1/4/16 and there was nothing to record.
+	Workload *AutoWorkload `json:"workload,omitzero"`
+
 	MiBPerS   float64 `json:"mib_per_s"`
 	FilesPerS float64 `json:"files_per_s"`
 
@@ -196,10 +201,47 @@ type Auto struct {
 }
 
 // Chosen is what an auto run resolved its three knobs to.
+//
+// The three plain fields are the *effective* settings, the largest the run
+// ended up using. Initial* is what the policy picked before the transfer
+// taught it anything, and Changes how many times the runtime controller
+// widened the pool while it ran; the two are equal on a run the controller
+// left alone, which is the common case (issue #209, stage 3). All four are
+// null for the sweeps stored before the policy existed.
 type Chosen struct {
 	Connections        *float64 `json:"connections"`
 	Concurrency        *float64 `json:"concurrency"`
 	RequestConcurrency *float64 `json:"request_concurrency"`
+
+	InitialConnections        *float64 `json:"initial_connections,omitzero"`
+	InitialConcurrency        *float64 `json:"initial_concurrency,omitzero"`
+	InitialRequestConcurrency *float64 `json:"initial_request_concurrency,omitzero"`
+	Changes                   *float64 `json:"changes,omitzero"`
+}
+
+// AutoWorkload is the input side of one policy decision: the features the run
+// computed from its plan and the link it measured. It is recorded so a stored
+// result explains why auto picked what it picked, without the reader having to
+// rerun anything (issue #209, "Observability").
+//
+// Every field is a pointer because every one of them is genuinely absent in a
+// result stored by a build that did not report it, and a zero RTT would read
+// as a measurement rather than as a gap.
+type AutoWorkload struct {
+	// Files and Bytes are the transfer the policy sized for, LargestBytes the
+	// biggest single file (the only size request_concurrency can act on) and
+	// Probes the metadata round-trips that are not uploads.
+	Files        *float64 `json:"files"`
+	Bytes        *float64 `json:"bytes"`
+	LargestBytes *float64 `json:"largest_bytes"`
+	Probes       *float64 `json:"probes"`
+
+	// RTTMS and HandshakeMS are what the run's own probe measured, which is
+	// not the same measurement as link.probes[]: those come from
+	// cmd/linkprobe, outside the code under test. Comparing the two is worth
+	// doing, which is why both are kept.
+	RTTMS       *float64 `json:"rtt_ms"`
+	HandshakeMS *float64 `json:"handshake_ms"`
 }
 
 // MatrixCompare pairs a build's cell with the reference build's cell at

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,16 @@ type Safety struct {
 	MaxDeletes int
 }
 
+// AutoSettings marks the transport settings whose value easySFTP works out
+// for itself. They are independent on purpose: a run may pin connections and
+// leave the other two adaptive, and the policy then optimizes within the
+// constraint the pinned one imposes.
+type AutoSettings struct {
+	Connections        bool
+	Concurrency        bool
+	RequestConcurrency bool
+}
+
 // Config holds the fully parsed action configuration.
 type Config struct {
 	Server              string
@@ -167,6 +177,15 @@ type Config struct {
 	// Concurrency: a connection without a worker on it is a handshake for
 	// nothing.
 	Connections int
+
+	// Auto records which of the three transport settings above the user left
+	// at "auto" (or did not write at all), and is therefore easySFTP's to
+	// choose. The int fields keep the historical fixed defaults so that code
+	// which never consults the policy (and a Config built directly in a test)
+	// behaves exactly as it did; internal/autotune replaces them per
+	// deployment once the plan and the link are known. See docs/tuning.md and
+	// issue #209.
+	Auto AutoSettings
 
 	Retries      int
 	Timeout      time.Duration
@@ -232,7 +251,10 @@ func (c *Config) SyncManifestName() string {
 
 const envPrefix = "EASYSFTP_"
 
-// Run-wide defaults, applied in inline mode and overridable per config file.
+// Run-wide defaults. The three transport numbers are the values easySFTP used
+// before the settings became adaptive; they are the fallback a Config carries
+// while the policy has not run (and the value a directly constructed Config
+// keeps), never a choice the policy makes. See AutoSettings.
 const (
 	defaultConcurrency        = 4
 	defaultRequestConcurrency = 16
@@ -319,9 +341,13 @@ func Load() (*Config, error) {
 		Concurrency:            defaultConcurrency,
 		SftpRequestConcurrency: defaultRequestConcurrency,
 		Connections:            defaultConnections,
-		Retries:                defaultRetries,
-		Timeout:                defaultTimeoutSec * time.Second,
-		ManifestName:           DefaultManifestName,
+		// Adaptive unless the config file pins a number. Inline mode has no
+		// input for any of the three (every non-secret setting has exactly
+		// one home in v3), so an inline run is always fully adaptive.
+		Auto:         AutoSettings{Connections: true, Concurrency: true, RequestConcurrency: true},
+		Retries:      defaultRetries,
+		Timeout:      defaultTimeoutSec * time.Second,
+		ManifestName: DefaultManifestName,
 	}
 
 	var err error

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -417,8 +417,112 @@ advanced:
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The int field keeps the pre-adaptive default as a fallback; what makes
+	// the setting adaptive is the flag next to it, which internal/autotune
+	// resolves per deployment (issue #209).
 	if cfg.Concurrency != 4 {
-		t.Errorf("expected 'auto' to resolve to the default concurrency, got %d", cfg.Concurrency)
+		t.Errorf("expected the fixed fallback to stay at 4, got %d", cfg.Concurrency)
+	}
+	if !cfg.Auto.Concurrency {
+		t.Error("'auto' must mark the concurrency as easySFTP's to choose")
+	}
+}
+
+// TestAutoIsPerSettingAndOptOut: each of the three transport settings resolves
+// on its own, so a config file may pin one and leave the others adaptive
+// (issue #209, "Manual override semantics"). Not writing a key at all means
+// the same as writing "auto".
+func TestAutoIsPerSettingAndOptOut(t *testing.T) {
+	const header = `version: 3
+connection:
+  host: sftp.example.com
+  username: deploy
+  host_key: SHA256:abc
+deployments:
+  website:
+    source: ./dist/
+    target: /www/
+`
+	for _, tc := range []struct {
+		name     string
+		advanced string
+		want     AutoSettings
+		values   [3]int // connections, concurrency, request_concurrency
+	}{
+		{
+			name: "nothing written is fully adaptive",
+			want: AutoSettings{Connections: true, Concurrency: true, RequestConcurrency: true},
+			// The fixed fallbacks the run carries until the policy replaces them.
+			values: [3]int{1, 4, 16},
+		},
+		{
+			name: "auto written out is the same thing",
+			advanced: `advanced:
+  connections: auto
+  concurrency: auto
+  request_concurrency: auto
+`,
+			want:   AutoSettings{Connections: true, Concurrency: true, RequestConcurrency: true},
+			values: [3]int{1, 4, 16},
+		},
+		{
+			name: "the mixed example from the issue",
+			advanced: `advanced:
+  connections: auto
+  concurrency: auto
+  request_concurrency: 32
+`,
+			want:   AutoSettings{Connections: true, Concurrency: true},
+			values: [3]int{1, 4, 32},
+		},
+		{
+			name: "a pinned pool with the rest adaptive",
+			advanced: `advanced:
+  connections: 2
+`,
+			want:   AutoSettings{Concurrency: true, RequestConcurrency: true},
+			values: [3]int{2, 4, 16},
+		},
+		{
+			name: "everything pinned",
+			advanced: `advanced:
+  connections: 2
+  concurrency: 8
+  request_concurrency: 4
+`,
+			want:   AutoSettings{},
+			values: [3]int{2, 8, 4},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setConfigModeEnv(t, header+tc.advanced)
+			cfg, err := Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Auto != tc.want {
+				t.Errorf("Auto = %+v, want %+v", cfg.Auto, tc.want)
+			}
+			got := [3]int{cfg.Connections, cfg.Concurrency, cfg.SftpRequestConcurrency}
+			if got != tc.values {
+				t.Errorf("values = %v, want %v", got, tc.values)
+			}
+		})
+	}
+}
+
+// TestInlineModeIsFullyAdaptive: inline mode has no input for any of the three
+// (every non-secret setting has exactly one home in v3), so a workflow that
+// writes source/target gets the adaptive behaviour without asking for it.
+func TestInlineModeIsFullyAdaptive(t *testing.T) {
+	setBaseEnv(t)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := AutoSettings{Connections: true, Concurrency: true, RequestConcurrency: true}
+	if cfg.Auto != want {
+		t.Errorf("Auto = %+v, want %+v", cfg.Auto, want)
 	}
 }
 

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -84,7 +84,9 @@ type yamlSync struct {
 }
 
 // autoInt is an integer that also accepts the literal "auto" (or being
-// absent), both meaning "let easySFTP pick the default".
+// absent), both meaning "let easySFTP work the value out for itself". What
+// that resolves to is internal/autotune's job, per deployment and per link;
+// this type only records which of the two the user wrote.
 type autoInt struct {
 	set bool
 	v   int
@@ -101,13 +103,18 @@ func (a *autoInt) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-// or returns the configured value, or def when unset/"auto".
+// or returns the configured value, or def when unset/"auto". def is the
+// pre-adaptive fixed default, which the run carries only until the policy
+// replaces it; auto reports which of the two happened.
 func (a autoInt) or(def int) int {
 	if a.set {
 		return a.v
 	}
 	return def
 }
+
+// auto reports whether easySFTP chooses this value.
+func (a autoInt) auto() bool { return !a.set }
 
 // allowedKeys lists the valid option names per config-file section, keyed by
 // the section's dotted path ("" is the file's top level, "deployments.*" any
@@ -348,6 +355,15 @@ func applyYAML(cfg *Config, yc *yamlConfig) error {
 	cfg.Concurrency = yc.Advanced.Concurrency.or(defaultConcurrency)
 	cfg.SftpRequestConcurrency = yc.Advanced.RequestConcurrency.or(defaultRequestConcurrency)
 	cfg.Connections = yc.Advanced.Connections.or(defaultConnections)
+	// Each key is resolved on its own: a file that pins connections and
+	// leaves concurrency at auto gets exactly that, and the policy then
+	// chooses the concurrency knowing the connection count it has to live
+	// with (issue #209).
+	cfg.Auto = AutoSettings{
+		Connections:        yc.Advanced.Connections.auto(),
+		Concurrency:        yc.Advanced.Concurrency.auto(),
+		RequestConcurrency: yc.Advanced.RequestConcurrency.auto(),
+	}
 	cfg.SkipUnchanged = yc.Advanced.SkipUnchanged
 
 	var err error

--- a/internal/uploader/autotune_test.go
+++ b/internal/uploader/autotune_test.go
@@ -1,0 +1,415 @@
+package uploader
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// autoConfig is baseConfig with every transport setting left to easySFTP, the
+// way config.Load leaves an inline run and a config file that writes "auto".
+func autoConfig(srv *testServer) *config.Config {
+	cfg := baseConfig(srv)
+	cfg.Auto = config.AutoSettings{Connections: true, Concurrency: true, RequestConcurrency: true}
+	return cfg
+}
+
+// TestAutoUploadsEverythingWithNothingConfigured is the end-to-end shape of the
+// policy: a config that pins nothing still deploys, correctly, and stays
+// inside the bounds the policy promises. What it picks here is a property of
+// the in-process server (a socket away, so its handshake is worth very little)
+// and not something to assert a number for; the decisions themselves are
+// pinned against measured links in internal/autotune.
+func TestAutoUploadsEverythingWithNothingConfigured(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 40)
+
+	cfg := autoConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 40 {
+		t.Fatalf("uploaded %d file(s), want 40", stats.FilesUploaded)
+	}
+	if got := atomic.LoadInt32(&srv.accepted); got > autotune.MaxConnections {
+		t.Errorf("opened %d connection(s), more than the policy maximum of %d", got, autotune.MaxConnections)
+	}
+	for _, name := range []string{"/www/file00.txt", "/www/file39.txt"} {
+		if !remoteExists(t, srv, name) {
+			t.Errorf("%s did not arrive", name)
+		}
+	}
+	if got := readRemote(t, srv, "/www/file39.txt"); got != "content 39" {
+		t.Errorf("unexpected content: %q", got)
+	}
+}
+
+// TestAutoPlansPerDeployment is the wiring between the uploader and the
+// policy, with the link injected so the decision is the same on every machine:
+// the same tree is worth a pool over a slow line, and the same tree behind
+// advanced.skip_unchanged is not, because then nothing is known to be uploaded
+// at all.
+func TestAutoPlansPerDeployment(t *testing.T) {
+	srv := startTestServer(t)
+	cfg := autoConfig(srv)
+	tune := newTuning(cfg)
+	tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
+
+	files := make([]fileItem, 300)
+	for i := range files {
+		files[i] = fileItem{size: 4096}
+	}
+
+	full := tune.planFor(uploadWorkload(files, false))
+	if full.Connections < 2 || full.Concurrency != autotune.MaxConcurrency {
+		t.Errorf("300 small files over a 13 ms line resolved to %v, want a pool and full worker count", full)
+	}
+
+	redeploy := tune.planFor(uploadWorkload(files, true))
+	if redeploy.Connections != 1 {
+		t.Errorf("a skip_unchanged redeploy resolved to %d connection(s), want 1 until the transfer says otherwise",
+			redeploy.Connections)
+	}
+	if redeploy.Concurrency != autotune.MaxConcurrency {
+		t.Errorf("a skip_unchanged redeploy resolved to %d worker(s), want the stats to run wide", redeploy.Concurrency)
+	}
+}
+
+// TestAutoReportsItsDecision: the choice has to be visible, or a surprising
+// one cannot be traced without rerunning the deploy. Debug level gets the
+// features, the link and the answer in one line (issue #209, "Observability").
+func TestAutoReportsItsDecision(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 6)
+
+	cfg := autoConfig(srv)
+	cfg.LogLevel = config.LogDebug
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatal(err)
+	}
+	line, ok := findLine(log.infos, "auto tuning:")
+	if !ok {
+		t.Fatalf("no auto tuning line in the debug log: %v", log.infos)
+	}
+	for _, want := range []string{"files=6", "rtt=", "handshake=", "connections=", "concurrency=", "request_concurrency="} {
+		if !strings.Contains(line, want) {
+			t.Errorf("the decision line is missing %q: %s", want, line)
+		}
+	}
+}
+
+// TestAutoStaysQuietAndFixedWhenTheConfigurationPinsEverything: a workflow
+// that already tuned its deploy must get exactly what it wrote, no probe and
+// no line about tuning.
+func TestAutoStaysQuietAndFixedWhenTheConfigurationPinsEverything(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 9)
+
+	cfg := baseConfig(srv) // Auto is zero: every setting is the user's
+	cfg.Concurrency = 3
+	cfg.Connections = 3
+	cfg.SftpRequestConcurrency = 8
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&srv.accepted); got != 3 {
+		t.Errorf("opened %d connection(s), want the configured 3", got)
+	}
+	if _, ok := findLine(log.infos, "auto tuning:"); ok {
+		t.Errorf("a fully configured run reported tuning it did not do: %v", log.infos)
+	}
+}
+
+// TestAutoLeavesAPinnedSettingAloneAndChoosesAroundIt is the mixed case the
+// issue calls out: connections pinned, the rest adaptive.
+func TestAutoLeavesAPinnedSettingAloneAndChoosesAroundIt(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 12)
+
+	cfg := baseConfig(srv)
+	cfg.Connections = 3
+	cfg.Auto = config.AutoSettings{Concurrency: true, RequestConcurrency: true}
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 12 {
+		t.Fatalf("uploaded %d file(s), want 12", stats.FilesUploaded)
+	}
+	if got := atomic.LoadInt32(&srv.accepted); got != 3 {
+		t.Errorf("opened %d connection(s); a pinned pool is never talked out of by the policy", got)
+	}
+}
+
+// TestAutoPoolStopsAskingAfterARefusal covers the shared-hosting case from the
+// other side: easySFTP asked for more connections than the server allows, and
+// the answer has to cost one warning and no further handshake attempts, rather
+// than one refusal per slot. The spread is set by hand because a server this
+// close is never given a pool by the policy itself.
+func TestAutoPoolStopsAskingAfterARefusal(t *testing.T) {
+	srv := startTestServer(t, withMaxConns(1))
+	cfg := autoConfig(srv)
+
+	tune := newTuning(cfg)
+	tune.resolveRunWide(autotune.Workload{Uploads: 100, UploadBytes: 1 << 20, LargestUpload: 1 << 12})
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	sess, err := newSession(context.Background(), cfg, tune, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.close()
+
+	if got := sess.setSpread(4); got != 4 {
+		t.Fatalf("setSpread(4) = %d, want the pool to widen before anything is dialed", got)
+	}
+	for i := range 8 {
+		if client, _, _ := sess.acquire(i); client == nil {
+			t.Fatalf("acquire(%d) returned no client", i)
+		}
+	}
+
+	// One accepted connection plus the single attempt the server dropped: the
+	// pool must not try the remaining slots one by one.
+	if got := atomic.LoadInt32(&srv.accepted); got != 2 {
+		t.Errorf("the server saw %d connection attempt(s), want 2: one that worked and one refusal, then no more", got)
+	}
+	if n := countLines(log.warnings, "would not open more than"); n != 1 {
+		t.Errorf("got %d refusal warning(s), want exactly one: %v", n, log.warnings)
+	}
+	if !sess.refusedConnection() {
+		t.Error("the session must remember the refusal so the runtime controller stops growing")
+	}
+	if got := sess.setSpread(8); got != 1 {
+		t.Errorf("setSpread(8) after a refusal = %d, want the pool to stay where the server left it", got)
+	}
+}
+
+// TestAutoSizesTheWorkersToTheWork: with concurrency at auto, a phase gets as
+// many workers as it has items and no more, so a three-file sync does not
+// start sixty-four goroutines and a two-thousand-file deploy is not held at
+// four.
+func TestAutoSizesTheWorkersToTheWork(t *testing.T) {
+	srv := startTestServer(t)
+	cfg := autoConfig(srv)
+	tune := newTuning(cfg)
+
+	for _, tc := range []struct{ items, want int }{
+		{0, 1},
+		{1, 1},
+		{3, 3},
+		{100, 64},
+		{5000, autotune.MaxConcurrency},
+	} {
+		if got := tune.workers(tc.items); got != tc.want {
+			t.Errorf("workers(%d) = %d, want %d", tc.items, got, tc.want)
+		}
+	}
+
+	pinned := baseConfig(srv) // Auto zero: concurrency 4 comes from the config
+	if got := newTuning(pinned).workers(5000); got != 4 {
+		t.Errorf("workers(5000) with a pinned concurrency = %d, want the configured 4", got)
+	}
+}
+
+// TestUploadWorkloadReadsSkipUnchangedAsMetadata pins the reason a redeploy is
+// not given a pool: with advanced.skip_unchanged the upload set is not decided
+// yet, so the plan counts the stats it is sure of instead of uploads it is not
+// (issue #209, stage 1 vs stage 3).
+func TestUploadWorkloadReadsSkipUnchangedAsMetadata(t *testing.T) {
+	files := []fileItem{{size: 4096}, {size: 8192}, {size: 1024}}
+
+	settled := uploadWorkload(files, false)
+	if settled.Uploads != 3 || settled.UploadBytes != 13312 || settled.LargestUpload != 8192 || settled.Unknown {
+		t.Errorf("a plain overlay workload came out %+v", settled)
+	}
+
+	unsettled := uploadWorkload(files, true)
+	if unsettled.Uploads != 0 || unsettled.Probes != 3 || !unsettled.Unknown {
+		t.Errorf("a skip_unchanged workload came out %+v, want three probes and nothing promised", unsettled)
+	}
+	if unsettled.LargestUpload != 8192 {
+		t.Errorf("largest upload = %d, want the biggest planned file: it still bounds request_concurrency", unsettled.LargestUpload)
+	}
+}
+
+// findLine returns the first logged line containing want.
+func findLine(lines []string, want string) (string, bool) {
+	for _, l := range lines {
+		if strings.Contains(l, want) {
+			return l, true
+		}
+	}
+	return "", false
+}
+
+func countLines(lines []string, want string) int {
+	n := 0
+	for _, l := range lines {
+		if strings.Contains(l, want) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestRuntimeControllerWidensThePoolWhileTheTransferRuns is the wiring of
+// stage 3: the loop has to notice that the transfer is far slower per stream
+// than the pre-transfer guess assumed, tell the session to spread wider, and
+// say so once.
+//
+// The controller's own decision table lives in internal/autotune; what is
+// checked here is that the progress the workers record reaches it and that its
+// answer reaches the pool.
+func TestRuntimeControllerWidensThePoolWhileTheTransferRuns(t *testing.T) {
+	defer func(v time.Duration) { tuningInterval = v }(tuningInterval)
+	tuningInterval = 10 * time.Millisecond
+
+	srv := startTestServer(t)
+	cfg := autoConfig(srv)
+	tune := newTuning(cfg)
+	tune.resolveRunWide(autotune.Workload{Uploads: 1000, UploadBytes: 1000 << 20, LargestUpload: 1 << 20})
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	sess, err := newSession(context.Background(), cfg, tune, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.close()
+	// After the session, because newSession fills the link in from its own
+	// probe: this is the line the stored sweeps were measured over.
+	tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
+
+	prog := &uploadProgress{totalFiles: 1000, totalBytes: 1000 << 20}
+	start := autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16}
+	sess.setSpread(start.Connections)
+
+	stop := startTuningController(context.Background(), sess, start, prog, log)
+	// Ten 1 MiB files through in the first window: one stream is carrying a
+	// fraction of what the remaining 990 MiB would need.
+	for range 10 {
+		prog.upload(1<<20, 1<<20)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		sess.mu.Lock()
+		spread := sess.spread
+		sess.mu.Unlock()
+		if spread > 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			stop()
+			t.Fatalf("the pool never widened; log: %v", log.infos)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	stop()
+
+	if _, ok := findLine(log.infos, "raising connections 1 ->"); !ok {
+		t.Errorf("a runtime change must be logged with its measurement: %v", log.infos)
+	}
+	tune.mu.Lock()
+	changes, effective := tune.changes, tune.effective.Connections
+	tune.mu.Unlock()
+	if changes != 1 {
+		t.Errorf("recorded %d runtime change(s), want 1", changes)
+	}
+	if effective < 2 {
+		t.Errorf("the effective connection count stayed at %d; the benchmark reads this back", effective)
+	}
+}
+
+// TestRuntimeControllerStaysOutOfDryRunsAndPinnedRuns: neither has anything to
+// measure or anything it is allowed to change, and starting a goroutine to
+// find that out every deployment would be waste.
+func TestRuntimeControllerStaysOutOfDryRunsAndPinnedRuns(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 5)
+
+	dry := autoConfig(srv)
+	dry.DryRun = true
+	dry.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+	if _, err := Run(context.Background(), dry, testLogger{t}); err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if remoteExists(t, srv, "/www/file00.txt") {
+		t.Error("a dry run uploaded something")
+	}
+}
+
+// TestTheLinkProbeIsSkippedWhenItCannotChangeAnything: the three extra
+// round-trips are only worth spending when the connection count is still open
+// to argument. Nothing else in the policy reads the link.
+func TestTheLinkProbeIsSkippedWhenItCannotChangeAnything(t *testing.T) {
+	many := autotune.Workload{Uploads: 100, UploadBytes: 1 << 20, LargestUpload: 1 << 12}
+	one := autotune.Workload{Uploads: 1, UploadBytes: 1 << 20, LargestUpload: 1 << 20}
+
+	for _, tc := range []struct {
+		name string
+		w    autotune.Workload
+		f    autotune.Fixed
+		want bool
+	}{
+		{"a tree of files with nothing pinned", many, autotune.Fixed{}, true},
+		{"a single file can never spread", one, autotune.Fixed{}, false},
+		{"a pinned pool leaves nothing to decide", many, autotune.Fixed{Connections: 4}, false},
+		{"the other two pinned still leave the pool", many, autotune.Fixed{Concurrency: 8, RequestConcurrency: 16}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := needsLink(tc.w, tc.f); got != tc.want {
+				t.Errorf("needsLink = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTheLinkProbeMeasuresAServerFasterThanTheClock: the in-process server
+// answers in less time than the platform timer resolves on some hosts, and a
+// zero there would be read as "unmeasurable" and answered with a stand-in
+// meant for a link nobody could measure at all.
+func TestTheLinkProbeMeasuresAServerFasterThanTheClock(t *testing.T) {
+	srv := startTestServer(t)
+	cfg := autoConfig(srv)
+	tune := newTuning(cfg)
+	tune.resolveRunWide(autotune.Workload{Uploads: 100, UploadBytes: 1 << 20, LargestUpload: 1 << 12})
+
+	sess, err := newSession(context.Background(), cfg, tune, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.close()
+
+	link := tune.currentLink()
+	if link.RTT <= 0 {
+		t.Errorf("the probe reported no RTT (%v); a successful probe must always produce one", link.RTT)
+	}
+	if link.Handshake <= 0 {
+		t.Errorf("the handshake was not timed: %v", link.Handshake)
+	}
+	if link.RTT > link.Handshake {
+		t.Errorf("RTT %v is longer than the whole handshake %v, which cannot be right", link.RTT, link.Handshake)
+	}
+}

--- a/internal/uploader/connection.go
+++ b/internal/uploader/connection.go
@@ -139,7 +139,10 @@ func logHostKeyStatus(h hop, log Logger) {
 // opens an SFTP session on top of SSH. The returned cleanup function closes
 // the jump-host transport (it is a no-op for direct connections) and must be
 // called after the SSH client is closed.
-func connect(cfg *config.Config, log Logger) (*ssh.Client, *sftp.Client, func(), error) {
+// requests is the resolved advanced.request_concurrency: pkg/sftp fixes it
+// when the client is created, which is why it is a parameter here rather than
+// read off the config (see internal/uploader/tuning.go).
+func connect(cfg *config.Config, requests int, log Logger) (*ssh.Client, *sftp.Client, func(), error) {
 	noop := func() {}
 	target := targetHop(cfg)
 	targetConfig, err := target.clientConfig(cfg.Timeout, log)
@@ -165,7 +168,7 @@ func connect(cfg *config.Config, log Logger) (*ssh.Client, *sftp.Client, func(),
 
 	sftpClient, err := sftp.NewClient(sshClient,
 		sftp.UseConcurrentWrites(true),
-		sftp.MaxConcurrentRequestsPerFile(cfg.SftpRequestConcurrency),
+		sftp.MaxConcurrentRequestsPerFile(requests),
 	)
 	if err != nil {
 		sshClient.Close()

--- a/internal/uploader/delete.go
+++ b/internal/uploader/delete.go
@@ -31,7 +31,7 @@ func deleteRemoteFiles(ctx context.Context, cfg *config.Config, sess *session, p
 		return deleted, nil
 	}
 
-	err := runBounded(ctx, cfg.Concurrency, len(paths), func(groupCtx context.Context, i int) error {
+	err := runBounded(ctx, sess.workers(len(paths)), len(paths), func(groupCtx context.Context, i int) error {
 		remotePath := paths[i]
 		if cfg.LogPerFile() {
 			log.Infof("delete %s", remotePath)
@@ -85,13 +85,9 @@ func removeRemoteDirs(ctx context.Context, cfg *config.Config, sess *session, wa
 		byDepth[depth] = append(byDepth[depth], dir)
 	}
 	sort.Sort(sort.Reverse(sort.IntSlice(depths)))
-	workers := cfg.Concurrency
-	if workers < 1 {
-		workers = 1
-	}
 	for _, depth := range depths {
 		level := byDepth[depth]
-		_ = runBounded(ctx, workers, len(level), func(groupCtx context.Context, i int) error {
+		_ = runBounded(ctx, sess.workers(len(level)), len(level), func(groupCtx context.Context, i int) error {
 			dir := level[i]
 			_ = sess.do(groupCtx, watch, func(client *sftp.Client) error {
 				done := metrics.Op("sftp_rmdir")

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -110,14 +110,15 @@ func checkMaxDeletes(n int, cfg *config.Config) error {
 // breadth-first boundary keeps a deterministic parent-before-child result.
 // Each ReadDir has its own sess.do call, so a dropped connection retries only
 // that idempotent listing instead of replaying the whole scan.
-func listRemoteContents(ctx context.Context, sess *session, root string, concurrency int, watch *stallWatchdog) (files, dirs []string, err error) {
-	if concurrency < 1 {
-		concurrency = 1
-	}
+//
+// The worker count is asked for per level rather than fixed for the scan: with
+// advanced.concurrency at auto it is the width of the level being listed, and a
+// tree whose levels are one directory wide never opens a worker it cannot use.
+func listRemoteContents(ctx context.Context, sess *session, root string, watch *stallWatchdog) (files, dirs []string, err error) {
 	level := []string{root}
 	for len(level) > 0 {
 		entries := make([][]fs.FileInfo, len(level))
-		err := runBounded(ctx, concurrency, len(level), func(groupCtx context.Context, i int) error {
+		err := runBounded(ctx, sess.workers(len(level)), len(level), func(groupCtx context.Context, i int) error {
 			dir := level[i]
 			err := sess.do(groupCtx, watch, func(client *sftp.Client) error {
 				done := metrics.Op("sftp_readdir")

--- a/internal/uploader/retry.go
+++ b/internal/uploader/retry.go
@@ -35,6 +35,7 @@ func uploadFileWithRetry(ctx context.Context, env *transferEnv, f fileItem, inde
 	for attempt := 0; attempt <= retries; attempt++ {
 		if attempt > 0 {
 			metrics.Count("retries", 1)
+			env.progress.failed()
 			backoff := time.Duration(1<<(attempt-1)) * time.Second
 			log.Warningf("retrying upload of %s in %s (attempt %d/%d): %v", f.localPath, backoff, attempt+1, retries+1, lastErr)
 			if err := sleepCtx(ctx, backoff); err != nil {

--- a/internal/uploader/session.go
+++ b/internal/uploader/session.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/eiserv/easySFTP/internal/autotune"
 	"github.com/eiserv/easySFTP/internal/config"
 	"github.com/eiserv/easySFTP/internal/metrics"
 )
@@ -37,11 +38,23 @@ type conn struct {
 // them on the first connection; manifest writes and directory setup do too.
 // Their reconnect behavior therefore stays independent of the upload pool.
 type session struct {
-	cfg *config.Config
-	log Logger
+	cfg  *config.Config
+	tune *tuning
+	log  Logger
 
 	mu    sync.Mutex
 	conns []*conn // slot 0 is dialed up front, the rest on first use
+	// spread is how many of those slots the current deployment hands files
+	// out over. conns is allocated to the run's ceiling once; spread is what
+	// the policy moves, per deployment and (upwards only) while a transfer
+	// runs. A slot past spread is never dialed, which is what makes an
+	// adaptive pool cost nothing until it is used.
+	spread int
+	// refused latches the first connection the server would not give us.
+	// After that the pool stops asking: sshd's MaxStartups and the
+	// per-account limits of shared hosting do not change mid-run, and one
+	// warning is information while eight are noise.
+	refused bool
 	// reconnects spent so far, bounded by cfg.Retries and shared by every
 	// connection: the input is a run-wide budget, and a server that drops
 	// connections drops them faster with more of them open.
@@ -56,7 +69,7 @@ type session struct {
 // failure (retrying risks fail2ban-style lockouts), fail immediately. With a
 // jump host configured, this covers either hop: a transient failure reaching
 // the bastion is retried exactly like one reaching the target.
-func newSession(ctx context.Context, cfg *config.Config, log Logger) (*session, error) {
+func newSession(ctx context.Context, cfg *config.Config, tune *tuning, log Logger) (*session, error) {
 	var lastErr error
 	for attempt := 0; attempt <= cfg.Retries; attempt++ {
 		if attempt > 0 {
@@ -67,13 +80,36 @@ func newSession(ctx context.Context, cfg *config.Config, log Logger) (*session, 
 			}
 		}
 		done := metrics.Op("ssh_connect")
-		sshClient, sftpClient, closeJump, err := connect(cfg, log)
+		// Timed here as well as in the metrics op, because this is stage 2 of
+		// the auto policy and not only instrumentation: what one extra
+		// connection costs is exactly what this call just paid.
+		start := time.Now()
+		sshClient, sftpClient, closeJump, err := connect(cfg, tune.requestConcurrency(), log)
+		handshake := time.Since(start)
 		done(err)
 		if err == nil {
 			metrics.Count("connections_opened", 1)
 			metrics.Count("connections_used", 1) // slot 0, dialed up front
-			s := &session{cfg: cfg, log: log, conns: make([]*conn, poolSize(cfg, log))}
+			s := &session{
+				cfg:    cfg,
+				tune:   tune,
+				log:    log,
+				conns:  make([]*conn, poolCeiling(tune, log)),
+				spread: 1,
+			}
 			s.conns[0] = &conn{ssh: sshClient, sftp: sftpClient, closeJump: closeJump}
+			// Stage 2. The handshake is always recorded (it is what an extra
+			// connection costs, and it was paid either way); the three extra
+			// round-trips of the RTT probe are only spent when they could
+			// still change an answer.
+			if tune.wantsLinkProbe() {
+				tune.setLink(probeLink(sftpClient, handshake))
+			} else {
+				tune.setLink(autotune.Link{Handshake: handshake})
+			}
+			// The slots allocated, not the ones the run will use: with the
+			// count at auto this is the ceiling the policy may grow into, and
+			// connections_opened/connections_used are what actually happened.
 			metrics.Set("connections_pool_size", int64(len(s.conns)))
 			return s, nil
 		}
@@ -85,23 +121,65 @@ func newSession(ctx context.Context, cfg *config.Config, log Logger) (*session, 
 	return nil, lastErr
 }
 
-// poolSize is how many connections the run may open. It never exceeds the
-// number of files uploaded in parallel: a connection no worker ever picks is a
-// handshake for nothing.
-func poolSize(cfg *config.Config, log Logger) int {
-	n := cfg.Connections
-	if n < 1 {
-		n = 1 // a directly constructed config (tests) leaves this at zero
-	}
-	if cfg.Concurrency > 0 && n > cfg.Concurrency {
+// poolCeiling is how many connection slots the run allocates, which is the
+// most it could ever open. Slots past the first are dialed on first use, so an
+// unreached one costs a nil pointer; what this really bounds is how far
+// setSpread may go.
+//
+// A pinned advanced.connections is still checked against a pinned
+// advanced.concurrency here and says so: those two numbers are both the user's,
+// and a connection no worker will ever pick is a handshake the user asked for
+// by accident. When either is adaptive there is nothing to warn about, because
+// the policy caps the spread against the workers itself.
+func poolCeiling(tune *tuning, log Logger) int {
+	n := tune.poolCeiling()
+	if tune.fixed.Connections > 0 && tune.fixed.Concurrency > 0 && n > tune.fixed.Concurrency {
 		log.Infof("advanced.connections is %d but only %d file(s) upload in parallel; opening at most %d connection(s)",
-			n, cfg.Concurrency, cfg.Concurrency)
-		n = cfg.Concurrency
+			n, tune.fixed.Concurrency, tune.fixed.Concurrency)
+		n = tune.fixed.Concurrency
 	}
-	if n > 1 {
-		log.Infof("uploads may use up to %d connections", n)
+	return max(n, 1)
+}
+
+// setSpread points the next files at n connections. It is the only way the
+// pool grows: slots are dialed lazily, so raising the spread costs nothing
+// until a worker lands on a fresh slot, and lowering it simply stops handing
+// files to connections that are already open.
+//
+// The spread never exceeds the allocated slots, and never grows again once the
+// server has refused one.
+func (s *session) setSpread(n int) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n = min(max(n, 1), len(s.conns))
+	if s.refused && n > s.spread {
+		return s.spread
 	}
-	return n
+	s.spread = n
+	return s.spread
+}
+
+// workers is how many of items one phase may have in flight. With
+// advanced.concurrency pinned it is that number; with it at auto it is the
+// phase's own item count, capped, so a delete sweep of 2000 files and an
+// upload of three are both sized for what they are (see tuning.workers).
+//
+// A directly constructed session (a test that never went through Run) has no
+// tuning and falls back to one worker, which is the safe reading of "nothing
+// said".
+func (s *session) workers(items int) int {
+	if s.tune == nil {
+		return 1
+	}
+	return s.tune.workers(items)
+}
+
+// refusedConnection reports whether the server has turned an extra connection
+// down. The runtime controller reads it and stops growing.
+func (s *session) refusedConnection() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.refused
 }
 
 // permanentError marks a connect() failure that must never be retried: local
@@ -130,24 +208,26 @@ func isRetryableConnect(err error) bool {
 // handed back to reconnect so that concurrent workers failing on the same
 // dead connection trigger only one redial between them.
 //
-// Files are spread over the pool round-robin. Connections past the first are
-// dialed on first use, so a run that uploads three files never pays for four
-// handshakes, and a server that refuses one (sshd's MaxSessions/MaxStartups,
-// a per-account connection limit on shared hosting) costs a warning rather
-// than the run: that slot falls back to the first connection.
+// Files are spread round-robin over the current spread, not over every
+// allocated slot: the pool is sized once for the run and pointed at the number
+// of connections this deployment decided on (see setSpread). Connections past
+// the first are dialed on first use, so a run that uploads three files never
+// pays for four handshakes.
+//
+// A server that refuses one (sshd's MaxSessions/MaxStartups, a per-account
+// connection limit on shared hosting) costs a warning rather than the run:
+// that slot falls back to the first connection, and the pool stops asking for
+// more. Where the connection count was easySFTP's own choice the run also
+// pulls its spread back in, so the refusal is answered once instead of being
+// rediscovered slot by slot.
 func (s *session) acquire(index int) (*sftp.Client, *conn, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	slot := index % len(s.conns)
+	slot := index % max(s.spread, 1)
 	if s.conns[slot] == nil {
-		c, err := s.dial()
+		c, err := s.dialSlot(slot)
 		if err != nil {
-			metrics.Count("connections_refused", 1)
-			s.log.Warningf("could not open connection %d of %d (%v); this run continues on its first connection",
-				slot+1, len(s.conns), err)
 			c = s.conns[0]
-		} else {
-			metrics.Count("connections_opened", 1)
 		}
 		// Slots the run actually reached, however they resolved: a pool whose
 		// tail is never touched (fewer files than connections) is the other
@@ -158,6 +238,53 @@ func (s *session) acquire(index int) (*sftp.Client, *conn, int) {
 	c := s.conns[slot]
 	return c.sftp, c, c.gen
 }
+
+// dialSlot opens the connection for one pool slot, or reports why the run has
+// to carry on without it. Must be called with s.mu held.
+func (s *session) dialSlot(slot int) (*conn, error) {
+	if s.refused {
+		// Already told no once. Another handshake attempt would cost a
+		// round-trip to be told no again.
+		return nil, errPoolRefused
+	}
+	c, err := s.dial()
+	if err != nil {
+		metrics.Count("connections_refused", 1)
+		s.refused = true
+		if s.tune.autoConnections() {
+			// easySFTP picked the number, so easySFTP takes the answer: pull
+			// the spread back to what is open and say so once.
+			s.spread = s.openSlots()
+			s.log.Warningf("the server would not open more than %d SSH connection(s) (%v); easySFTP had chosen more and continues with %d",
+				s.spread, err, s.spread)
+			return nil, err
+		}
+		s.log.Warningf("could not open connection %d of %d (%v); this run continues on its first connection",
+			slot+1, len(s.conns), err)
+		return nil, err
+	}
+	metrics.Count("connections_opened", 1)
+	return c, nil
+}
+
+// openSlots counts the leading slots that already hold their own connection,
+// which is how many the server has actually granted. Must be called with s.mu
+// held.
+func (s *session) openSlots() int {
+	n := 0
+	for _, c := range s.conns {
+		if c == nil {
+			break
+		}
+		n++
+	}
+	return max(n, 1)
+}
+
+// errPoolRefused marks a dial that was never attempted because the server
+// already refused one. It never reaches the user: acquire answers it with the
+// first connection, exactly as it answers a real refusal.
+var errPoolRefused = errors.New("the server already refused an extra connection")
 
 // dial opens one additional pooled connection. Must be called with s.mu held,
 // which also serializes the handshakes of a starting run: the alternative is
@@ -174,7 +301,7 @@ func (s *session) dial() (*conn, error) {
 	if !s.cfg.Debug() {
 		log = quietLogger{s.log}
 	}
-	sshClient, sftpClient, closeJump, err := connect(s.cfg, log)
+	sshClient, sftpClient, closeJump, err := connect(s.cfg, s.tune.requestConcurrency(), log)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +346,7 @@ func (s *session) reconnect(ctx context.Context, c *conn, gen int) (*sftp.Client
 	c.sftp.Close()
 	c.ssh.Close()
 	c.closeJump()
-	sshClient, sftpClient, closeJump, err := connect(s.cfg, s.log)
+	sshClient, sftpClient, closeJump, err := connect(s.cfg, s.tune.requestConcurrency(), s.log)
 	doneReconnect(err)
 	if err != nil {
 		return nil, fmt.Errorf("reconnecting: %w", err)

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -48,6 +48,10 @@ type transferEnv struct {
 	modeWarned *atomic.Bool
 	// timesWarned doubles as the preserve-times switch: nil means off.
 	timesWarned *atomic.Bool
+	// progress is what stage 3 of the auto policy watches. It is nil when
+	// there is nothing to tune (every setting pinned, or a dry run), and
+	// every method on it tolerates that.
+	progress *uploadProgress
 }
 
 // uploadFiles creates the needed remote directories and uploads files in
@@ -93,10 +97,25 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 	}
 
 	defer metrics.Phase("upload")()
+
+	// Stages 1 and 2 of the auto policy, for this deployment: the workload is
+	// the transfer that is about to start (for sync, the changed set the
+	// manifest just produced), and the link is what the first connection
+	// measured. Everything the configuration pinned comes back unchanged.
+	settings := sess.tune.planFor(uploadWorkload(files, skipUnchanged))
+	sess.setSpread(settings.Connections)
+	logTuning(cfg, sess, files, skipUnchanged, settings, log)
+
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(cfg.Concurrency)
+	g.SetLimit(settings.Concurrency)
 	results := make([]int64, len(files))
 	env := &transferEnv{cfg: cfg, sess: sess, watch: watch, log: log}
+	if sess.tune.adaptive() && !cfg.DryRun && len(files) > 0 {
+		// Stage 3. A dry run moves no bytes, so there is nothing to measure
+		// and nothing a wider pool could carry.
+		env.progress = newUploadProgress(files)
+		defer startTuningController(ctx, sess, settings, env.progress, log)()
+	}
 	// modeWarned is only armed when file-mode is an explicit override: a
 	// mirrored local mode (the default) stays silent on failure, as before.
 	if cfg.FileMode != nil {
@@ -127,6 +146,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 						log.Infof("%sskip %s (remote file has the same size)", verb, f.remotePath)
 					}
 					skipped[i] = true
+					env.progress.skip(f.size)
 					return nil
 				}
 			}
@@ -150,6 +170,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 			}
 			results[i] = n
 			completed[i] = true
+			env.progress.upload(n, f.size)
 			return nil
 		})
 	}

--- a/internal/uploader/tuning.go
+++ b/internal/uploader/tuning.go
@@ -1,0 +1,487 @@
+package uploader
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/sftp"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
+	"github.com/eiserv/easySFTP/internal/config"
+	"github.com/eiserv/easySFTP/internal/metrics"
+)
+
+// tuning is the run's side of internal/autotune: it holds what the policy was
+// told (the pinned settings and the measured link), what it decided, and the
+// bookkeeping the log lines and the benchmark counters read back.
+//
+// The policy itself has no state and no clock; everything mutable about it
+// lives here, behind one mutex, because the runtime controller changes the
+// connection count while the upload workers are reading it.
+type tuning struct {
+	// fixed is written once, before anything else runs, and read without the
+	// lock from both the upload workers and the controller goroutine. It must
+	// stay immutable after newTuning for that to be safe.
+	fixed autotune.Fixed
+
+	mu   sync.Mutex
+	link autotune.Link
+	// requests is resolved once, before the first connection: it is
+	// pkg/sftp's MaxConcurrentRequestsPerFile, which is fixed when a client
+	// is created, so it cannot follow a deployment the way the other two do.
+	requests int
+
+	// probe is set by resolveRunWide when measuring the link could still
+	// change an answer; see needsLink.
+	probe bool
+
+	// initial is what the policy chose for the first deployment's transfer,
+	// before that transfer taught it anything, seen the features behind that
+	// choice, and effective the largest the run ended up using. The benchmark
+	// reads all three back out of the counters, so a policy run can be scored
+	// against the grid it is measured next to and a runtime change is visible
+	// as the gap between initial and effective.
+	initial     autotune.Settings
+	seen        autotune.Workload
+	haveInitial bool
+	effective   autotune.Settings
+	changes     int
+}
+
+// newTuning reads which settings the configuration pinned. Everything it does
+// not pin is the policy's.
+func newTuning(cfg *config.Config) *tuning {
+	t := &tuning{}
+	if !cfg.Auto.Connections {
+		t.fixed.Connections = max(cfg.Connections, 1)
+	}
+	if !cfg.Auto.Concurrency {
+		t.fixed.Concurrency = max(cfg.Concurrency, 1)
+	}
+	if !cfg.Auto.RequestConcurrency {
+		t.fixed.RequestConcurrency = max(cfg.SftpRequestConcurrency, 1)
+	}
+	t.requests = t.fixed.RequestConcurrency
+	// What a run that fails before it plans anything used: one connection and
+	// one worker. Left at zero, report() would tell the benchmark the run ran
+	// with no settings at all.
+	t.effective = autotune.Settings{Connections: 1, Concurrency: 1, RequestConcurrency: max(t.requests, 1)}
+	return t
+}
+
+// adaptive reports whether the policy has anything to decide at all. A run
+// that pinned all three never starts a controller and never logs a decision.
+func (t *tuning) adaptive() bool { return !t.fixed.All() }
+
+// wantsLinkProbe reports whether the three extra round-trips of the link probe
+// could still change an answer.
+func (t *tuning) wantsLinkProbe() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.probe
+}
+
+// needsLink reports whether the link measurement can affect anything.
+//
+// Only the connection count reads it: the worker count follows the item count
+// and request_concurrency follows the file size, neither of which the path to
+// the server has an opinion about. So the probe is worth its round-trips
+// exactly when the pool is still open to argument, and is skipped for a run
+// that pinned advanced.connections or that sends at most one file (which can
+// never spread over a pool, however slow the link).
+func needsLink(w autotune.Workload, f autotune.Fixed) bool {
+	return f.Connections == 0 && w.Uploads > 1
+}
+
+// resolveRunWide fixes request_concurrency and the pool's ceiling before the
+// first connection, from the whole run's plan.
+//
+// It has to happen here rather than per deployment because both are properties
+// of a connection, not of a transfer: request_concurrency is baked into the
+// SFTP client at creation, and the pool is a slice the session allocates once.
+// Both are ceilings, so taking the run-wide plan (every deployment's planned
+// files, before sync narrows anything down) is the safe direction: a
+// deployment may use less of them, never more.
+func (t *tuning) resolveRunWide(w autotune.Workload) autotune.Settings {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := autotune.Plan(w, t.link, t.fixed)
+	t.requests = s.RequestConcurrency
+	t.probe = needsLink(w, t.fixed)
+	// The other two are per deployment and recorded when they are decided;
+	// what a run that never reaches a transfer used is one connection and one
+	// worker, which is what it opened.
+	t.effective = autotune.Settings{Connections: 1, Concurrency: 1, RequestConcurrency: s.RequestConcurrency}
+	return s
+}
+
+// requestConcurrency is what a new SFTP client is opened with.
+func (t *tuning) requestConcurrency() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.requests < 1 {
+		return 1
+	}
+	return t.requests
+}
+
+// setLink records what the first connection measured about the path to the
+// server: stage 2 of the policy.
+func (t *tuning) setLink(l autotune.Link) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.link = l
+}
+
+func (t *tuning) currentLink() autotune.Link {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.link
+}
+
+// planFor resolves one deployment's transfer against the work it really has.
+// For sync that is the changed set the manifest just produced, not the tree
+// that was scanned.
+func (t *tuning) planFor(w autotune.Workload) autotune.Settings {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := autotune.Plan(w, t.link, t.fixed)
+	s.RequestConcurrency = t.requests // fixed with the connection; see resolveRunWide
+	if !t.haveInitial {
+		// The first transfer's choice is the one worth reporting as "what the
+		// policy picked": it is the decision taken purely from the plan and
+		// the link, with nothing measured yet. Its features go with it, so a
+		// stored benchmark result explains the choice as well as recording it.
+		t.initial, t.seen, t.haveInitial = s, w, true
+	}
+	t.record(s)
+	return s
+}
+
+// record keeps the high-water mark of what the run actually ran with.
+func (t *tuning) record(s autotune.Settings) {
+	t.effective.Connections = max(t.effective.Connections, s.Connections)
+	t.effective.Concurrency = max(t.effective.Concurrency, s.Concurrency)
+	t.effective.RequestConcurrency = max(t.effective.RequestConcurrency, s.RequestConcurrency)
+}
+
+// grew notes one accepted runtime change.
+func (t *tuning) grew(s autotune.Settings) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.changes++
+	t.record(s)
+}
+
+// poolCeiling is how many connection slots the session allocates. Slots are
+// dialed on first use, so an unused one costs a nil pointer and nothing else;
+// what this number really bounds is how far the runtime controller may grow.
+func (t *tuning) poolCeiling() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.fixed.Connections > 0 {
+		return t.fixed.Connections
+	}
+	return autotune.MaxConnections
+}
+
+// autoConnections reports whether easySFTP chose the connection count, which
+// is what decides how a refused connection is phrased and whether the run
+// stops asking for more.
+func (t *tuning) autoConnections() bool { return t.fixed.Connections == 0 }
+
+// workers is how many of items may be in flight in one phase. A pinned
+// concurrency is used verbatim; otherwise it is the item count, capped, which
+// is the largest number of workers that can ever be busy.
+func (t *tuning) workers(items int) int {
+	if t.fixed.Concurrency > 0 {
+		return t.fixed.Concurrency
+	}
+	if items < 1 {
+		return 1
+	}
+	return min(items, autotune.MaxConcurrency)
+}
+
+// report writes the policy's inputs and its two answers into the run counters.
+// The benchmark reads them back to score auto against the grid it was measured
+// next to (benchmarks/README.md), and they are the only record of a decision
+// that is otherwise invisible in a non-debug log.
+func (t *tuning) report() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	metrics.Set("config_connections", int64(t.effective.Connections))
+	metrics.Set("config_concurrency", int64(t.effective.Concurrency))
+	metrics.Set("config_request_concurrency", int64(t.effective.RequestConcurrency))
+	metrics.Set("auto_initial_connections", int64(t.initial.Connections))
+	metrics.Set("auto_initial_concurrency", int64(t.initial.Concurrency))
+	metrics.Set("auto_initial_request_concurrency", int64(t.initial.RequestConcurrency))
+	metrics.Set("auto_changes", int64(t.changes))
+	metrics.Set("workload_files", int64(t.seen.Uploads))
+	metrics.Set("workload_bytes", t.seen.UploadBytes)
+	metrics.Set("workload_largest_bytes", t.seen.LargestUpload)
+	metrics.Set("workload_probes", int64(t.seen.Probes))
+	metrics.Set("link_rtt_us", t.link.RTT.Microseconds())
+	metrics.Set("link_handshake_us", t.link.Handshake.Microseconds())
+}
+
+// planWorkload turns a set of planned files into the features the policy
+// reads. probes counts the remote round-trips that are not uploads (the one
+// stat per file advanced.skip_unchanged costs), and unknown marks a set whose
+// members may turn out not to be uploaded at all.
+func planWorkload(files []fileItem, probes int, unknown bool) autotune.Workload {
+	w := autotune.Workload{Probes: probes, Unknown: unknown}
+	for _, f := range files {
+		w.Uploads++
+		w.UploadBytes += f.size
+		w.LargestUpload = max(w.LargestUpload, f.size)
+	}
+	return w
+}
+
+// runWorkload is every deployment's plan added together: the ceiling the run
+// is sized against before it knows what sync will narrow down. Deployments run
+// one after another, so their handshakes are shared and adding them up is what
+// the pool actually faces.
+func runWorkload(plans []plan) autotune.Workload {
+	var total autotune.Workload
+	for _, p := range plans {
+		w := planWorkload(p.files, 0, false)
+		total.Uploads += w.Uploads
+		total.UploadBytes += w.UploadBytes
+		total.LargestUpload = max(total.LargestUpload, w.LargestUpload)
+	}
+	return total
+}
+
+// uploadWorkload is the workload of one deployment's transfer phase.
+//
+// With advanced.skip_unchanged the upload set is not decided yet: every
+// planned file costs a stat and only some of them are then sent. The workload
+// says so (Unknown) and counts the stats it is certain of rather than uploads
+// it is not, which is what keeps a redeploy that changed three files from
+// paying for a pool sized for the whole tree. The controller fills the rest in
+// once the run has seen the real ratio.
+func uploadWorkload(files []fileItem, skipUnchanged bool) autotune.Workload {
+	if skipUnchanged {
+		w := autotune.Workload{Probes: len(files), Unknown: true}
+		for _, f := range files {
+			w.LargestUpload = max(w.LargestUpload, f.size)
+		}
+		return w
+	}
+	return planWorkload(files, 0, false)
+}
+
+// logTuning reports what the policy decided for one deployment.
+//
+// Two levels, because two readers want different things. A debug run gets the
+// whole decision (every feature, the measured link and the answer), which is
+// what makes a surprising choice traceable without rerunning anything. A
+// normal run only hears about it when the run is about to use more than one
+// connection, which is the one part of the decision a user can feel: it is
+// visible on the server, it is what a MaxStartups limit reacts to, and it
+// replaces the fixed "uploads may use up to N connections" line advanced.
+// connections used to print.
+func logTuning(cfg *config.Config, sess *session, files []fileItem, skipUnchanged bool, s autotune.Settings, log Logger) {
+	if !sess.tune.adaptive() || len(files) == 0 {
+		return
+	}
+	if cfg.Debug() {
+		w := uploadWorkload(files, skipUnchanged)
+		log.Infof("auto tuning: %s", autotune.Explain(w, sess.tune.currentLink(), sess.tune.fixed, s))
+		return
+	}
+	if s.Connections > 1 {
+		log.Infof("auto tuning: spreading %d file(s) over up to %d connections, %d at a time",
+			len(files), s.Connections, s.Concurrency)
+	}
+}
+
+// How many round-trips the RTT is taken over. Three is enough for a median to
+// survive one scheduling hiccup and costs about as much as a single stat, and
+// is what a link with any latency at all needs.
+//
+// The batch grows past that only when the median still reads as zero, which
+// means the answers are arriving faster than the platform clock ticks (Go's
+// clock on Windows resolves to about a millisecond, and a loopback or LAN
+// server beats that). Thirty-two of the cheapest request in the protocol still
+// costs a couple of milliseconds on such a link, and it turns "too fast to
+// time" into a number instead of into a fallback meant for a link nobody could
+// measure.
+const (
+	linkProbeSamples    = 3
+	linkProbeMaxSamples = 32
+)
+
+// probeLink measures the path to the server: the handshake that has just been
+// paid, and the round-trip time of a few of the cheapest requests the protocol
+// has. SSH_FXP_REALPATH of "." reads nothing, writes nothing and is answered by
+// every server that speaks SFTP at all, so the probe leaves no trace on the
+// remote side (issue #209, stage 2).
+//
+// Two things can leave the RTT at zero: a server that refuses the request, and
+// a link that answers faster than the platform's clock resolution (a loopback
+// or LAN server on Windows does). Both are handed on as "unmeasured", and the
+// policy then reads the handshake as a number of round-trips instead, which is
+// consistent with whichever of the two happened.
+func probeLink(client *sftp.Client, handshake time.Duration) autotune.Link {
+	samples := make([]time.Duration, 0, linkProbeMaxSamples)
+	batch := time.Now()
+	for len(samples) < linkProbeMaxSamples {
+		start := time.Now()
+		done := metrics.Op("sftp_realpath")
+		_, err := client.Getwd()
+		done(err)
+		if err != nil {
+			return autotune.Link{Handshake: handshake}
+		}
+		samples = append(samples, time.Since(start))
+		if len(samples) >= linkProbeSamples && medianDuration(samples) > 0 {
+			break
+		}
+	}
+	rtt := medianDuration(samples)
+	if rtt == 0 {
+		// Every single answer was below the clock's resolution; the batch as a
+		// whole is not, so it is the measurement.
+		rtt = time.Since(batch) / time.Duration(len(samples))
+	}
+	return autotune.Link{RTT: rtt, Handshake: handshake}
+}
+
+// medianDuration sorts a copy of samples and returns the middle one.
+func medianDuration(samples []time.Duration) time.Duration {
+	sorted := append([]time.Duration(nil), samples...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted[len(sorted)/2]
+}
+
+// tuningInterval is how often the runtime controller looks at the transfer.
+// The controller ignores anything shorter than its own observation window, so
+// this only sets how promptly a decision can be taken once that window has
+// passed; a tick costs a handful of atomic loads. A variable only so tests can
+// drive it faster than a real deploy would.
+var tuningInterval = 250 * time.Millisecond
+
+// uploadProgress is what one deployment's workers report while they run, and
+// the only input stage 3 of the policy has. Every field is written from the
+// upload workers and read from the controller goroutine, so all of it is
+// atomic; a nil *uploadProgress is a run with the controller switched off and
+// every method below is a no-op on it.
+type uploadProgress struct {
+	totalFiles int
+	totalBytes int64
+
+	uploaded  atomic.Int64
+	skipped   atomic.Int64
+	bytesSent atomic.Int64 // bytes that really went over the wire
+	bytesDone atomic.Int64 // planned size of every finished file, sent or skipped
+	failures  atomic.Int64
+}
+
+func newUploadProgress(files []fileItem) *uploadProgress {
+	p := &uploadProgress{totalFiles: len(files)}
+	for _, f := range files {
+		p.totalBytes += f.size
+	}
+	return p
+}
+
+// upload records one finished transfer: sent is what went over the wire,
+// planned what the plan expected it to be.
+func (p *uploadProgress) upload(sent, planned int64) {
+	if p == nil {
+		return
+	}
+	p.uploaded.Add(1)
+	p.bytesSent.Add(sent)
+	p.bytesDone.Add(planned)
+}
+
+// skip records one file the run did not have to send.
+func (p *uploadProgress) skip(planned int64) {
+	if p == nil {
+		return
+	}
+	p.skipped.Add(1)
+	p.bytesDone.Add(planned)
+}
+
+// failed records one retried upload. A transfer that is already retrying is
+// not one to put more load on.
+func (p *uploadProgress) failed() {
+	if p == nil {
+		return
+	}
+	p.failures.Add(1)
+}
+
+func (p *uploadProgress) snapshot(elapsed time.Duration, refused bool) autotune.Progress {
+	uploaded := int(p.uploaded.Load())
+	skipped := int(p.skipped.Load())
+	return autotune.Progress{
+		Elapsed:        elapsed,
+		Uploaded:       uploaded,
+		Skipped:        skipped,
+		Remaining:      max(p.totalFiles-uploaded-skipped, 0),
+		RemainingBytes: max(p.totalBytes-p.bytesDone.Load(), 0),
+		UploadedBytes:  p.bytesSent.Load(),
+		Refused:        refused,
+		Failures:       int(p.failures.Load()),
+	}
+}
+
+// startTuningController runs stage 3 for one deployment: it watches the
+// transfer and widens the connection pool while the work that is left still
+// justifies another handshake. The returned function stops the watcher and
+// must be called before the phase ends.
+//
+// Only the pool moves; see the comment on autotune.Controller for why the
+// other two settings are already where they belong. Growth is applied through
+// session.setSpread, which hands the next files to more slots without dialing
+// anything itself, so a decision that turns out to be unnecessary (the phase
+// ends first) costs nothing at all.
+func startTuningController(ctx context.Context, sess *session, start autotune.Settings, prog *uploadProgress, log Logger) func() {
+	ctrl := autotune.NewController(start, sess.tune.currentLink(), sess.tune.fixed)
+	if stopped, _ := ctrl.Stopped(); stopped {
+		return func() {}
+	}
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		began := time.Now()
+		t := time.NewTicker(tuningInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			case <-t.C:
+			}
+			change, ok := ctrl.Observe(prog.snapshot(time.Since(began), sess.refusedConnection()))
+			if ok {
+				applied := sess.setSpread(change.To.Connections)
+				change.To.Connections = applied
+				sess.tune.grew(change.To)
+				log.Infof("auto tuning: %s", change)
+			}
+			if stopped, why := ctrl.Stopped(); stopped {
+				if why != "" && sess.cfg.Debug() {
+					log.Infof("auto tuning: no further changes this deployment (%s)", why)
+				}
+				return
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		<-finished
+	}
+}

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -62,11 +62,12 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	stats := &Stats{}
 	defer func() { stats.Duration = time.Since(start) }()
 
-	// The benchmark reads these back out of the metrics file to label a cell of
-	// its connections/concurrency matrix; a normal run collects nothing.
-	metrics.Set("config_connections", int64(cfg.Connections))
-	metrics.Set("config_concurrency", int64(cfg.Concurrency))
-	metrics.Set("config_request_concurrency", int64(cfg.SftpRequestConcurrency))
+	// Everything the configuration left at "auto" is this value's to decide;
+	// see internal/autotune and docs/tuning.md. The benchmark reads the
+	// decision back out of the metrics file to score the policy against the
+	// grid it was measured next to; a normal run collects nothing.
+	tune := newTuning(cfg)
+	defer tune.report()
 
 	// Build the full local plan first so config/path errors surface before
 	// we touch the network.
@@ -100,8 +101,15 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	}
 	endScan()
 
+	// Stage 1 of the policy, run-wide: request_concurrency is baked into every
+	// SFTP client when it is created and the connection pool is one slice, so
+	// both are sized here, against every deployment's plan, before the first
+	// handshake. Stage 2 (the link) happens inside newSession, stage 3 during
+	// each transfer.
+	tune.resolveRunWide(runWorkload(plans))
+
 	endConnect := metrics.Phase("connect")
-	sess, err := newSession(ctx, cfg, log)
+	sess, err := newSession(ctx, cfg, tune, log)
 	endConnect()
 	if err != nil {
 		return stats, err
@@ -202,7 +210,7 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 		}
 		var files, dirs []string
 		endRemoteScan := metrics.Phase("remote_scan")
-		files, dirs, err := listRemoteContents(ctx, sess, base, cfg.Concurrency, watch)
+		files, dirs, err := listRemoteContents(ctx, sess, base, watch)
 		endRemoteScan()
 		if err != nil {
 			return fmt.Errorf("scanning remote directory %q: %w", p.pair.Remote, err)

--- a/schema/easysftp.schema.json
+++ b/schema/easysftp.schema.json
@@ -153,15 +153,15 @@
           "minimum": 0
         },
         "concurrency": {
-          "description": "Maximum parallel file uploads and independent remote scan, file delete, and same-depth directory delete requests, or \"auto\" for the built-in default.",
+          "description": "Maximum parallel file uploads and independent remote scan, file delete, and same-depth directory delete requests. \"auto\" (the default) sizes it to the number of independent items the phase has, capped at 64.",
           "$ref": "#/$defs/autoInt"
         },
         "request_concurrency": {
-          "description": "Maximum in-flight SFTP requests per file (pipelining within one file's transfer), or \"auto\" for the built-in default.",
+          "description": "Maximum in-flight SFTP requests per file (pipelining within one file's transfer). \"auto\" (the default) sizes it to the largest file being uploaded: 16 for a tree of small files, up to 64 for large ones.",
           "$ref": "#/$defs/autoInt"
         },
         "connections": {
-          "description": "Number of SSH connections uploads may spread over (default 1, never more than concurrency). More connections lift the single-TCP-flow and single-cipher-stream ceiling on high-latency links, but some servers and shared hosts limit concurrent connections per account.",
+          "description": "Number of SSH connections uploads may spread over (never more than concurrency). More connections lift the single-TCP-flow and single-cipher-stream ceiling on high-latency links, but some servers and shared hosts limit concurrent connections per account. \"auto\" (the default) opens another one only while it would save more time than its SSH handshake costs, up to 8, and widens the pool while a long transfer runs if the measured throughput justifies it.",
           "$ref": "#/$defs/autoInt"
         },
         "skip_unchanged": {
@@ -220,6 +220,7 @@
       "items": { "type": "string" }
     },
     "autoInt": {
+      "description": "A fixed number, or \"auto\" to let easySFTP choose the value per deployment from the workload and the measured link. Absent means \"auto\". Each setting is resolved on its own, so pinning one leaves the others adaptive.",
       "oneOf": [
         { "type": "integer", "minimum": 1 },
         { "const": "auto" }

--- a/site/assets/docs.js
+++ b/site/assets/docs.js
@@ -12,6 +12,7 @@ var REPO = "https://github.com/eiserv/easySFTP";
 /* dir: what links inside the source file are relative to, in the repo */
 var PAGES = [
   { id: "configuration", title: "configuration", group: "guide", dir: "docs/" },
+  { id: "tuning", title: "tuning", group: "guide", dir: "docs/" },
   { id: "strategies", title: "strategies", group: "guide", dir: "docs/" },
   { id: "examples", title: "examples", group: "guide", dir: "docs/" },
   { id: "security", title: "security", group: "guide", dir: "docs/" },


### PR DESCRIPTION
Closes #209.

## What changed

`advanced.connections`, `advanced.concurrency` and `advanced.request_concurrency`
resolved `auto` to a compile-time `1` / `4` / `16`. The stored sweeps say that
is not defensible: replayed against the best measured cell of each scenario it
is **up to 375% behind**, and only the one-large-file case is close.

New package `internal/autotune` is the policy. It has no clock, no I/O and no
state, which is what makes it replayable against the committed sweeps instead
of argued about.

| Setting | How `auto` resolves it |
|---|---|
| `concurrency` | the number of independent items the phase has, capped at 64. A worker with nothing to do never starts, so there is no trade-off and nothing for a runtime ramp to discover. |
| `request_concurrency` | the largest file, in 32 KiB write packets, floored at today's 16 and capped at the 64 that fill one SSH channel window (2 MiB). A 4 KiB file cannot use a second request however high the number is. |
| `connections` | `T(k) = W/k + (k-1)*H` is smallest at `k = sqrt(W/H)`: open another connection while the time it saves is larger than the handshake it costs. Everything else in the package exists to estimate `W`. |

### The three stages

1. **Workload** — after the local scan, and again per deployment right before
   its transfer, so a sync deployment sizes for the files it actually changed
   rather than the tree it scanned.
2. **Link** — the first connection times its own handshake and measures the RTT
   with three `SSH_FXP_REALPATH` round-trips (reads nothing, writes nothing, no
   remote artifact). The probe is skipped entirely when it could not change an
   answer: only the connection count reads the link.
3. **Runtime** — the one thing stage 1 cannot know is the link's throughput, so
   it starts from a deliberately conservative prior and the controller replaces
   it with what the transfer is really achieving, widening the pool while the
   *remaining* work still justifies a handshake. It grows at most one doubling
   per step and stops for good the first time a step is not measurably faster,
   or the server refuses a connection, or an upload retries.

This is also what makes an overlay redeploy safe to start small: with
`advanced.skip_unchanged` easySFTP cannot know how many files really changed,
so it sizes for the stats it is sure of and lets the observed ratio correct it.

### Manual overrides

Each setting resolves on its own and a pinned number is never touched, at any
stage. `connections: 2` with the other two at `auto` chooses inside that
constraint, and switches the runtime stage off because there is nothing it may
change.

## Measured effect

`internal/autotune/regret_test.go` replays the policy over every sweep
committed under `benchmarks/matrix/` with at least three repeats per cell,
using each sweep's own probes for the link and `internal/benchmark/scenario`
for the workload, and scores it against the fastest cell that sweep measured.

| Scenario | fixed 1/4/16 | this policy |
|---|---|---|
| `bulk` (2000 x 4 KiB) | +411% | **+0.0%** |
| `small` (300 x 4 KiB) | +157% | **+7.5%** |
| `mixed` (a built website) | +135% | **+2.6%** |
| `calib-100x64k` | +126% | **+6.2%** |
| `redeploy` (500 files, 3 changed) | +114% | **+0.0%** |
| `large` (2 x 16 MiB) | +54% | **+0.0%** |
| `deep` (400 files, 7 levels) | +48% | **+1.7%** |
| `sync` (500 files, 3 changed) | +13% | **+5.5%** |
| `single` (1 x 32 MiB) | +0.9% | **+0.0%** |

Worst case across both full sweeps is 14% (`sync`, which is a 185 ms gap on a
1.3 second run, where the sweeps' own canary spread is 9%). The issue's target
is 15%. A sibling test asserts the old fixed defaults would **fail** that same
replay, so it cannot quietly stop discriminating.

The replay only scores stages 1 and 2: a grid cell is a fixed configuration
measured from its first byte, so there is nothing in it for the controller to
react to. What the controller adds is on top of these numbers.

## Behaviour change worth calling out

**`advanced.connections` now defaults to `auto` rather than `1`.** A deploy that
warrants a pool gets one without being asked, which is the point of the issue
("`auto` should be the default and should work well without user tuning"). The
downside case is a host that limits connections per account: that already
degrades rather than fails, and it now costs **one** warning instead of one per
pool slot, with the run pulling its own spread back and not asking again. Pin a
number to silence it.

The other visible change is the log. At the default level a deployment that
spreads says so once; at `debug` the whole decision is printed, inputs first:

```text
auto tuning: files=2000 bytes=7.8 MiB largest=4.0 KiB probes=0 rtt=13ms handshake=384ms throughput=assumed 1.0 MiB/s -> connections=8 concurrency=64 request_concurrency=16
```

## Also in this PR

- `session` grew a `spread` (how many pool slots the current deployment hands
  files to) separate from the allocated slots, which is what lets the pool be
  sized per deployment and widened mid-transfer. Slots are still dialed lazily,
  so widening costs nothing until a worker lands on a fresh one.
- Phases that were bounded by `advanced.concurrency` now ask for the worker
  count they can actually use (`sess.workers(items)`), so a delete sweep of
  2000 files and an upload of three are each sized for what they are.
- The benchmark records the decision: `auto[].workload` (the features the
  policy read and the link it measured) and `auto[].chosen.initial_*` /
  `changes` next to the effective settings, so a stored result explains its own
  regret. New counters, no schema break; the analysis layer reads them or not.
- The container self-test in `ci.yml` now asserts the policy ran against a real
  OpenSSH server: it measured the link, recorded the workload and stayed inside
  its bounds. That is the only place the probe and the pool run for real.
- `docs/tuning.md` is new (linked from the docs index, the site nav and the
  Pages deploy), and `configuration.md`, the example config, the JSON schema,
  `troubleshooting.md`, `benchmarks/README.md` and the agent notes are updated.

## Follow-up filed

While reading the sweeps for this: **#213**. The adaptive policy now sizes the
upload phase of the `deep` scenario correctly, and the run is still dominated
by two phases the policy has no say over, because they are still serial on the
first connection. `create_dirs` (11.6 s) and `sweep_stale_temps` (8.9 s) are
75% of that 27 s deployment. Same shape as #157/#210, out of scope here.

## Testing

`go build ./...`, `go vet ./...` and `go test ./...` are green, as are the
Python analysis self-checks (`python -m unittest discover -s benchmarks/analysis`).

`go test -race` could **not** be run here: this machine has no C toolchain, so
`-race` fails with "requires cgo". Per `CLAUDE.md` that pass is left to CI. The
new concurrent surface is small and worth a reviewer's eye regardless: the
controller goroutine reaches the pool only through `session.setSpread`
(under the session lock) and `tuning.grew` (under the tuning lock), never both
at once; progress is atomic counters written by the upload workers;
`tuning.fixed` is written once before anything starts and read without a lock.

Not done, and deliberately: the sweeps under `benchmarks/` were measured
against the pre-policy build, so the numbers above are a replay and not a fresh
measurement. The next `benchmark-matrix` run against a real host is what turns
them into one, and its `auto[]` rows now carry the workload and the initial
choice needed to read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

