### PR TITLE
perf(uploader): parallelize remaining remote phases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,8 @@ not that the test needs relaxing.
   `withDropFirstConnAfter`), request-triggered drops
   (`withDropOnRequest(method, path)`, which kills the live connection the
   first time a matching SFTP request arrives; use it to simulate a drop
-  during a non-transfer phase like a delete sweep or remote scan) and
+  during a non-transfer phase like directory setup, a stale-temp sweep, a
+  delete sweep or remote scan) and
   request-triggered hangs (`withStallOnRequest`) and refused connections
   (`withMaxConns(n)`, which closes everything accepted beyond the first n; the
   connection pool's degradation path uses it). Follow that pattern (wrap
@@ -179,13 +180,19 @@ not that the test needs relaxing.
 - A run may hold more than one connection (`advanced.connections`, issue
   #158; how many is the policy's, issue #209). Only the per-file upload path
   spreads over them, by file index modulo `session.spread`; `session.do` and
-  therefore everything else always uses the first one. Remote scans, file
-  deletes and same-depth directory deletes may call `session.do` concurrently,
-  bounded by `session.workers(items)`; they still open no extra connections. A
-  connection the server refuses is not an error: that pool slot falls back to
-  the first connection after one warning, and the run stops asking. The
-  reconnect budget stays run-wide and the stall watchdog closes every
-  connection.
+  therefore everything else always uses the first one. Remote scans, directory
+  creation/chmod, stale-temp sweeps, file deletes and same-depth directory
+  deletes may call `session.do` concurrently, bounded by
+  `session.workers(items)`; they still open no extra connections. A connection
+  the server refuses is not an error: that pool slot falls back to the first
+  connection after one warning, and the run stops asking. The reconnect budget
+  stays run-wide and the stall watchdog closes every connection.
+- Parallel `MkdirAll` calls for different leaves can share a missing parent.
+  `pkg/sftp` normally resolves that race, but a connection drop between its
+  failed `Mkdir` and confirming `Lstat` can surface a misleading already-exists
+  error. `createRemoteDirs` confirms the completed leaf before failing and
+  turns a failed confirmation connection into a `session.do` retry; keep that
+  final-state check.
 - Every remote operation outside the per-file upload path must go through
   `session.do` (see `internal/uploader/session.go`): it redials on
   connection-class errors sharing the `retries` reconnect budget and marks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,8 @@ not that the test needs relaxing.
   `withDropFirstConnAfter`), request-triggered drops
   (`withDropOnRequest(method, path)`, which kills the live connection the
   first time a matching SFTP request arrives; use it to simulate a drop
-  during a non-transfer phase like a delete sweep or remote scan) and
+  during a non-transfer phase like directory setup, a stale-temp sweep, a
+  delete sweep or remote scan) and
   request-triggered hangs (`withStallOnRequest`) and refused connections
   (`withMaxConns(n)`, which closes everything accepted beyond the first n; the
   connection pool's degradation path uses it). Follow that pattern (wrap
@@ -179,13 +180,19 @@ not that the test needs relaxing.
 - A run may hold more than one connection (`advanced.connections`, issue
   #158; how many is the policy's, issue #209). Only the per-file upload path
   spreads over them, by file index modulo `session.spread`; `session.do` and
-  therefore everything else always uses the first one. Remote scans, file
-  deletes and same-depth directory deletes may call `session.do` concurrently,
-  bounded by `session.workers(items)`; they still open no extra connections. A
-  connection the server refuses is not an error: that pool slot falls back to
-  the first connection after one warning, and the run stops asking. The
-  reconnect budget stays run-wide and the stall watchdog closes every
-  connection.
+  therefore everything else always uses the first one. Remote scans, directory
+  creation/chmod, stale-temp sweeps, file deletes and same-depth directory
+  deletes may call `session.do` concurrently, bounded by
+  `session.workers(items)`; they still open no extra connections. A connection
+  the server refuses is not an error: that pool slot falls back to the first
+  connection after one warning, and the run stops asking. The reconnect budget
+  stays run-wide and the stall watchdog closes every connection.
+- Parallel `MkdirAll` calls for different leaves can share a missing parent.
+  `pkg/sftp` normally resolves that race, but a connection drop between its
+  failed `Mkdir` and confirming `Lstat` can surface a misleading already-exists
+  error. `createRemoteDirs` confirms the completed leaf before failing and
+  turns a failed confirmation connection into a `session.do` retry; keep that
+  final-state check.
 - Every remote operation outside the per-file upload path must go through
   `session.do` (see `internal/uploader/session.go`): it redials on
   connection-class errors sharing the `retries` reconnect budget and marks

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,7 +220,7 @@ sync:
 | `retries` | `2` | Retries per file on transient errors, and the reconnect budget for dropped connections. Failures the server reports with a permanent status code are never retried; see [which upload failures are retried](troubleshooting.md#which-upload-failures-easysftp-retries). `0` disables. |
 | `timeout` | `30` | Connection timeout in seconds. `0` disables. |
 | `stall_timeout` | `0` (off) | Abort when active remote operations make no progress for this many seconds. |
-| `concurrency` | `auto` | Files uploaded in parallel, and independent remote scan / delete requests. `auto` sizes it to the work (see [transfer tuning](tuning.md)). Sync hashing uses the runner's available Go CPU parallelism independently. |
+| `concurrency` | `auto` | Files uploaded in parallel, and independent remote metadata requests such as directory setup, stale-temp cleanup, scans and deletes. `auto` sizes it to the work (see [transfer tuning](tuning.md)). Sync hashing uses the runner's available Go CPU parallelism independently. |
 | `request_concurrency` | `auto` | Max in-flight SFTP requests per file (pipelining within one transfer). `auto` sizes it to the largest file. |
 | `connections` | `auto` | SSH connections the parallel uploads spread over. Never more than `concurrency`. `auto` opens another one only while it would save more time than its handshake costs. See below. |
 | `skip_unchanged` | `false` | For `overlay`, skip a file whose remote counterpart has the same size (coarse; `sync` compares content hashes). |
@@ -234,9 +234,10 @@ throughput, and neither knob can lift it.
 
 `connections: 4` opens up to four connections and spreads the parallel uploads
 over them. Remote scans and deletes issue up to `concurrency` independent
-requests over the first connection; the sync manifest stays there too. This
-keeps the server-facing parallelism under one limit without paying for extra
-SSH handshakes during metadata-only work.
+requests over the first connection. Directory setup and stale-temp cleanup use
+the same limit, and the sync manifest stays on that connection too. This keeps
+the server-facing parallelism under one limit without paying for extra SSH
+handshakes during metadata-only work.
 
 At `auto` (the default) easySFTP decides per deployment, because a connection
 is not free:

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -13,6 +13,11 @@ Set the mode inline with the `mode` input, or in the
 [config file](configuration.md#the-config-file) as `defaults.mode` (global)
 or a per-deployment `mode`.
 
+Before uploading, easySFTP creates remote directory leaves in parallel and
+checks touched directories for stale temporary files with up to
+`advanced.concurrency` SFTP requests. Directory permission updates use the
+same bound. These metadata requests stay on the first SSH connection.
+
 > **Renamed in v3.** What v2 called the `strategy` input (and `strategy:` in
 > the config file) is the `mode` input and `mode:` field in v3. The three
 > behaviors are unchanged. See the [migration guide](migration-v3.md).

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -5,7 +5,7 @@ easySFTP has three settings that decide how much work it does at once:
 | Setting | What it controls |
 |---|---|
 | `advanced.connections` | How many SSH connections the uploads spread over. |
-| `advanced.concurrency` | How many files are transferred in parallel, and how many independent remote scan / delete requests run at once. |
+| `advanced.concurrency` | How many files are transferred in parallel, and how many independent remote metadata requests run at once (directory setup, stale-temp cleanup, scans and deletes). |
 | `advanced.request_concurrency` | How many SFTP write requests **one file** may have in flight (pipelining inside a single transfer). |
 
 All three default to `auto`, and `auto` means easySFTP works the value out for

--- a/internal/uploader/phasereconnect_test.go
+++ b/internal/uploader/phasereconnect_test.go
@@ -15,6 +15,39 @@ import (
 	"github.com/eiserv/easySFTP/internal/config"
 )
 
+// Each leaf directory has its own retry scope. A connection drop while one
+// MkdirAll is active must reconnect and finish the other independent leaves,
+// rather than failing before uploads begin.
+func TestReconnectsDuringDirectorySetup(t *testing.T) {
+	srv := startTestServer(t, withDropOnRequest("Mkdir", "/www/b"))
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"a/one.txt": "one",
+		"b/two.txt": "two",
+	})
+
+	cfg := baseConfig(srv)
+	cfg.Concurrency = 2
+	cfg.Retries = 2
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatalf("expected directory setup to survive the connection drop, got %v", err)
+	}
+	for remote, want := range map[string]string{
+		"/www/a/one.txt": "one",
+		"/www/b/two.txt": "two",
+	} {
+		if got := readRemote(t, srv, remote); got != want {
+			t.Errorf("%s content: got %q, want %q", remote, got, want)
+		}
+	}
+	if got := reconnectWarnings(log); got != 1 {
+		t.Errorf("reconnect warnings: got %d, want one collapsed redial; warnings: %v", got, log.warnings)
+	}
+}
+
 // A connection drop during the clean strategy's delete sweep must redial and
 // finish the sweep, not fail the run.
 func TestCleanReconnectsDuringDeletePhase(t *testing.T) {

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/pkg/sftp"
 
@@ -20,35 +21,66 @@ import (
 // directories: MkdirAll creates any missing parents in the same walk and
 // treats an already-existing directory as success, so ancestors are never
 // stat'd or created one level at a time. Only when a creation fails does it
-// look closer, to report a path that already exists as a file clearly.
-func createRemoteDirs(client *sftp.Client, dirs []string, dirMode *fs.FileMode, watch *stallWatchdog, log Logger) error {
-	for _, dir := range leafDirs(dirs) {
-		done := metrics.Op("sftp_mkdirall")
-		err := client.MkdirAll(dir)
-		done(err)
-		if err != nil {
-			if bad := nonDirConflict(client, dir); bad != "" {
-				return fmt.Errorf("remote path %q exists but is not a directory", bad)
+// look closer, to report a path that already exists as a file clearly. Leaves
+// and directory chmods run through the session's bounded worker pool, with one
+// idempotent operation per sess.do retry scope.
+func createRemoteDirs(ctx context.Context, sess *session, dirs []string, dirMode *fs.FileMode, watch *stallWatchdog, log Logger) error {
+	leaves := leafDirs(dirs)
+	err := runBounded(ctx, sess.workers(len(leaves)), len(leaves), func(groupCtx context.Context, i int) error {
+		dir := leaves[i]
+		return sess.do(groupCtx, watch, func(client *sftp.Client) error {
+			done := metrics.Op("sftp_mkdirall")
+			err := client.MkdirAll(dir)
+			done(err)
+			watch.tick()
+			if err != nil {
+				// Two leaves may share a missing parent. pkg/sftp's MkdirAll
+				// normally resolves that race itself, but a connection drop
+				// between its failed Mkdir and confirming Lstat can hide the
+				// directory another worker just created behind the Mkdir error.
+				// Confirm the final state before treating the operation as failed.
+				info, statErr := client.Stat(dir)
+				watch.tick()
+				if statErr == nil && info.IsDir() {
+					return nil
+				}
+				if isConnError(statErr) {
+					return statErr
+				}
+				bad, conflictErr := nonDirConflict(client, dir, watch)
+				if conflictErr != nil {
+					return conflictErr
+				}
+				if bad != "" {
+					return fmt.Errorf("remote path %q exists but is not a directory", bad)
+				}
+				return fmt.Errorf("creating remote directory %q: %w", dir, err)
 			}
-			return fmt.Errorf("creating remote directory %q: %w", dir, err)
-		}
-		watch.tick()
+			return nil
+		})
+	})
+	if err != nil {
+		return err
 	}
 
 	if dirMode != nil {
-		warned := false
-		for _, dir := range dirs {
-			done := metrics.Op("sftp_chmod_dir")
-			err := client.Chmod(dir, dirMode.Perm())
-			done(err)
-			if err != nil && !warned {
+		var warned atomic.Bool
+		_ = runBounded(ctx, sess.workers(len(dirs)), len(dirs), func(groupCtx context.Context, i int) error {
+			dir := dirs[i]
+			err := sess.do(groupCtx, watch, func(client *sftp.Client) error {
+				done := metrics.Op("sftp_chmod_dir")
+				err := client.Chmod(dir, dirMode.Perm())
+				done(err)
+				watch.tick()
+				return err
+			})
+			if err != nil && !warned.Swap(true) {
 				// Scoped to this pass (one per deployment), like the file-mode
 				// and preserve-times warnings in transfer.go; see issue #121.
 				log.Warningf("could not set dir-mode %04o on %s (server may reject SETSTAT); not warning again for this deployment: %v", dirMode.Perm(), dir, err)
-				warned = true
 			}
-			watch.tick()
-		}
+			return nil
+		})
 	}
 	return nil
 }
@@ -76,14 +108,20 @@ func leafDirs(dirs []string) []string {
 // nonDirConflict returns the shallowest ancestor of dir (dir itself included)
 // that exists on the server but is not a directory, or "" if there is none. It
 // is consulted only after MkdirAll fails, to turn a low-level error into a
-// clear message naming the offending path.
-func nonDirConflict(client *sftp.Client, dir string) string {
+// clear message naming the offending path. Connection errors are returned so
+// sess.do can retry the idempotent leaf operation.
+func nonDirConflict(client *sftp.Client, dir string, watch *stallWatchdog) (string, error) {
 	for _, d := range append(parentDirs(dir), dir) {
-		if info, err := client.Stat(d); err == nil && !info.IsDir() {
-			return d
+		info, err := client.Stat(d)
+		watch.tick()
+		if isConnError(err) {
+			return "", err
+		}
+		if err == nil && !info.IsDir() {
+			return d, nil
 		}
 	}
-	return ""
+	return "", nil
 }
 
 // checkRemoteRoot refuses a destructive mode whose target resolves to the

--- a/internal/uploader/session.go
+++ b/internal/uploader/session.go
@@ -34,9 +34,9 @@ type conn struct {
 // that number is one connection's ceiling: one TCP congestion window and one
 // cipher stream carry the whole run, which neither concurrency nor
 // request_concurrency can lift (issue #158). Parallel uploads spread over the
-// pool. Remote scans and delete sweeps may issue concurrent requests, but keep
-// them on the first connection; manifest writes and directory setup do too.
-// Their reconnect behavior therefore stays independent of the upload pool.
+// pool. Remote scans, directory setup, stale-temp sweeps and deletes may issue
+// concurrent requests, but keep them on the first connection. Their reconnect
+// behavior therefore stays independent of the upload pool.
 type session struct {
 	cfg  *config.Config
 	tune *tuning
@@ -394,7 +394,7 @@ func (s *session) closeSSH() {
 // do runs op against the first connection, redialing on a connection-class
 // failure so the retried op runs against a fresh client instead of the dead one.
 // Everything outside the per-file upload path goes through here, which keeps
-// remote scans, delete sweeps and manifest writes on the first connection.
+// remote metadata phases and manifest writes on the first connection.
 // Several callers may use do concurrently; acquire/reconnect uses the failed
 // connection generation to collapse their simultaneous redials into one.
 // Reconnects share the run-wide budget (the retries input) with the upload
@@ -402,8 +402,8 @@ func (s *session) closeSSH() {
 // errors are returned as-is, untouched.
 //
 // The op is marked active for the stall watchdog for its duration, so a
-// server that hangs during a remote scan, a delete sweep or a manifest write
-// trips stall-timeout just like a hung transfer. Ops must be idempotent: a
+// server that hangs during a remote metadata phase or a manifest write trips
+// stall-timeout just like a hung transfer. Ops must be idempotent: a
 // retried op may have partially (or fully) taken effect on the server before
 // the connection died.
 func (s *session) do(ctx context.Context, watch *stallWatchdog, op func(*sftp.Client) error) error {

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -76,13 +76,10 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 	skipped := make([]bool, len(files))
 
 	if !cfg.DryRun {
-		// Through sess.do so a connection drop during directory setup redials
-		// instead of failing the run; MkdirAll and chmod are idempotent, so
-		// rerunning the whole pass on a fresh client is safe.
+		// Each idempotent operation has its own sess.do retry scope, so a
+		// connection drop does not replay directories that already completed.
 		endDirs := metrics.Phase("create_dirs")
-		err := sess.do(ctx, watch, func(client *sftp.Client) error {
-			return createRemoteDirs(client, dirs, cfg.DirMode, watch, log)
-		})
+		err := createRemoteDirs(ctx, sess, dirs, cfg.DirMode, watch, log)
 		endDirs()
 		if err != nil {
 			return completed, err
@@ -411,10 +408,11 @@ func isTempFileName(name string) bool {
 // against safety.max_deletes (which budgets deletions of deployed files) and
 // are not reported in the run's delete stats.
 //
-// Everything is best-effort: each directory runs through sess.do so a dropped
-// connection redials, but a listing or removal failure only warns and never
-// fails the deploy. Removals are logged, so a user who wondered what those
-// files were gets an answer.
+// Everything is best-effort: directories run concurrently through the
+// session's bounded worker pool, with each one in its own sess.do so a dropped
+// connection redials. A listing or removal failure only warns and never fails
+// the deploy. Removals are logged, so a user who wondered what those files were
+// gets an answer.
 func sweepStaleTemps(ctx context.Context, sess *session, watch *stallWatchdog, base string, files, planned []fileItem, log Logger) {
 	keep := make(map[string]struct{}, len(planned))
 	for _, f := range planned {
@@ -435,11 +433,12 @@ func sweepStaleTemps(ctx context.Context, sess *session, watch *stallWatchdog, b
 		dirs = append(dirs, dir)
 	}
 	sort.Strings(dirs)
-	for _, dir := range dirs {
-		_ = sess.do(ctx, watch, func(client *sftp.Client) error {
-			return sweepDirStaleTemps(client, dir, keep, watch, log)
+	_ = runBounded(ctx, sess.workers(len(dirs)), len(dirs), func(groupCtx context.Context, i int) error {
+		_ = sess.do(groupCtx, watch, func(client *sftp.Client) error {
+			return sweepDirStaleTemps(client, dirs[i], keep, watch, log)
 		})
-	}
+		return nil
+	})
 }
 
 // sweepDirStaleTemps sweeps a single remote directory; see sweepStaleTemps.

--- a/schema/easysftp.schema.json
+++ b/schema/easysftp.schema.json
@@ -153,7 +153,7 @@
           "minimum": 0
         },
         "concurrency": {
-          "description": "Maximum parallel file uploads and independent remote scan, file delete, and same-depth directory delete requests. \"auto\" (the default) sizes it to the number of independent items the phase has, capped at 64.",
+          "description": "Maximum parallel file uploads and independent remote metadata requests, including directory setup, stale-temp cleanup, scans, and deletes. \"auto\" (the default) sizes it to the number of independent items the phase has, capped at 64.",
           "$ref": "#/$defs/autoInt"
         },
         "request_concurrency": {


### PR DESCRIPTION
## What

Parallelize the two remaining latency-bound remote metadata phases behind the existing `advanced.concurrency` worker limit:

- create remote leaf directories and apply directory modes concurrently
- sweep touched directories for stale temporary files concurrently

Both phases continue to use the first SFTP connection, so this does not add SSH handshakes or a new configuration field.

Fixes #213.

## Why

The stored `deep` benchmark spends about 11.6 seconds in `create_dirs` and 8.9 seconds in `sweep_stale_temps`, compared with about 5.5 seconds uploading. Those phases issue one round-trip at a time today, so changing `advanced.concurrency` or `advanced.connections` cannot reduce roughly 75% of the deployment time.

The existing remote scan and delete implementation already provides the needed bounded scheduler and concurrent `session.do` behavior. Reusing that path keeps one server-facing concurrency limit and the existing reconnect, retry-budget and stall-watchdog semantics.

## Root cause and fix

`createRemoteDirs` wrapped the entire leaf and chmod loops in one `session.do`, while `sweepStaleTemps` called one `session.do` per directory from a serial loop. The first shape also replayed the complete directory pass after a connection drop.

This change runs both sets through `runBounded`, sized by `session.workers(items)`. Every `MkdirAll`, directory `Chmod` and per-directory stale-temp sweep has its own `session.do` scope. Completed round-trips tick the watchdog, and the directory-mode warning uses `atomic.Bool` so it remains once per deployment under concurrency.

Parallel `MkdirAll` calls can share a missing parent. `pkg/sftp` normally resolves that creation race, but a connection drop between its failed `Mkdir` and confirming `Lstat` can expose a misleading already-exists error. The implementation now verifies the final leaf state before failing and returns connection errors from that confirmation so `session.do` can retry the idempotent leaf operation.

The stale-temp sweep remains best effort. Its keep set is read-only across workers, failures still do not fail the deployment, and every removal keeps the existing name, age and planned-target guards.

## Verification

- `go test -race ./...`
- affected uploader tests repeated with `-count=5`
- `go vet ./...`
- `bash scripts/test-action.sh`
- `shellcheck scripts/*.sh`
- `gofmt -l .`
- `python3 -m json.tool schema/easysftp.schema.json`
- `git diff --check`

The new reconnect test exercises two parallel leaves with a shared missing parent while one `Mkdir` drops the connection, then verifies one collapsed redial and both completed uploads.
