### PR TITLE
feat(uploader): model workload shape and let auto take a step back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,18 +449,28 @@ jobs:
                    and .process.max_rss_bytes > 0
                    and .process.user_cpu_ms > 0
                    and .process.net_write_bytes > 0' "$OUT_DIR/results.json"
-          # The adaptive settings (issue #209) against a real server, which is
-          # the only place the link probe and the connection pool run at all.
-          # The standard benchmark is an inline run, so all three settings are
-          # at auto: the policy must have read the workload, measured the link
-          # and stayed inside its own bounds.
+          # The adaptive settings (issues #209 and #215) against a real server,
+          # which is the only place the link probe and the connection pool run
+          # at all. The standard benchmark is an inline run, so all three
+          # settings are at auto: the policy must have read the workload
+          # including its shape, measured the link, left the throughput at the
+          # prior (nothing observes one before the first byte moves) and stayed
+          # inside its own bounds. auto_changes has to add up to the two
+          # directions, or a step back is being counted as a step forward.
           jq -e '.results[] | select(.label == "candidate" and .scenario == "small")
                  | (.operations | map(select(.name == "sftp_realpath")) | first | .count) >= 3
                    and .counters.workload_files == 300
                    and .counters.workload_probes == 0
+                   and .counters.workload_p50_bytes == 4096
+                   and .counters.workload_p90_bytes == 4096
+                   and .counters.workload_small_files == 300
                    and .counters.link_rtt_us > 0
                    and .counters.link_handshake_us > 0
+                   and .counters.link_stream_bytes_per_second == 0
                    and .counters.auto_initial_connections >= 1
+                   and .counters.auto_final_connections >= 1
+                   and .counters.auto_changes == (.counters.auto_spread_increases + .counters.auto_spread_decreases)
+                   and .counters.config_connections >= .counters.auto_final_connections
                    and .counters.config_connections >= .counters.auto_initial_connections
                    and .counters.config_connections <= 8
                    and .counters.config_concurrency == 64

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -103,7 +103,7 @@ Markdown:
 | `results[].process` | CPU time, peak RSS, Go allocations, GC count and pause, peak goroutines, disk and network bytes |
 | `results[].phases[]` | wall clock per phase (connect, local_scan, remote_scan, hash, create_dirs, sweep_stale_temps, upload, delete_sweep, manifest_read, manifest_write, prune_dirs, cleanup) |
 | `results[].operations[]` | per round-trip: count, cumulative total, average, p50/p90/p99, max, errors |
-| `results[].counters` | connections opened/used/refused, reconnects, retries, stalls, errors, the settings the run used (`config_*`), what the policy first picked (`auto_initial_*`, `auto_changes`), the features it read (`workload_*`) and the link it measured (`link_rtt_us`, `link_handshake_us`) |
+| `results[].counters` | connections opened/used/refused, reconnects, retries, stalls, errors, the settings the run used (`config_*`), what the policy first picked (`auto_initial_*`), how it moved afterwards (`auto_changes`, `auto_spread_increases`, `auto_spread_decreases`, `auto_final_connections`), the features it read (`workload_*`, including `workload_p50_bytes`, `workload_p90_bytes` and `workload_small_files`) and the link it measured (`link_rtt_us`, `link_handshake_us`, `link_stream_bytes_per_second`, `link_bdp_bytes`) |
 | `comparison[]` | each build against the reference build: `delta_ms`, `delta_percent`, and `within_noise` (is the delta smaller than the reference's MAD?) |
 | `deletes[]` | the delete sweeps, one row per (build, scenario, link profile); see "The delete sweeps" below |
 | `runs[]` | every individual repeat, verbatim, including its own metrics document |
@@ -190,8 +190,9 @@ candidate build, and scores it against the grid:
 | Field | What it is |
 |---|---|
 | `chosen` | the `connections`, `concurrency` and `request_concurrency` the run ended up using, read from its own counters rather than assumed |
-| `chosen.initial_*`, `chosen.changes` | what the policy picked before the transfer taught it anything, and how many times it widened the pool while the transfer ran; equal to `chosen` on a run the runtime stage left alone |
-| `workload` | the features the policy was looking at: `files`, `bytes`, `largest_bytes`, `probes`, and the `rtt_ms` / `handshake_ms` the run measured itself |
+| `chosen.initial_*`, `chosen.changes` | what the policy picked before the transfer taught it anything, and how many times it moved the connection spread while the transfer ran; equal to `chosen` on a run the runtime stage left alone |
+| `chosen.spread_increases`, `chosen.spread_decreases`, `chosen.final_connections` | which way those changes went and where the run settled. A growth step that does not pay for itself is taken back without closing anything (issue #215), so the plain `connections` above is a high-water mark and this is the number the last deployment ran on |
+| `workload` | the features the policy was looking at: `files`, `bytes`, `largest_bytes`, `probes`, the shape of the set (`p50_bytes`, `p90_bytes`, `small_files`, the files that fit in one 32 KiB write packet), and the link it measured itself (`rtt_ms`, `handshake_ms`, and `stream_bytes_per_second` / `bdp_bytes` where a throughput was known) |
 | `median_ms`, `min_ms`, `max_ms`, `mad_ms`, `durations_ms`, `mib_per_s`, `files_per_s` | the same statistics a cell carries |
 | `best` | the fastest candidate cell of that scenario and profile |
 | `regret_ms`, `regret_percent` | the gap: how much slower the policy is than the settings a sweep would have picked |
@@ -223,7 +224,7 @@ Four things about it:
   react to. What `chosen.changes` records is that the controller acted; whether
   it acted well shows up in `median_ms` and nowhere else.
 
-The policy itself lives in `internal/autotune` (issue #209), and its own test
+The policy itself lives in `internal/autotune` (issues #209 and #215), and its own test
 replays it against every sweep committed here and fails when the regret goes
 over the target. That test is the fast feedback loop; the sweep is the
 measurement it is fitted to.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,7 +221,7 @@ sync:
 | `timeout` | `30` | Connection timeout in seconds. `0` disables. |
 | `stall_timeout` | `0` (off) | Abort when active remote operations make no progress for this many seconds. |
 | `concurrency` | `auto` | Files uploaded in parallel, and independent remote metadata requests such as directory setup, stale-temp cleanup, scans and deletes. `auto` sizes it to the work (see [transfer tuning](tuning.md)). Sync hashing uses the runner's available Go CPU parallelism independently. |
-| `request_concurrency` | `auto` | Max in-flight SFTP requests per file (pipelining within one transfer). `auto` sizes it to the largest file. |
+| `request_concurrency` | `auto` | Max in-flight SFTP requests per file (pipelining within one transfer). `auto` sizes it to the largest file and to what the whole set costs to hold in flight (see [transfer tuning](tuning.md)). |
 | `connections` | `auto` | SSH connections the parallel uploads spread over. Never more than `concurrency`. `auto` opens another one only while it would save more time than its handshake costs. See below. |
 | `skip_unchanged` | `false` | For `overlay`, skip a file whose remote counterpart has the same size (coarse; `sync` compares content hashes). |
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -36,19 +36,45 @@ overriding.
 
 After the local scan, and again for each deployment right before its transfer,
 easySFTP knows the files it is about to send: how many, how large in total, the
-size of the biggest one, and how many pure metadata round-trips come with them
-(the one stat per file that `advanced.skip_unchanged` costs, the removals of a
-delete sweep).
+size of the biggest one, how those sizes are *distributed* (the median, the
+ninetieth percentile, and how many files fit in a single 32 KiB write packet),
+and how many pure metadata round-trips come with them (the one stat per file
+that `advanced.skip_unchanged` costs, the removals of a delete sweep).
 
-`concurrency` follows directly from that: as many workers as there are
-independent items, capped at 64. A worker with nothing to do never starts, so
-there is nothing to trade off.
+The distribution is there because totals do not describe a deploy. A hundred
+files carrying twelve megabytes can be a hundred medium files or ninety tiny
+ones with a handful of archives among them, and the two want different
+pipelining. A summary that only knows the total and the largest file cannot
+tell them apart.
 
-`request_concurrency` follows from the largest file. The setting counts 32 KiB
-write packets in flight for a single file, so a 4 KiB file cannot use a second
-one however high the number is; a 16 MiB file can use many. It stays at the
-long-standing 16 for a tree of small files and rises to at most 64 for large
-ones, which is where one SSH channel's 2 MiB window is full anyway.
+`concurrency` follows directly from the item count: as many workers as there
+are independent items, capped at 64. A worker with nothing to do never starts,
+so there is nothing to trade off.
+
+`request_concurrency` follows from the largest file and from what the whole set
+costs to keep in flight. The setting counts 32 KiB write packets in flight for
+a single file, so a 4 KiB file cannot use a second one however high the number
+is; a 16 MiB file can use many. It stays at the long-standing 16 for a tree of
+small files and rises to at most 64 for large ones, which is where one SSH
+channel's 2 MiB window is full anyway.
+
+The buffers those packets hold are capped run-wide (32 MiB), and that ceiling
+used to be shared as if every file in flight were as large as the largest one.
+It is now shared against the distribution: at most a tenth of the files can be
+above the ninetieth percentile, so a deploy of small files with a few archives
+in it keeps the deep pipelining its archives need instead of paying for
+buffers no file will use.
+
+One number this would like it cannot have yet: how many bytes the path can hold
+in flight, which is throughput times round-trip time (the bandwidth-delay
+product). The round-trip time is measured a moment later; the throughput is
+not, and a pipeline depth computed from a guessed throughput would be a guess
+wearing an argument's clothes. So while the throughput is still the built-in
+assumption, `request_concurrency` stays on the rule above. Once a throughput
+has really been observed, the bandwidth-delay product is what sizes it: a long
+fat path is given every packet the channel window has, and a path that carries
+five kilobytes per round-trip is not asked to hold two megabytes of one file
+open for no reason.
 
 ### 2. What the connection costs
 
@@ -74,15 +100,27 @@ One thing cannot be known before any bytes move: how fast the link actually is.
 easySFTP starts from a deliberately conservative assumption and then measures.
 While a transfer runs, it watches the throughput it is really achieving and
 widens the connection pool if the work that is left still justifies another
-handshake. It grows at most one doubling at a time, and it stops for good the
-first time a step does not make things measurably faster.
+handshake. It grows at most one doubling at a time.
+
+A window only counts as a measurement when it is long enough (three quarters of
+a second), saw enough files finish (four) and carried enough bytes (half a
+megabyte). Until it is, the window keeps widening rather than being reset, so a
+short deploy of tiny files is never resized on the strength of a few kilobytes.
+
+If a step does not make things measurably faster, it is **taken back**: the
+files that are left go over the number of connections that was carrying them
+before. Nothing is closed and nothing in flight moves; what changes is only
+where the next file is sent. Then the policy settles. One correction is a
+correction, a second one would be an oscillation, and a deploy tool that
+oscillates its connection count is worse than one that settles on a slightly
+wrong number.
 
 It also stops immediately if the server refuses a connection or if any upload
 has to be retried. A server that is already pushing back is not one to put more
 load on.
 
-The pool never shrinks (a handshake already paid is spent, and closing a
-connection would abort the files on it), and `concurrency` and
+Connections are never *closed* mid-run (a handshake already paid is spent, and
+closing a connection would abort the files on it), and `concurrency` and
 `request_concurrency` never move at runtime: the first is already at the
 largest value that can be busy, and the second is fixed when an SFTP client is
 created.
@@ -138,10 +176,16 @@ and a runtime change says what moved and on the strength of what measurement:
 auto tuning: 1.1 MiB/s over the connections in use; raising connections 2 -> 4 for the rest of this deployment
 ```
 
+as does one that turns out not to have been worth it:
+
+```text
+auto tuning: 1.1 MiB/s is no better than the 1.1 MiB/s before the spread grew to 8; assigning the remaining files across 4 connection(s) instead, without closing any
+```
+
 With `log-level: debug` every decision is printed in full, inputs first:
 
 ```text
-auto tuning: files=2000 bytes=7.8 MiB largest=4.0 KiB probes=0 rtt=13ms handshake=384ms throughput=assumed 1.0 MiB/s -> connections=8 concurrency=64 request_concurrency=16
+auto tuning: files=2000 bytes=7.8 MiB p50=4.0 KiB p90=4.0 KiB small=2000 largest=4.0 KiB probes=0 rtt=13ms handshake=384ms throughput=assumed 1.0 MiB/s bdp=13.3 KiB -> connections=8 concurrency=64 request_concurrency=16
 ```
 
 If the server will not open as many connections as easySFTP asked for, you get
@@ -168,7 +212,12 @@ knowing:
 - On a link that is much faster than the one it was fitted on, easySFTP may
   open a connection or two more than it needed to before its own measurement
   corrects the assumption. The cost of that is bounded by the handshakes
-  themselves, which on a fast link are cheap.
+  themselves, which on a fast link are cheap, and a step that did not help is
+  taken back within a window.
+- The bandwidth-delay product only sizes the pipelining once a throughput has
+  been observed, and nothing observes one before the first byte moves. Today
+  that means the conservative rule is what a normal run uses; the measured path
+  exists for the run that starts with a throughput it inherited.
 
 If your deploy is slower than you expect, `log-level: debug` prints the whole
 decision, and [troubleshooting](troubleshooting.md) covers the failure modes

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -107,6 +107,17 @@ a second), saw enough files finish (four) and carried enough bytes (half a
 megabyte). Until it is, the window keeps widening rather than being reset, so a
 short deploy of tiny files is never resized on the strength of a few kilobytes.
 
+And a byte rate only counts as a measurement of the *link* when the files could
+fill one. A deployment of files that each fit in a single 32 KiB write is
+limited by four round-trips per file, not by bandwidth; its megabytes per second
+are its files per second in other units, and reading them as a bandwidth makes
+the link look dead and buys connections that cannot help. For those deployments
+the round-trip model that sized the run up front already had everything it was
+going to get (the round-trip time was measured before the first file), so the
+runtime stage only re-plans the work that is left. Where the bytes really do
+come from files large enough to stream, the measurement means what it says and
+the pool follows it.
+
 If a step does not make things measurably faster, it is **taken back**: the
 files that are left go over the number of connections that was carrying them
 before. Nothing is closed and nothing in flight moves; what changes is only
@@ -128,8 +139,9 @@ created.
 This runtime stage is what makes an overlay redeploy safe to start small. With
 `advanced.skip_unchanged` easySFTP cannot know in advance how many files really
 changed, so it sizes the run for the checks it is certain of. If it then turns
-out that most files *are* changing, the ratio it observes in the first second
-tells it, and the pool widens.
+out that most files *are* changing, the ratio it observes in its first window
+tells it, and the pool widens: that correction is about how much work there
+turned out to be, so it applies whatever the files look like.
 
 ## Overriding it
 

--- a/internal/autotune/autotune.go
+++ b/internal/autotune/autotune.go
@@ -13,9 +13,12 @@
 // only ever adds information to the same model:
 //
 //  1. Workload. After the local scan a run knows what it is about to send:
-//     how many files, how many bytes, the largest one, and how many pure
-//     metadata round-trips (skip stats, deletes) come with them. That is
-//     enough to size concurrency exactly and to bound the other two.
+//     how many files, how many bytes, how they are distributed (the median,
+//     the ninetieth percentile and how many of them fit in a single write
+//     packet), and how many pure metadata round-trips (skip stats, deletes)
+//     come with them. Totals alone cannot tell a tree of 4 KiB files with one
+//     archive in it from a tree of megabyte files, and the two want different
+//     pipelining; the distribution can (issue #215, stage 1).
 //  2. Link. The first connection measures its own handshake, and a few cheap
 //     round-trips measure the RTT. Both go into Link and make the cost model
 //     concrete: an extra connection costs one handshake, and a round-trip
@@ -23,7 +26,9 @@
 //  3. Runtime. What the model cannot know before the transfer is the link's
 //     throughput, so Plan starts from a deliberately conservative prior.
 //     Controller replaces that prior with the throughput the run is actually
-//     achieving and re-plans against the work that is left. See controller.go.
+//     achieving and re-plans against the work that is left. A step that does
+//     not pay for itself is taken back: the connections stay open, the files
+//     that are left simply stop being handed to them. See controller.go.
 //
 // # Why connections are the interesting knob
 //
@@ -56,6 +61,7 @@ package autotune
 import (
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"time"
 )
@@ -116,6 +122,21 @@ const (
 	// 340 ms over one connection at a 13 ms RTT.
 	probesInFlightPerConnection = 16
 
+	// bdpSafetyFactor is how many bandwidth-delay products of data a stream
+	// is asked to keep in flight. One BDP is the textbook amount that fills a
+	// pipe exactly and leaves nothing over for the server's own write latency,
+	// for an ack that arrives late, or for an RTT that was measured on a good
+	// moment. Four is the usual engineering answer and it is cheap to be
+	// generous with here: the result is clamped by the file, by the memory
+	// budget and by MaxRequestConcurrency anyway.
+	bdpSafetyFactor = 4
+
+	// tailShare is the share of the files in flight that the memory model
+	// treats as possibly the big ones. The rest are bounded by the ninetieth
+	// percentile, which is exactly what a percentile promises: no more than a
+	// tenth of the files are above it. See inFlightPackets.
+	tailShare = 0.1
+
 	// assumedStreamBytesPerSecond is the per-connection throughput Plan
 	// assumes while nothing has been measured yet. It is deliberately low.
 	// The number is only used to ask "is this run long enough to be worth
@@ -144,11 +165,26 @@ const (
 // it scanned.
 type Workload struct {
 	// Uploads is how many files will be sent, and UploadBytes their total
-	// size. LargestUpload is the biggest single one, which is the only file
-	// size request_concurrency can act on.
+	// size. LargestUpload is the biggest single one.
 	Uploads       int
 	UploadBytes   int64
 	LargestUpload int64
+
+	// P50Upload and P90Upload are the median and the ninetieth percentile of
+	// the file sizes, and SmallUploads counts the files that fit in a single
+	// SFTP write packet, which is the size below which no amount of
+	// pipelining can do anything for a file.
+	//
+	// They are here so that two transfers with the same totals and the same
+	// largest file stop looking alike: 99 medium files plus one archive and a
+	// thousand tiny files plus a few archives cost very different amounts of
+	// memory to pipeline, and only the distribution can tell them apart
+	// (issue #215, stage 1). SummarizeUploads fills all three; a workload
+	// built by hand may leave them at zero, and every reader below falls back
+	// to LargestUpload when they are.
+	P50Upload    int64
+	P90Upload    int64
+	SmallUploads int
 
 	// Probes counts remote round-trips that are not uploads: the one stat per
 	// file that advanced.skip_unchanged costs, and the removals of a delete
@@ -164,6 +200,49 @@ type Workload struct {
 	Unknown bool
 }
 
+// SummarizeUploads is how a caller turns the file sizes it is about to send
+// into the upload side of a Workload: the totals, the largest file and the
+// distribution features stage 1 of the policy reads.
+//
+// The sizes are only needed here. Nothing downstream keeps them, which is the
+// point of reducing them to a handful of numbers: a deployment of a hundred
+// thousand files is summarised once, in one pass plus a sort, and the policy
+// then works on a plain struct. The caller's slice is not modified.
+func SummarizeUploads(sizes []int64) Workload {
+	var w Workload
+	if len(sizes) == 0 {
+		return w
+	}
+	sorted := make([]int64, 0, len(sizes))
+	for _, size := range sizes {
+		size = max(size, 0)
+		sorted = append(sorted, size)
+		w.Uploads++
+		w.UploadBytes += size
+		if size <= packetBytes {
+			w.SmallUploads++
+		}
+	}
+	slices.Sort(sorted)
+	w.LargestUpload = sorted[len(sorted)-1]
+	w.P50Upload = percentile(sorted, 0.5)
+	w.P90Upload = percentile(sorted, 0.9)
+	return w
+}
+
+// percentile is the nearest-rank percentile of an ascending slice: the
+// smallest value at or above which the given share of the files sit. Exact,
+// deterministic and without interpolation, because the readers of these
+// numbers ask "how big is a file up here" rather than "what is the continuous
+// quantile of the distribution".
+func percentile(sorted []int64, q float64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	rank := int(math.Ceil(q * float64(len(sorted))))
+	return sorted[min(max(rank, 1), len(sorted))-1]
+}
+
 // Items is how many independent units of work the phase has, which is the
 // largest number of workers that can ever be busy at once.
 func (w Workload) Items() int {
@@ -172,6 +251,37 @@ func (w Workload) Items() int {
 
 // Empty reports whether there is nothing to do.
 func (w Workload) Empty() bool { return w.Uploads == 0 && w.Probes == 0 }
+
+// Source says where a throughput number came from, because a decision taken on
+// a guess and one taken on a measurement do not deserve the same confidence.
+// New evidence always outranks old evidence: the runtime measurement of the
+// current transfer wins over a cached one, which wins over the built-in prior.
+type Source uint8
+
+const (
+	// SourcePrior is the built-in conservative guess: nothing about this link
+	// has been observed. It is what the whole policy starts from.
+	SourcePrior Source = iota
+	// SourceCached is an observation carried over from an earlier run with a
+	// similar workload and link (issue #212). easySFTP does not produce these
+	// yet; Link accepts them so the policy that consumes one is written and
+	// tested before the cache exists.
+	SourceCached
+	// SourceRuntime is what this transfer is achieving right now, which is the
+	// only evidence that describes the run being tuned.
+	SourceRuntime
+)
+
+func (s Source) String() string {
+	switch s {
+	case SourceCached:
+		return "cached"
+	case SourceRuntime:
+		return "measured"
+	default:
+		return "assumed"
+	}
+}
 
 // Link is what a run knows about the path to its server. RTT and Handshake are
 // measured once, on the first connection; StreamBytesPerSecond is not
@@ -185,6 +295,12 @@ type Link struct {
 	// Zero means "not measured yet" and makes Plan fall back to the
 	// conservative prior; see assumedStreamBytesPerSecond.
 	StreamBytesPerSecond float64
+
+	// ThroughputSource records where that number came from. It only means
+	// anything while StreamBytesPerSecond is positive, and a caller that fills
+	// in a throughput without saying where it found it is taken at its word:
+	// an observation of the run in front of it.
+	ThroughputSource Source
 }
 
 // rtt is the measured RTT, or a plain-internet stand-in when the probe could
@@ -215,9 +331,30 @@ func (l Link) streamBytesPerSecond() float64 {
 }
 
 // Measured reports whether the link carries an observed throughput rather than
-// the prior. Callers log the difference, because a decision taken on a guess
-// and one taken on a measurement deserve different confidence.
+// the prior.
 func (l Link) Measured() bool { return l.StreamBytesPerSecond > 0 }
+
+// Source is where the throughput this link reports came from.
+func (l Link) Source() Source {
+	if !l.Measured() {
+		return SourcePrior
+	}
+	if l.ThroughputSource == SourcePrior {
+		// A throughput with no provenance is the caller's own measurement:
+		// nothing else could have produced one.
+		return SourceRuntime
+	}
+	return l.ThroughputSource
+}
+
+// BDPBytes is the bandwidth-delay product of this path: how many bytes one
+// stream has to keep in flight for the pipe to stay full. It is what stage 3
+// of the policy sizes request_concurrency against, and it is exported so the
+// number behind a surprising choice can be read back out of the run's counters
+// instead of recomputed by hand.
+func (l Link) BDPBytes() int64 {
+	return int64(l.streamBytesPerSecond() * l.rtt().Seconds())
+}
 
 // Fixed holds the values the user pinned in the config file. Zero means the
 // setting was left at "auto" and is the policy's to choose. Each field is
@@ -265,7 +402,7 @@ func Plan(w Workload, l Link, f Fixed) Settings {
 		s.Concurrency = planConcurrency(w)
 	}
 	if s.RequestConcurrency == 0 {
-		s.RequestConcurrency = planRequestConcurrency(w, s.Concurrency)
+		s.RequestConcurrency = planRequestConcurrency(w, l, s.Concurrency)
 	}
 	if s.Connections == 0 {
 		s.Connections = planConnections(w, l, s.Concurrency)
@@ -277,6 +414,20 @@ func Plan(w Workload, l Link, f Fixed) Settings {
 // independent items, capped. A worker with nothing to do costs nothing (the
 // upload loop simply never starts it), so there is no trade-off to make here
 // and nothing for the runtime controller to discover later.
+//
+// Issue #215 asks whether an *active* worker is free too, since it holds a
+// remote file handle, a slot in the server's request queue and its share of
+// the in-flight buffers. It is not, and the answer is still this one: across
+// the seven sweeps under benchmarks/matrix/ the fastest concurrency at the
+// connection count the policy picks is 32 or 64 for every payload-heavy
+// scenario, and the two cases that disagree (small at 4 connections, mixed at
+// 8) disagree by two to fourteen per cent in opposite directions on grids
+// whose own canary spread is around seven. There is no rule in that, and
+// fitting one to it would be fitting noise. The other two costs the issue
+// names are bounded elsewhere: the buffers by inFlightPackets, which is a real
+// constraint and does now read the distribution, and the pool by
+// planConnections, which is where the measured cost of over-provisioning
+// actually lives.
 func planConcurrency(w Workload) int {
 	items := w.Items()
 	if items < 1 {
@@ -285,28 +436,102 @@ func planConcurrency(w Workload) int {
 	return min(items, MaxConcurrency)
 }
 
-// planRequestConcurrency pipelines one file's writes as far as the file itself
-// can use, then as far as the memory budget allows.
+// planRequestConcurrency sizes one file's pipeline: enough in-flight bytes to
+// keep the path busy, never more than the file itself or the memory budget can
+// use.
 //
 // The setting is pkg/sftp's MaxConcurrentRequestsPerFile: how many 32 KiB write
 // packets of *one* file may be in flight. A 4 KiB file is a single packet and
 // cannot use a second request no matter what the value says, so raising it for
 // a tree of small files only reserves buffers. It is the large files that can
-// use it, and on a high-latency link they need it: with 16 packets in flight a
-// file moves at most 512 KiB per round-trip.
-func planRequestConcurrency(w Workload, concurrency int) int {
-	packets := 1
-	if w.LargestUpload > 0 {
-		packets = int(min((w.LargestUpload+packetBytes-1)/packetBytes, int64(MaxRequestConcurrency)))
+// use it, and how many of them they need is a property of the path rather than
+// of the file: a stream keeps a pipe full by holding one bandwidth-delay
+// product of data in it, so that (times a safety factor) is the target, and
+// the file only ever caps it (issue #215, stage 3).
+//
+// The BDP is only spent when somebody measured the throughput. While the
+// number is the built-in prior, a BDP computed from it would be a guess
+// dressed as an argument, so the conservative pre-#215 rule stands: pipeline
+// the file as far as it goes. That direction is the safe one. Under-pipelining
+// a long fat path costs throughput on every large file, while over-pipelining a
+// slow one costs buffers the budget below already bounds.
+func planRequestConcurrency(w Workload, l Link, concurrency int) int {
+	file := packetsFor(w.LargestUpload)
+	want := max(file, MinRequestConcurrency)
+	if l.Measured() {
+		// A measured path may argue the file down as well as up: on a link
+		// that carries 5 KiB per round-trip, holding two megabytes of one file
+		// in flight buys nothing that the floor does not already buy.
+		bdp := int(min((int64(bdpSafetyFactor)*l.BDPBytes()+packetBytes-1)/packetBytes, int64(MaxRequestConcurrency)))
+		want = min(max(bdp, MinRequestConcurrency), max(file, MinRequestConcurrency))
 	}
-	want := max(packets, MinRequestConcurrency)
+	want = quantize(want)
 
-	// Never let concurrency times request_concurrency reserve more than the
-	// in-flight budget, but never drop below the long-standing default doing
-	// so: a run with 64 files in flight is a run of small files, where the
-	// setting cannot do anything anyway.
-	budget := max(maxInFlightPackets/max(concurrency, 1), MinRequestConcurrency)
-	return min(want, budget, MaxRequestConcurrency)
+	// Never let the files in flight reserve more than the in-flight budget,
+	// but never drop below the long-standing default doing so: at 64 workers
+	// the floor and the budget meet exactly, so this can only ever bind
+	// request_concurrency and never the worker count.
+	for want > MinRequestConcurrency && inFlightPackets(w, concurrency, want) > maxInFlightPackets {
+		want = quantize(want / 2)
+	}
+	return min(want, MaxRequestConcurrency)
+}
+
+// packetsFor is how many write packets a file of this size occupies, capped at
+// the most one file may have in flight. Zero and negative sizes are one packet:
+// every file costs at least one write.
+func packetsFor(size int64) int {
+	if size <= 0 {
+		return 1
+	}
+	return int(min((size+packetBytes-1)/packetBytes, int64(MaxRequestConcurrency)))
+}
+
+// quantize snaps a request count to a power of two. The value is a pipeline
+// depth, not a measurement: 18 and 16 cannot behave differently, and a policy
+// that reports 18 invites the reader to believe the second digit means
+// something. Snapping down also keeps the choice on the coordinates the stored
+// sweeps actually measured, which is what makes the replay in regret_test.go
+// able to score it.
+func quantize(n int) int {
+	if n < 1 {
+		return 1
+	}
+	p := 1
+	for p*2 <= n {
+		p *= 2
+	}
+	return p
+}
+
+// inFlightPackets is what a transfer holds in write buffers at once, in 32 KiB
+// packets. It is an upper bound rather than an estimate, and the distribution
+// is what makes it one worth having.
+//
+// Before issue #215 the bound was concurrency times request_concurrency: every
+// file in flight assumed to be large enough to use the whole pipeline. For a
+// deployment of 4 KiB files with a couple of archives in it that is off by
+// more than an order of magnitude, and it was the reason the stored 'mixed'
+// sweep ran with a request_concurrency of 18: 56 workers divided into the
+// budget, as if all 56 files were the 2 MiB one.
+//
+// With a percentile the same bound gets much tighter without getting wrong. At
+// most a tenth of the files are above P90Upload, so a tenth of the workers may
+// be holding a full pipeline each and the rest are holding no more than the
+// percentile needs.
+func inFlightPackets(w Workload, concurrency, requests int) int {
+	workers := float64(max(concurrency, 1))
+	tail := workers * tailShare
+	body := workers - tail
+
+	// Without a distribution (a workload built by hand, or the controller's
+	// extrapolation of what is left) the largest file is all there is to go
+	// on, which is the pre-#215 bound.
+	perFile := float64(min(packetsFor(w.LargestUpload), requests))
+	if w.P90Upload > 0 {
+		perFile = float64(min(packetsFor(w.P90Upload), requests))
+	}
+	return int(math.Ceil(body*perFile + tail*float64(requests)))
 }
 
 // planConnections is the sqrt(W/H) rule from the package comment, clamped by
@@ -366,15 +591,12 @@ func Explain(w Workload, l Link, f Fixed, s Settings) string {
 	if w.Unknown {
 		unknown = ", upload set not known yet"
 	}
-	rate := "assumed"
-	if l.Measured() {
-		rate = "measured"
-	}
 	return fmt.Sprintf(
-		"files=%d bytes=%s largest=%s probes=%d%s rtt=%s handshake=%s throughput=%s %s/s -> %s%s",
-		w.Uploads, humanBytes(w.UploadBytes), humanBytes(w.LargestUpload), w.Probes, unknown,
+		"files=%d bytes=%s p50=%s p90=%s small=%d largest=%s probes=%d%s rtt=%s handshake=%s throughput=%s %s/s bdp=%s -> %s%s",
+		w.Uploads, humanBytes(w.UploadBytes), humanBytes(w.P50Upload), humanBytes(w.P90Upload),
+		w.SmallUploads, humanBytes(w.LargestUpload), w.Probes, unknown,
 		roundMS(l.rtt()), roundMS(l.handshake()),
-		rate, humanBytes(int64(l.streamBytesPerSecond())),
+		l.Source(), humanBytes(int64(l.streamBytesPerSecond())), humanBytes(l.BDPBytes()),
 		s, pinned(f))
 }
 

--- a/internal/autotune/controller.go
+++ b/internal/autotune/controller.go
@@ -15,12 +15,18 @@ import (
 //
 // What it may change, and what it deliberately may not:
 //
-//   - Connections grow. This is the whole point. The pool is dialed lazily, so
+//   - The spread grows. This is the whole point. The pool is dialed lazily, so
 //     raising the number costs one handshake per connection that a worker
 //     then really uses, and the same sqrt(W/H) rule decides whether the work
 //     that is *left* justifies it.
-//   - Connections never shrink. A handshake already paid is sunk, and closing
-//     a connection mid-transfer would abort the files on it.
+//   - The spread comes back down when a step did not pay for itself, and that
+//     is not the same as closing a connection. What moves is how many of the
+//     open connections the files that are *left* are handed to; every
+//     handshake already paid stays paid and every transfer already running
+//     stays where it is (issue #215, stage 5). Before that the controller
+//     could only widen a pool it had widened too far, and the stored 'small'
+//     sweep is what that costs: 4 connections widened to 8 on one thin
+//     window, on a workload whose measured optimum was 2.
 //   - Concurrency never moves. Plan already sizes it to the number of
 //     independent items, which is the largest value that can ever be busy;
 //     there is nothing for a hill climb to find.
@@ -29,18 +35,33 @@ import (
 //     changing it would mean reconnecting.
 //
 // The controller is deliberately dull. It re-plans, it grows at most to double
-// the current pool per step, and it stops for good the first time a step fails
-// to pay off or the server pushes back. A deploy tool that oscillates its
-// connection count is worse than one that settles on a slightly wrong number.
+// the current pool per step, it takes at most one step back, and it stops for
+// good the first time a step fails to pay off or the server pushes back. A
+// deploy tool that oscillates its connection count is worse than one that
+// settles on a slightly wrong number.
 const (
-	// minObservation is how much transfer has to have happened before the
-	// first decision. Short enough that a run of a few seconds still gets one
+	// minObservation is how long a window has to be before it is a
+	// measurement. Short enough that a run of a few seconds still gets one
 	// adjustment, long enough that the measurement is not one file's noise.
+	//
+	// It is the length of the *window*, not the time since the phase started:
+	// every decision after the first one compares two windows, and a 250 ms
+	// tick against a 750 ms baseline compares two different amounts of
+	// evidence (issue #215, stage 6).
 	minObservation = 750 * time.Millisecond
 
-	// minSamples is the other half of that: a window that saw a single file
+	// minSamples is the second half of that: a window that saw a single file
 	// finish says nothing about throughput.
 	minSamples = 4
+
+	// minWindowBytes is the third. Time and file counts alone let a window of
+	// mostly-empty files decide the size of the pool, which is how a 1 MiB
+	// deployment of 4 KiB files ended up on eight connections. Half a
+	// megabyte is sixteen write packets, one fully pipelined file at the
+	// default request_concurrency, and it is deliberately a floor on
+	// *evidence* rather than on the workload: a transfer too small to produce
+	// it is a transfer too small to be worth a handshake either way.
+	minWindowBytes = MinRequestConcurrency * packetBytes
 
 	// improvementBand is how much better a step has to make things before the
 	// controller believes it. Below this the two windows are the same
@@ -92,12 +113,19 @@ type Controller struct {
 	stopped bool
 	reason  string
 
-	// last is the previous accepted observation, and pending records the
-	// throughput measured just before the most recent growth so the next
-	// observation can tell whether that growth paid off.
-	last        Progress
-	haveLast    bool
+	// last is the previous accepted observation. An observation that is not
+	// evidence yet (too short a window, too few files, too few bytes) does not
+	// replace it, so the window widens until it is one instead of a thin
+	// window deciding the size of the pool.
+	last     Progress
+	haveLast bool
+
+	// pendingRate is the throughput measured just before the most recent
+	// growth, and pendingFrom the spread it grew from, so the next window can
+	// say whether that step paid for itself and, if it did not, where to put
+	// the spread back.
 	pendingRate float64
+	pendingFrom int
 }
 
 // NewController returns the controller for a deployment that Plan resolved to
@@ -123,9 +151,23 @@ type Change struct {
 	// Rate is the aggregate throughput of the window that motivated the
 	// change, in bytes per second.
 	Rate float64
+	// Before is the throughput of the window before the step this change is
+	// taking back. It is zero for a change that grows the spread, which has no
+	// earlier step to compare against.
+	Before float64
 }
 
+// Shrinks reports whether this change narrows the spread rather than widening
+// it. The two are logged differently and counted separately, because "easySFTP
+// asked for more connections" and "easySFTP stopped using some of the ones it
+// has" are different events on a server.
+func (c Change) Shrinks() bool { return c.To.Connections < c.From.Connections }
+
 func (c Change) String() string {
+	if c.Shrinks() {
+		return fmt.Sprintf("%s is no better than the %s before the spread grew to %d; assigning the remaining files across %d connection(s) instead, without closing any",
+			rateString(c.Rate), rateString(c.Before), c.From.Connections, c.To.Connections)
+	}
 	return fmt.Sprintf("%s over the connections in use; raising connections %d -> %d for the rest of this deployment",
 		rateString(c.Rate), c.From.Connections, c.To.Connections)
 }
@@ -159,12 +201,8 @@ func (c *Controller) Observe(p Progress) (Change, bool) {
 	case p.Failures > 0:
 		c.stop("the transfer is retrying, so this is not the moment to add load")
 		return none, false
-	case p.Remaining <= c.current.Connections:
-		// Fewer files left than connections open: a new one would finish its
-		// handshake with nothing to carry.
-		return none, false
 	}
-	if p.Elapsed < minObservation || p.Uploaded+p.Skipped < minSamples {
+	if !c.eligible(p) {
 		return none, false
 	}
 
@@ -178,14 +216,21 @@ func (c *Controller) Observe(p Progress) (Change, bool) {
 	}
 
 	// Did the previous growth pay for itself? Checked before planning the
-	// next one, so a pool that stopped scaling stops growing.
+	// next one, so a pool that stopped scaling stops growing, and answered by
+	// putting the spread back where it came from rather than by living with
+	// it (issue #215, stage 5).
 	if c.pendingRate > 0 {
 		if rate < c.pendingRate*improvementBand {
-			c.stop(fmt.Sprintf("%s is no faster than the %s before the last connection was added, so the pool stays at %d",
-				rateString(rate), rateString(c.pendingRate), c.current.Connections))
-			return none, false
+			return c.reject(rate), true
 		}
-		c.pendingRate = 0
+		c.pendingRate, c.pendingFrom = 0, 0
+	}
+
+	if p.Remaining <= c.current.Connections {
+		// Fewer files left than connections in use: a new one would finish its
+		// handshake with nothing to carry. Checked after the validation above,
+		// so a step that has already been taken is still judged.
+		return none, false
 	}
 
 	want := Plan(c.remaining(p), c.measuredLink(p, rate), c.fixed)
@@ -194,13 +239,52 @@ func (c *Controller) Observe(p Progress) (Change, bool) {
 		return none, false
 	}
 	change := Change{From: c.current, To: c.current, Rate: rate}
-	c.pendingRate = rate
+	c.pendingRate, c.pendingFrom = rate, c.current.Connections
 	c.current.Connections = grown
 	change.To = c.current
 	if c.current.Connections >= MaxConnections {
 		c.stop("the pool reached the policy maximum")
 	}
 	return change, true
+}
+
+// eligible reports whether this report closes a window worth deciding on: long
+// enough, over enough finished files, and carrying enough bytes that the number
+// is a throughput rather than one file's latency.
+//
+// A report that fails any of the three is not an observation at all: it does
+// not replace the baseline, so the window keeps widening until it is evidence.
+// That is the difference between "measure every 250 ms and hope" and "decide
+// when there is something to decide on" (issue #215, stage 6).
+func (c *Controller) eligible(p Progress) bool {
+	window, files, bytes := p.Elapsed, p.Uploaded+p.Skipped, p.UploadedBytes
+	if c.haveLast {
+		window -= c.last.Elapsed
+		files -= c.last.Uploaded + c.last.Skipped
+		bytes -= c.last.UploadedBytes
+	}
+	if window < minObservation || files < minSamples {
+		return false
+	}
+	// A phase that is moving no bytes at all (a redeploy skipping everything)
+	// is judged on its files: it is never going to reach a byte threshold, and
+	// the throughput check below leaves it alone anyway.
+	return bytes == 0 || bytes >= minWindowBytes
+}
+
+// reject takes back the growth step the previous window motivated. The
+// connections opened for it stay open and every transfer running on them runs
+// to the end; what changes is where the files that are *left* go. Then the
+// controller settles: one step back is a correction, and a second one would be
+// the start of an oscillation.
+func (c *Controller) reject(rate float64) Change {
+	change := Change{From: c.current, To: c.current, Rate: rate, Before: c.pendingRate}
+	c.current.Connections = c.pendingFrom
+	change.To = c.current
+	c.pendingRate, c.pendingFrom = 0, 0
+	c.stop(fmt.Sprintf("%s did not improve on the %s measured before the last connection was added, so the remaining files go over %d connection(s)",
+		rateString(rate), rateString(change.Before), c.current.Connections))
+	return change
 }
 
 // throughput is the aggregate bytes per second of the window since the last
@@ -227,6 +311,7 @@ func (c *Controller) measuredLink(p Progress, rate float64) Link {
 	streams := min(c.current.Connections, c.current.Concurrency, p.Uploaded+p.Remaining)
 	l := c.link
 	l.StreamBytesPerSecond = rate / float64(max(streams, 1))
+	l.ThroughputSource = SourceRuntime // the transfer being tuned, which outranks everything else
 	return l
 }
 

--- a/internal/autotune/controller.go
+++ b/internal/autotune/controller.go
@@ -27,6 +27,10 @@ import (
 //     could only widen a pool it had widened too far, and the stored 'small'
 //     sweep is what that costs: 4 connections widened to 8 on one thin
 //     window, on a workload whose measured optimum was 2.
+//   - What counts as evidence is narrower than "a number arrived". A window has
+//     to be long enough, see enough files and carry enough bytes, and a byte
+//     rate is only read as a bandwidth when the files were large enough to
+//     produce one (issue #215, stage 6, and see bandwidthBound).
 //   - Concurrency never moves. Plan already sizes it to the number of
 //     independent items, which is the largest value that can ever be busy;
 //     there is nothing for a hill climb to find.
@@ -109,6 +113,12 @@ type Controller struct {
 	link    Link
 	current Settings
 
+	// workload is the shape of the transfer being watched. Only its
+	// distribution is read: what the observed byte rate is evidence *of*
+	// depends on whether the files are big enough for a byte rate to mean
+	// anything. See bandwidthBound.
+	workload Workload
+
 	// stopped latches once there is nothing left to try.
 	stopped bool
 	reason  string
@@ -129,10 +139,11 @@ type Controller struct {
 }
 
 // NewController returns the controller for a deployment that Plan resolved to
-// start. It reports nothing to change while every setting it could move is
-// pinned by the user or already at its ceiling.
-func NewController(start Settings, l Link, f Fixed) *Controller {
-	c := &Controller{fixed: f, link: l, current: start}
+// start, watching the workload it was resolved for. It reports nothing to
+// change while every setting it could move is pinned by the user or already at
+// its ceiling.
+func NewController(w Workload, start Settings, l Link, f Fixed) *Controller {
+	c := &Controller{fixed: f, link: l, current: start, workload: w}
 	switch {
 	case f.Connections > 0:
 		c.stop("connections come from the configuration")
@@ -224,6 +235,15 @@ func (c *Controller) Observe(p Progress) (Change, bool) {
 			return c.reject(rate), true
 		}
 		c.pendingRate, c.pendingFrom = 0, 0
+		if c.current.Connections >= MaxConnections {
+			// The step that reached the ceiling paid for itself, so there is
+			// nothing left to grow into and nothing left to take back. This is
+			// checked *here* rather than when the step was taken: a controller
+			// that latched at the maximum could never judge the step that got
+			// it there, which is exactly the step most worth judging.
+			c.stop("the pool reached the policy maximum")
+			return none, false
+		}
 	}
 
 	if p.Remaining <= c.current.Connections {
@@ -242,9 +262,6 @@ func (c *Controller) Observe(p Progress) (Change, bool) {
 	c.pendingRate, c.pendingFrom = rate, c.current.Connections
 	c.current.Connections = grown
 	change.To = c.current
-	if c.current.Connections >= MaxConnections {
-		c.stop("the pool reached the policy maximum")
-	}
 	return change, true
 }
 
@@ -307,12 +324,50 @@ func (c *Controller) throughput(p Progress) float64 {
 // really carrying. The aggregate is divided by the streams that were actually
 // serving files, not by the pool size: a pool whose tail no worker reached
 // would make every connection look slower than it is.
+//
+// For a workload that cannot fill a stream the prior stays, because the
+// measurement is not one. See bandwidthBound.
 func (c *Controller) measuredLink(p Progress, rate float64) Link {
-	streams := min(c.current.Connections, c.current.Concurrency, p.Uploaded+p.Remaining)
 	l := c.link
+	if !c.bandwidthBound() {
+		return l
+	}
+	streams := min(c.current.Connections, c.current.Concurrency, p.Uploaded+p.Remaining)
 	l.StreamBytesPerSecond = rate / float64(max(streams, 1))
 	l.ThroughputSource = SourceRuntime // the transfer being tuned, which outranks everything else
 	return l
+}
+
+// bandwidthBound reports whether this transfer's byte rate says anything about
+// the link's bandwidth.
+//
+// A deployment of files that each fit in a single 32 KiB write packet never
+// fills a stream: what limits it is four round-trips per file, not bytes per
+// second, and its megabytes-per-second reading is a restatement of its
+// files-per-second reading. Feeding that number back in as a bandwidth makes
+// the link look catastrophically slow, which makes the remaining work look
+// enormous, which buys connections that cannot help. That is the stored 'small'
+// miss: 300 files of 4 KiB, widened from four connections to eight, measured
+// fastest at two.
+//
+// The round-trip half of the model does not need a runtime correction, because
+// nothing about it was guessed: the RTT was measured before the first file and
+// the file count is known. So for these workloads the pre-transfer plan already
+// had every input it was going to get, and the controller's job is only to
+// re-plan the work that is *left* (which is what an unsettled skip_unchanged
+// set still needs).
+//
+// The ninetieth percentile is the test rather than the mean or the largest
+// file, so a tree of small files with a few archives in it, where the bytes
+// really do come from files that can fill a stream, still gets a runtime
+// correction.
+func (c *Controller) bandwidthBound() bool {
+	size := c.workload.P90Upload
+	if size == 0 {
+		// A workload with no distribution: the largest file is all there is.
+		size = c.workload.LargestUpload
+	}
+	return size > packetBytes
 }
 
 // remaining is the workload the run still has in front of it. For a settled
@@ -336,7 +391,17 @@ func (c *Controller) remaining(p Progress) Workload {
 	if uploads > 0 {
 		largest = bytes / int64(uploads)
 	}
-	return Workload{Uploads: uploads, UploadBytes: bytes, LargestUpload: largest, Probes: probes}
+	// The shape carries over from the plan: which files are left is not known,
+	// but nothing observed so far suggests they are shaped differently from
+	// the ones that were planned.
+	return Workload{
+		Uploads:       uploads,
+		UploadBytes:   bytes,
+		LargestUpload: largest,
+		P50Upload:     c.workload.P50Upload,
+		P90Upload:     c.workload.P90Upload,
+		Probes:        probes,
+	}
 }
 
 func rateString(bytesPerSecond float64) string {

--- a/internal/autotune/controller_test.go
+++ b/internal/autotune/controller_test.go
@@ -13,12 +13,21 @@ import (
 // and enough workers for the files it has.
 var start = autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16}
 
+// byteHeavy is the workload behind that configuration: a thousand files of a
+// megabyte each. The size matters as much as the count, because a byte rate is
+// only evidence about a link when the files are big enough to fill a stream
+// (see the controller's bandwidthBound).
+var byteHeavy = autotune.Workload{
+	Uploads: 1000, UploadBytes: 1000 * MiB,
+	LargestUpload: MiB, P50Upload: MiB, P90Upload: MiB,
+}
+
 // TestControllerGrowsOnMeasuredThroughputThenStops is the whole of stage 3 in
 // one run: the transfer turns out to be far slower per stream than the prior
 // assumed, so the pool grows; it grows one doubling at a time; and the moment
 // a step stops paying for itself the controller settles instead of climbing on.
 func TestControllerGrowsOnMeasuredThroughputThenStops(t *testing.T) {
-	c := autotune.NewController(start, house, autotune.Fixed{})
+	c := autotune.NewController(byteHeavy, start, house, autotune.Fixed{})
 	if stopped, why := c.Stopped(); stopped {
 		t.Fatalf("a fresh controller with room to grow reported stopped: %s", why)
 	}
@@ -85,7 +94,7 @@ func TestControllerGrowsOnMeasuredThroughputThenStops(t *testing.T) {
 // handshake would pay for itself, and a redeploy whose files are all skipped.
 func TestControllerLeavesShortAndMetadataOnlyPhasesAlone(t *testing.T) {
 	t.Run("too early to say anything", func(t *testing.T) {
-		c := autotune.NewController(start, house, autotune.Fixed{})
+		c := autotune.NewController(byteHeavy, start, house, autotune.Fixed{})
 		if _, ok := c.Observe(autotune.Progress{
 			Elapsed: 100 * time.Millisecond, Uploaded: 1, Remaining: 999,
 			RemainingBytes: 999 * MiB, UploadedBytes: MiB,
@@ -95,7 +104,7 @@ func TestControllerLeavesShortAndMetadataOnlyPhasesAlone(t *testing.T) {
 	})
 
 	t.Run("a redeploy that skips everything", func(t *testing.T) {
-		c := autotune.NewController(autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16}, house, autotune.Fixed{})
+		c := autotune.NewController(byteHeavy, autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16}, house, autotune.Fixed{})
 		for i := 1; i <= 5; i++ {
 			p := autotune.Progress{
 				Elapsed:   time.Duration(i) * time.Second,
@@ -112,7 +121,7 @@ func TestControllerLeavesShortAndMetadataOnlyPhasesAlone(t *testing.T) {
 	})
 
 	t.Run("fewer files left than connections", func(t *testing.T) {
-		c := autotune.NewController(autotune.Settings{Connections: 4, Concurrency: 64, RequestConcurrency: 16}, house, autotune.Fixed{})
+		c := autotune.NewController(byteHeavy, autotune.Settings{Connections: 4, Concurrency: 64, RequestConcurrency: 16}, house, autotune.Fixed{})
 		if _, ok := c.Observe(autotune.Progress{
 			Elapsed: 5 * time.Second, Uploaded: 996, Remaining: 4,
 			RemainingBytes: 4 * MiB, UploadedBytes: 996 * MiB,
@@ -135,7 +144,7 @@ func TestControllerStandsDownWhenTheServerPushesBack(t *testing.T) {
 		{"a retrying transfer", autotune.Progress{Failures: 1}, "retrying"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := autotune.NewController(start, house, autotune.Fixed{})
+			c := autotune.NewController(byteHeavy, start, house, autotune.Fixed{})
 			p := tc.p
 			p.Elapsed, p.Uploaded, p.Remaining = 2*time.Second, 100, 900
 			p.RemainingBytes, p.UploadedBytes = 900*MiB, 100*MiB
@@ -154,7 +163,7 @@ func TestControllerStandsDownWhenTheServerPushesBack(t *testing.T) {
 // pinned there is nothing the runtime half is allowed to do, and it must not
 // even start.
 func TestControllerNeverOverridesTheConfiguration(t *testing.T) {
-	c := autotune.NewController(autotune.Settings{Connections: 2, Concurrency: 64, RequestConcurrency: 16},
+	c := autotune.NewController(byteHeavy, autotune.Settings{Connections: 2, Concurrency: 64, RequestConcurrency: 16},
 		house, autotune.Fixed{Connections: 2})
 	stopped, why := c.Stopped()
 	if !stopped || !strings.Contains(why, "configuration") {
@@ -171,7 +180,7 @@ func TestControllerNeverOverridesTheConfiguration(t *testing.T) {
 // TestControllerStopsAtTheCeiling: once the pool is as wide as the policy
 // allows there is nothing left to decide, and the loop should not keep asking.
 func TestControllerStopsAtTheCeiling(t *testing.T) {
-	c := autotune.NewController(autotune.Settings{Connections: autotune.MaxConnections, Concurrency: 64}, house, autotune.Fixed{})
+	c := autotune.NewController(byteHeavy, autotune.Settings{Connections: autotune.MaxConnections, Concurrency: 64}, house, autotune.Fixed{})
 	if stopped, why := c.Stopped(); !stopped || !strings.Contains(why, "maximum") {
 		t.Errorf("stopped=%v reason=%q, want a stop at the ceiling", stopped, why)
 	}
@@ -182,7 +191,7 @@ func TestControllerStopsAtTheCeiling(t *testing.T) {
 // and only the ratio of real uploads to skips, observed while it runs, says
 // whether it is a metadata sweep or a full deploy in disguise.
 func TestControllerExtrapolatesAnUnsettledUploadSet(t *testing.T) {
-	c := autotune.NewController(start, house, autotune.Fixed{})
+	c := autotune.NewController(byteHeavy, start, house, autotune.Fixed{})
 	// Half of the first 200 files turned out to be changed, at about 4 MiB/s
 	// on the one stream: the 800 that are left are another 400 uploads.
 	change, ok := c.Observe(autotune.Progress{
@@ -200,7 +209,7 @@ func TestControllerExtrapolatesAnUnsettledUploadSet(t *testing.T) {
 // "enough files" while saying nothing at all about throughput. A window has to
 // carry real bytes before it may size a pool.
 func TestControllerNeedsBytesBeforeItDecides(t *testing.T) {
-	c := autotune.NewController(start, house, autotune.Fixed{})
+	c := autotune.NewController(byteHeavy, start, house, autotune.Fixed{})
 
 	// 4 KiB files, one second in: long enough, four files, 16 KiB moved.
 	if _, ok := c.Observe(autotune.Progress{
@@ -233,7 +242,7 @@ func TestControllerNeedsBytesBeforeItDecides(t *testing.T) {
 // correction, taking a second would be the start of an oscillation. Whatever
 // arrives after the reversal, the spread stays where the reversal put it.
 func TestControllerSettlesAfterASingleStepBack(t *testing.T) {
-	c := autotune.NewController(start, house, autotune.Fixed{})
+	c := autotune.NewController(byteHeavy, start, house, autotune.Fixed{})
 
 	if _, ok := c.Observe(autotune.Progress{
 		Elapsed: time.Second, Uploaded: 10, Remaining: 990,
@@ -266,7 +275,7 @@ func TestControllerSettlesAfterASingleStepBack(t *testing.T) {
 // noticing that the last step it took was a mistake, or a pool that grew on the
 // second-to-last window would never be corrected.
 func TestControllerJudgesAStepEvenAtTheEndOfAPhase(t *testing.T) {
-	c := autotune.NewController(start, house, autotune.Fixed{})
+	c := autotune.NewController(byteHeavy, start, house, autotune.Fixed{})
 	if _, ok := c.Observe(autotune.Progress{
 		Elapsed: time.Second, Uploaded: 10, Remaining: 990,
 		RemainingBytes: 990 * MiB, UploadedBytes: 10 * MiB,
@@ -279,5 +288,94 @@ func TestControllerJudgesAStepEvenAtTheEndOfAPhase(t *testing.T) {
 	})
 	if !ok || !back.Shrinks() {
 		t.Errorf("a phase running out of files must still take back a step that did not pay: %+v (changed: %v)", back, ok)
+	}
+}
+
+// TestTheStepThatReachesTheCeilingIsStillJudged: the pool's maximum used to
+// latch the controller the moment a step reached it, so the one step that could
+// no longer be undone was also the one step nobody checked. That is the shape
+// of the stored 'small' miss, which widened from four connections to eight and
+// stayed there.
+func TestTheStepThatReachesTheCeilingIsStillJudged(t *testing.T) {
+	near := autotune.Settings{Connections: autotune.MaxConnections / 2, Concurrency: 64, RequestConcurrency: 16}
+	c := autotune.NewController(byteHeavy, near, house, autotune.Fixed{})
+
+	up, ok := c.Observe(autotune.Progress{
+		Elapsed: time.Second, Uploaded: 10, Remaining: 990,
+		RemainingBytes: 990 * MiB, UploadedBytes: 10 * MiB,
+	})
+	if !ok || up.To.Connections != autotune.MaxConnections {
+		t.Fatalf("step = %+v (changed: %v), want a doubling to the ceiling", up, ok)
+	}
+	if stopped, why := c.Stopped(); stopped {
+		t.Fatalf("reaching the ceiling must not stop the controller before it judged the step: %s", why)
+	}
+
+	back, ok := c.Observe(autotune.Progress{
+		Elapsed: 2 * time.Second, Uploaded: 18, Remaining: 982,
+		RemainingBytes: 982 * MiB, UploadedBytes: 18 * MiB,
+	})
+	if !ok || !back.Shrinks() || back.To.Connections != near.Connections {
+		t.Fatalf("step back = %+v (changed: %v), want the spread returned to %d", back, ok, near.Connections)
+	}
+
+	// And when the step does pay for itself, the controller settles at the
+	// ceiling instead of observing forever.
+	c = autotune.NewController(byteHeavy, near, house, autotune.Fixed{})
+	c.Observe(autotune.Progress{
+		Elapsed: time.Second, Uploaded: 10, Remaining: 990,
+		RemainingBytes: 990 * MiB, UploadedBytes: 10 * MiB,
+	})
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: 2 * time.Second, Uploaded: 60, Remaining: 940,
+		RemainingBytes: 940 * MiB, UploadedBytes: 60 * MiB,
+	}); ok {
+		t.Error("there is nothing above the ceiling to change to")
+	}
+	stopped, why := c.Stopped()
+	if !stopped || !strings.Contains(why, "policy maximum") {
+		t.Errorf("a validated step to the ceiling must settle there, got stopped=%v (%s)", stopped, why)
+	}
+}
+
+// TestAByteRateIsOnlyEvidenceWhenTheFilesCanFillAStream is the stored 'small'
+// miss stated as a rule. 300 files of 4 KiB are limited by four round-trips
+// each, not by bandwidth, so their megabytes-per-second is a restatement of
+// their files-per-second. Read as a bandwidth it makes the link look dead, the
+// work that is left look enormous, and buys connections that measured slower
+// than the two the sweep preferred.
+func TestAByteRateIsOnlyEvidenceWhenTheFilesCanFillAStream(t *testing.T) {
+	tiny := autotune.Workload{
+		Uploads: 300, UploadBytes: 300 * 4 * KiB,
+		LargestUpload: 4 * KiB, P50Upload: 4 * KiB, P90Upload: 4 * KiB,
+	}
+	c := autotune.NewController(tiny, autotune.Settings{Connections: 4, Concurrency: 64, RequestConcurrency: 16},
+		house, autotune.Fixed{})
+
+	// A window that satisfies every eligibility rule and reads as 0.7 MiB/s
+	// over four connections. The old model divided that by the streams,
+	// concluded each was carrying 180 KiB/s, and asked for more of them.
+	if change, ok := c.Observe(autotune.Progress{
+		Elapsed: 2 * time.Second, Uploaded: 150, Remaining: 150,
+		RemainingBytes: 150 * 4 * KiB, UploadedBytes: MiB + MiB/2,
+	}); ok {
+		t.Errorf("a tree of one-packet files must not buy connections with its byte rate: %+v", change)
+	}
+	if c.Settings().Connections != 4 {
+		t.Errorf("connections = %d, want the pre-transfer choice left alone", c.Settings().Connections)
+	}
+
+	// The same numbers where the bytes really do come from files that can fill
+	// a stream: now the measurement means what it says and the pool grows.
+	fat := tiny
+	fat.LargestUpload, fat.P50Upload, fat.P90Upload = 8*MiB, 4*MiB, 8*MiB
+	fat.UploadBytes = 300 * 4 * MiB
+	c = autotune.NewController(fat, autotune.Settings{Connections: 4, Concurrency: 64, RequestConcurrency: 16},
+		house, autotune.Fixed{})
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: 2 * time.Second, Uploaded: 150, Remaining: 150,
+		RemainingBytes: 150 * 4 * MiB, UploadedBytes: MiB + MiB/2,
+	}); !ok {
+		t.Error("600 MiB left over a link measured this slow is worth another connection")
 	}
 }

--- a/internal/autotune/controller_test.go
+++ b/internal/autotune/controller_test.go
@@ -51,22 +51,32 @@ func TestControllerGrowsOnMeasuredThroughputThenStops(t *testing.T) {
 	}
 
 	// This window is slower than the one before the growth, so the pool has
-	// stopped scaling and the controller stops with it.
-	if _, ok := c.Observe(autotune.Progress{
+	// stopped scaling. The step is taken back rather than merely stopped at:
+	// the four connections stay open and the files that are left go over the
+	// two that were carrying them before (issue #215, stage 5).
+	back, ok := c.Observe(autotune.Progress{
 		Elapsed: 3 * time.Second, Uploaded: 45, Remaining: 955,
 		RemainingBytes: 955 * MiB, UploadedBytes: 45 * MiB,
-	}); ok {
-		t.Fatal("a step that did not pay off must not be followed by another")
+	})
+	if !ok {
+		t.Fatal("a step that did not pay off must be taken back")
+	}
+	if !back.Shrinks() || back.From.Connections != 4 || back.To.Connections != 2 {
+		t.Fatalf("step back went %d -> %d (shrinks: %v), want the spread returned to 2",
+			back.From.Connections, back.To.Connections, back.Shrinks())
+	}
+	if !strings.Contains(back.String(), "without closing any") {
+		t.Errorf("a step back must say the connections stay open: %s", back)
 	}
 	stopped, why := c.Stopped()
 	if !stopped {
 		t.Fatal("the controller must settle once growing stops helping")
 	}
-	if !strings.Contains(why, "no faster") {
+	if !strings.Contains(why, "did not improve") {
 		t.Errorf("the reason should say the measurement did not improve, got %q", why)
 	}
-	if c.Settings().Connections != 4 {
-		t.Errorf("settled at %d connections, want the last accepted 4", c.Settings().Connections)
+	if c.Settings().Connections != 2 {
+		t.Errorf("settled at %d connections, want the spread back at 2", c.Settings().Connections)
 	}
 }
 
@@ -181,5 +191,93 @@ func TestControllerExtrapolatesAnUnsettledUploadSet(t *testing.T) {
 	})
 	if !ok || change.To.Connections <= change.From.Connections {
 		t.Fatalf("a redeploy that is really uploading must widen the pool, got %+v (changed: %v)", change, ok)
+	}
+}
+
+// TestControllerNeedsBytesBeforeItDecides is stage 6 of issue #215. The window
+// that grew the stored 'small' sweep from four connections to eight was
+// 250 ms long and carried a few dozen kilobytes: it satisfied "enough time" and
+// "enough files" while saying nothing at all about throughput. A window has to
+// carry real bytes before it may size a pool.
+func TestControllerNeedsBytesBeforeItDecides(t *testing.T) {
+	c := autotune.NewController(start, house, autotune.Fixed{})
+
+	// 4 KiB files, one second in: long enough, four files, 16 KiB moved.
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: time.Second, Uploaded: 4, Remaining: 296,
+		RemainingBytes: 296 * 4 * KiB, UploadedBytes: 4 * 4 * KiB,
+	}); ok {
+		t.Fatal("16 KiB is not a throughput measurement, whatever the clock says")
+	}
+
+	// A window that never becomes evidence must not become the baseline
+	// either: the next report is still measured from the start of the phase,
+	// so the evidence accumulates instead of being reset every tick.
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: 2 * time.Second, Uploaded: 8, Remaining: 292,
+		RemainingBytes: 292 * 4 * KiB, UploadedBytes: 8 * 4 * KiB,
+	}); ok {
+		t.Fatal("two thin windows in a row are not one thick one")
+	}
+
+	// The same phase once it has really moved something.
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: 3 * time.Second, Uploaded: 200, Remaining: 800,
+		RemainingBytes: 800 * MiB, UploadedBytes: 8 * MiB,
+	}); !ok {
+		t.Error("a window carrying megabytes over three seconds is a measurement")
+	}
+}
+
+// TestControllerSettlesAfterASingleStepBack: taking one step back is a
+// correction, taking a second would be the start of an oscillation. Whatever
+// arrives after the reversal, the spread stays where the reversal put it.
+func TestControllerSettlesAfterASingleStepBack(t *testing.T) {
+	c := autotune.NewController(start, house, autotune.Fixed{})
+
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: time.Second, Uploaded: 10, Remaining: 990,
+		RemainingBytes: 990 * MiB, UploadedBytes: 10 * MiB,
+	}); !ok {
+		t.Fatal("a stream measured far slower than the prior must widen the pool")
+	}
+	back, ok := c.Observe(autotune.Progress{
+		Elapsed: 2 * time.Second, Uploaded: 18, Remaining: 982,
+		RemainingBytes: 982 * MiB, UploadedBytes: 18 * MiB,
+	})
+	if !ok || !back.Shrinks() || back.To.Connections != 1 {
+		t.Fatalf("a step that bought nothing must go back to 1, got %+v (changed: %v)", back, ok)
+	}
+	for i := range 3 {
+		if _, ok := c.Observe(autotune.Progress{
+			Elapsed: time.Duration(3+i) * time.Second, Uploaded: 100 * (i + 1), Remaining: 900 - 100*i,
+			RemainingBytes: int64(900-100*i) * MiB, UploadedBytes: int64(100*(i+1)) * MiB,
+		}); ok {
+			t.Fatalf("the controller moved again after settling (observation %d)", i)
+		}
+	}
+	if c.Settings().Connections != 1 {
+		t.Errorf("settled at %d connections, want the spread left where the step back put it", c.Settings().Connections)
+	}
+}
+
+// TestControllerJudgesAStepEvenAtTheEndOfAPhase: "fewer files left than
+// connections" stops the controller opening more, but it must not stop it
+// noticing that the last step it took was a mistake, or a pool that grew on the
+// second-to-last window would never be corrected.
+func TestControllerJudgesAStepEvenAtTheEndOfAPhase(t *testing.T) {
+	c := autotune.NewController(start, house, autotune.Fixed{})
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: time.Second, Uploaded: 10, Remaining: 990,
+		RemainingBytes: 990 * MiB, UploadedBytes: 10 * MiB,
+	}); !ok {
+		t.Fatal("the pool must widen first for there to be anything to judge")
+	}
+	back, ok := c.Observe(autotune.Progress{
+		Elapsed: 2 * time.Second, Uploaded: 999, Remaining: 1,
+		RemainingBytes: MiB, UploadedBytes: 20 * MiB,
+	})
+	if !ok || !back.Shrinks() {
+		t.Errorf("a phase running out of files must still take back a step that did not pay: %+v (changed: %v)", back, ok)
 	}
 }

--- a/internal/autotune/regret_test.go
+++ b/internal/autotune/regret_test.go
@@ -140,26 +140,38 @@ func workloadOf(name string) (autotune.Workload, error) {
 	}
 	shape := scenario.ShapeOf(name)
 
-	var files int
-	var bytes, largest int64
+	// The sizes the payload really has, in the order a scan would produce
+	// them, so the distribution features of the workload (issue #215, stage 1)
+	// are the ones a run would compute rather than a summary of a summary.
+	var sizes []int64
 	for _, g := range groups {
-		files += g.Count
-		bytes += int64(g.Count) * int64(g.KiB) * KiB
-		largest = max(largest, int64(g.KiB)*KiB)
+		for range g.Count {
+			sizes = append(sizes, int64(g.KiB)*KiB)
+		}
 	}
+	files := len(sizes)
 
 	switch {
 	case shape.Prepopulate && shape.Mode == "sync":
+		// A sync knows what changed before it uploads: the manifest already
+		// told it. The harness changes the first ChangedFiles files of the
+		// tree, which is what those sizes describe.
 		changed := min(scenario.ChangedFiles, files)
-		return autotune.Workload{
-			Uploads:       changed,
-			UploadBytes:   bytes / int64(max(files, 1)) * int64(changed),
-			LargestUpload: largest,
-		}, nil
+		return autotune.SummarizeUploads(sizes[:changed]), nil
 	case shape.Prepopulate:
-		return autotune.Workload{Probes: files, LargestUpload: largest, Unknown: true}, nil
+		// An overlay redeploy with skip_unchanged has not decided anything
+		// yet: every file costs a stat and only some are then sent.
+		w := autotune.SummarizeUploads(sizes)
+		return autotune.Workload{
+			Probes:        files,
+			Unknown:       true,
+			LargestUpload: w.LargestUpload,
+			P50Upload:     w.P50Upload,
+			P90Upload:     w.P90Upload,
+			SmallUploads:  w.SmallUploads,
+		}, nil
 	default:
-		return autotune.Workload{Uploads: files, UploadBytes: bytes, LargestUpload: largest}, nil
+		return autotune.SummarizeUploads(sizes), nil
 	}
 }
 

--- a/internal/autotune/workload_test.go
+++ b/internal/autotune/workload_test.go
@@ -171,6 +171,15 @@ func TestBDPDrivesRequestConcurrencyOnlyOnceMeasured(t *testing.T) {
 		t.Errorf("a measured narrow path should fall back to the floor, got %d", got)
 	}
 
+	// A LAN: enormous bandwidth, but a fifth of a millisecond of delay holds
+	// almost nothing in flight. Bandwidth alone is not the argument for
+	// pipelining; bandwidth times delay is.
+	lan := autotune.Link{RTT: 200 * time.Microsecond, Handshake: 20 * time.Millisecond,
+		StreamBytesPerSecond: 100 * MiB, ThroughputSource: autotune.SourceRuntime}
+	if got := autotune.Plan(w, lan, autotune.Fixed{}).RequestConcurrency; got != autotune.MinRequestConcurrency {
+		t.Errorf("a fast link with no delay needs no deep pipeline, got %d", got)
+	}
+
 	// And whatever the link says, a file that is one packet long cannot use a
 	// second request.
 	tiny := autotune.Workload{Uploads: 500, UploadBytes: 2 * MiB, LargestUpload: 4 * KiB, P90Upload: 4 * KiB}

--- a/internal/autotune/workload_test.go
+++ b/internal/autotune/workload_test.go
@@ -1,0 +1,213 @@
+package autotune_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
+)
+
+// TestSummarizeUploadsSeparatesShapesWithEqualTotals is the distinction stage 1
+// of issue #215 exists for. Two deployments can carry the same number of bytes
+// in the same number of files, with the same largest file, and still be
+// completely different work: the policy has to be able to see that.
+func TestSummarizeUploadsSeparatesShapesWithEqualTotals(t *testing.T) {
+	// A: 99 medium files and one archive.
+	a := make([]int64, 0, 100)
+	for range 99 {
+		a = append(a, 320*KiB)
+	}
+	a = append(a, 4*MiB)
+
+	// B: the same 100 files carrying the same total, as a heap of tiny ones
+	// with a handful of archives among them.
+	b := make([]int64, 0, 100)
+	for range 90 {
+		b = append(b, 4*KiB)
+	}
+	for range 8 {
+		b = append(b, 4*MiB)
+	}
+	b = append(b, 1324*KiB, 1324*KiB)
+
+	ws, wb := autotune.SummarizeUploads(a), autotune.SummarizeUploads(b)
+	if ws.Uploads != wb.Uploads || ws.UploadBytes != wb.UploadBytes || ws.LargestUpload != wb.LargestUpload {
+		t.Fatalf("the two shapes were meant to agree on everything the old model saw:\n A %+v\n B %+v", ws, wb)
+	}
+	if ws.SmallUploads != 0 {
+		t.Errorf("no file in A fits in one write packet, got SmallUploads=%d", ws.SmallUploads)
+	}
+	if wb.SmallUploads != 90 {
+		t.Errorf("90 files in B fit in one write packet, got SmallUploads=%d", wb.SmallUploads)
+	}
+	if ws.P50Upload <= wb.P50Upload {
+		t.Errorf("A's median (%d) must be above B's (%d): A has no tiny files at all", ws.P50Upload, wb.P50Upload)
+	}
+	if ws.P90Upload <= wb.P90Upload {
+		t.Errorf("A's ninetieth percentile (%d) must be above B's (%d): nine files in ten of B are 4 KiB",
+			ws.P90Upload, wb.P90Upload)
+	}
+}
+
+// TestSummarizeUploadsIsNearestRank pins the percentile definition, because
+// every reader of P50Upload and P90Upload is a threshold comparison and an
+// off-by-one bucket is exactly the kind of thing that only shows up as a
+// mysterious two percent in a sweep.
+func TestSummarizeUploadsIsNearestRank(t *testing.T) {
+	var sizes []int64
+	for range 40 {
+		sizes = append(sizes, 16*KiB)
+	}
+	for range 12 {
+		sizes = append(sizes, 256*KiB)
+	}
+	for range 4 {
+		sizes = append(sizes, 2*MiB)
+	}
+	w := autotune.SummarizeUploads(sizes)
+
+	switch {
+	case w.Uploads != 56:
+		t.Errorf("files = %d, want 56", w.Uploads)
+	case w.UploadBytes != 40*16*KiB+12*256*KiB+4*2*MiB:
+		t.Errorf("bytes = %d", w.UploadBytes)
+	case w.LargestUpload != 2*MiB:
+		t.Errorf("largest = %d, want 2 MiB", w.LargestUpload)
+	case w.P50Upload != 16*KiB:
+		t.Errorf("p50 = %d, want 16 KiB: the 28th of 56 files", w.P50Upload)
+	case w.P90Upload != 256*KiB:
+		t.Errorf("p90 = %d, want 256 KiB: the 51st of 56 files", w.P90Upload)
+	case w.SmallUploads != 40:
+		t.Errorf("small = %d, want the 40 files that fit in one 32 KiB packet", w.SmallUploads)
+	}
+
+	if empty := autotune.SummarizeUploads(nil); empty != (autotune.Workload{}) {
+		t.Errorf("summarizing nothing produced %+v", empty)
+	}
+	if one := autotune.SummarizeUploads([]int64{7}); one.P50Upload != 7 || one.P90Upload != 7 {
+		t.Errorf("a single file is its own median and its own p90, got %+v", one)
+	}
+}
+
+// TestRequestConcurrencySeesTheDistribution is the 'mixed' miss of issue #215.
+// The scenario is 40 x 16 KiB + 12 x 256 KiB + 4 x 2 MiB: the memory budget
+// used to divide 56 workers into the in-flight ceiling as though all 56 of them
+// were the 2 MiB file, and the transfer ran with a request_concurrency of 18.
+// Only a tenth of them can be above the ninetieth percentile, which is what
+// makes the real bound far looser.
+func TestRequestConcurrencySeesTheDistribution(t *testing.T) {
+	var sizes []int64
+	for range 40 {
+		sizes = append(sizes, 16*KiB)
+	}
+	for range 12 {
+		sizes = append(sizes, 256*KiB)
+	}
+	for range 4 {
+		sizes = append(sizes, 2*MiB)
+	}
+	mixed := autotune.SummarizeUploads(sizes)
+
+	if got := autotune.Plan(mixed, house, autotune.Fixed{}).RequestConcurrency; got != 64 {
+		t.Errorf("request_concurrency = %d, want the 2 MiB files fully pipelined at 64: "+
+			"the stored 'mixed' sweep is 10%% faster at 4/56/64 than at 4/56/16", got)
+	}
+
+	// The same file count where every file really is large: now the budget is
+	// the real constraint and it still binds.
+	var heavy []int64
+	for range 56 {
+		heavy = append(heavy, 2*MiB)
+	}
+	if got := autotune.Plan(autotune.SummarizeUploads(heavy), house, autotune.Fixed{}).RequestConcurrency; got > 16 {
+		t.Errorf("request_concurrency = %d: 56 files that are all 2 MiB cannot all hold a full pipeline", got)
+	}
+}
+
+// TestRequestConcurrencyIsAPowerOfTwo: the value is a pipeline depth, not a
+// measurement. 18 invites a reader to believe the eight means something.
+func TestRequestConcurrencyIsAPowerOfTwo(t *testing.T) {
+	for _, w := range []autotune.Workload{
+		{Uploads: 56, UploadBytes: 12 * MiB, LargestUpload: 2 * MiB, P90Upload: 256 * KiB},
+		{Uploads: 300, UploadBytes: 300 * 4 * KiB, LargestUpload: 4 * KiB, P90Upload: 4 * KiB},
+		{Uploads: 7, UploadBytes: 70 * MiB, LargestUpload: 10 * MiB, P90Upload: 10 * MiB},
+	} {
+		got := autotune.Plan(w, house, autotune.Fixed{}).RequestConcurrency
+		if got&(got-1) != 0 {
+			t.Errorf("request_concurrency = %d for %+v, want a power of two", got, w)
+		}
+	}
+}
+
+// TestBDPDrivesRequestConcurrencyOnlyOnceMeasured is stage 3. The number of
+// bytes a stream has to keep in flight is bandwidth times delay, but bandwidth
+// is the one thing nothing can measure before the transfer starts. So a link
+// that has been measured gets a BDP-sized pipeline, and a link that has not
+// keeps the conservative pre-#215 answer.
+func TestBDPDrivesRequestConcurrencyOnlyOnceMeasured(t *testing.T) {
+	// One 8 MiB file, so nothing but the link can decide the answer.
+	w := autotune.Workload{Uploads: 4, UploadBytes: 32 * MiB, LargestUpload: 8 * MiB, P90Upload: 8 * MiB}
+
+	prior := autotune.Link{RTT: 100 * time.Millisecond, Handshake: 300 * time.Millisecond}
+	if got := autotune.Plan(w, prior, autotune.Fixed{}).RequestConcurrency; got != 64 {
+		t.Errorf("an unmeasured link must keep pipelining the file as far as it goes, got %d", got)
+	}
+
+	// A long fat path: 40 MiB/s over 100 ms is 4 MiB in flight per stream, so
+	// the file wants every packet the channel window has.
+	fat := prior
+	fat.StreamBytesPerSecond = 40 * MiB
+	fat.ThroughputSource = autotune.SourceCached
+	if got := autotune.Plan(w, fat, autotune.Fixed{}).RequestConcurrency; got != 64 {
+		t.Errorf("a measured long fat path must pipeline fully, got %d", got)
+	}
+
+	// A path measured as narrow: 300 KiB/s over 13 ms is four kilobytes in
+	// flight. Holding two megabytes of one file open for that buys nothing,
+	// and the policy floor is what stops it going lower still.
+	narrow := autotune.Link{RTT: 13 * time.Millisecond, Handshake: 300 * time.Millisecond,
+		StreamBytesPerSecond: 300 * KiB, ThroughputSource: autotune.SourceRuntime}
+	if got := autotune.Plan(w, narrow, autotune.Fixed{}).RequestConcurrency; got != autotune.MinRequestConcurrency {
+		t.Errorf("a measured narrow path should fall back to the floor, got %d", got)
+	}
+
+	// And whatever the link says, a file that is one packet long cannot use a
+	// second request.
+	tiny := autotune.Workload{Uploads: 500, UploadBytes: 2 * MiB, LargestUpload: 4 * KiB, P90Upload: 4 * KiB}
+	if got := autotune.Plan(tiny, fat, autotune.Fixed{}).RequestConcurrency; got != autotune.MinRequestConcurrency {
+		t.Errorf("4 KiB files cannot use a pipeline, got %d", got)
+	}
+}
+
+// TestLinkReportsWhereItsThroughputCameFrom: the hierarchy of evidence is part
+// of the policy, so it has to be readable rather than implied.
+func TestLinkReportsWhereItsThroughputCameFrom(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		link autotune.Link
+		want autotune.Source
+		text string
+	}{
+		{"nothing measured", house, autotune.SourcePrior, "assumed"},
+		{"a throughput with no provenance is this run's own", autotune.Link{StreamBytesPerSecond: 1 * MiB}, autotune.SourceRuntime, "measured"},
+		{"a cached one says so", autotune.Link{StreamBytesPerSecond: 1 * MiB, ThroughputSource: autotune.SourceCached}, autotune.SourceCached, "cached"},
+		{"a source without a number is still the prior", autotune.Link{ThroughputSource: autotune.SourceCached}, autotune.SourcePrior, "assumed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.link.Source(); got != tc.want {
+				t.Errorf("Source() = %v, want %v", got, tc.want)
+			}
+			if got := tc.link.Source().String(); got != tc.text {
+				t.Errorf("Source().String() = %q, want %q", got, tc.text)
+			}
+		})
+	}
+
+	l := autotune.Link{RTT: 100 * time.Millisecond, StreamBytesPerSecond: 10 * MiB}
+	if got := l.BDPBytes(); got != MiB {
+		t.Errorf("BDPBytes() = %d, want 1 MiB: 10 MiB/s for a tenth of a second", got)
+	}
+	if got := (autotune.Link{}).BDPBytes(); got <= 0 {
+		t.Errorf("an unmeasured link must still report a usable BDP, got %d", got)
+	}
+}

--- a/internal/benchmark/matrix.go
+++ b/internal/benchmark/matrix.go
@@ -325,6 +325,13 @@ func matrixAuto(runs []RunRecord, cells []schema.Cell) []schema.Auto {
 			InitialConcurrency:        stats.Median(counterValues(ms, "auto_initial_concurrency")),
 			InitialRequestConcurrency: stats.Median(counterValues(ms, "auto_initial_request_concurrency")),
 			Changes:                   stats.Median(counterValues(ms, "auto_changes")),
+
+			// And which way they went: a run that grew and then took the step
+			// back reports one of each and settles below its own high-water
+			// mark (issue #215).
+			SpreadIncreases:  stats.Median(counterValues(ms, "auto_spread_increases")),
+			SpreadDecreases:  stats.Median(counterValues(ms, "auto_spread_decreases")),
+			FinalConnections: stats.Median(counterValues(ms, "auto_final_connections")),
 		}
 		workload := autoWorkload(ms)
 
@@ -379,8 +386,14 @@ func autoWorkload(ms []*schema.Metrics) *schema.AutoWorkload {
 		Bytes:        stats.Median(counterValues(ms, "workload_bytes")),
 		LargestBytes: stats.Median(counterValues(ms, "workload_largest_bytes")),
 		Probes:       stats.Median(counterValues(ms, "workload_probes")),
+		P50Bytes:     stats.Median(counterValues(ms, "workload_p50_bytes")),
+		P90Bytes:     stats.Median(counterValues(ms, "workload_p90_bytes")),
+		SmallFiles:   stats.Median(counterValues(ms, "workload_small_files")),
 		RTTMS:        micros(stats.Median(counterValues(ms, "link_rtt_us"))),
 		HandshakeMS:  micros(stats.Median(counterValues(ms, "link_handshake_us"))),
+
+		StreamBytesPerSecond: stats.Median(counterValues(ms, "link_stream_bytes_per_second")),
+		BDPBytes:             stats.Median(counterValues(ms, "link_bdp_bytes")),
 	}
 	if w == (schema.AutoWorkload{}) {
 		return nil

--- a/internal/benchmark/report/matrix.go
+++ b/internal/benchmark/report/matrix.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strings"
@@ -267,6 +268,18 @@ func (m Matrix) candidateAgainstBaseline(b *buf) {
 	}
 }
 
+// changeSummary renders the runtime changes as "total (+up/-down)", so a run
+// that grew once and took the step back reads differently from one that never
+// moved and from one that grew twice (issue #215, stage 5). Builds that report
+// only the total keep the plain number.
+func changeSummary(c schema.Chosen) string {
+	total := raw(c.Changes)
+	if c.SpreadIncreases == nil && c.SpreadDecreases == nil {
+		return total
+	}
+	return fmt.Sprintf("%s (+%s/-%s)", total, raw(c.SpreadIncreases), raw(c.SpreadDecreases))
+}
+
 func (m Matrix) autoCost(b *buf) {
 	b.line("")
 	b.line("### What `auto` costs (policy regret)")
@@ -293,11 +306,11 @@ func (m Matrix) autoCost(b *buf) {
 			a.Scenario, a.LinkProfile,
 			raw(a.Chosen.Connections), raw(a.Chosen.Concurrency), raw(a.Chosen.RequestConcurrency),
 			raw(a.Chosen.InitialConnections), raw(a.Chosen.InitialConcurrency), raw(a.Chosen.InitialRequestConcurrency),
-			raw(a.Chosen.Changes),
+			changeSummary(a.Chosen),
 			num(a.MedianMS), best, bestMS, percent(a.RegretPercent), inGrid)
 	}
 	b.line("")
-	b.line("`Started at` is what the policy chose before the transfer taught it anything, and `Changes` how many times it widened the connection pool while the transfer ran; when the two coordinate columns agree, the run was decided entirely up front. The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the `auto` column means the two runs saw different conditions, and then the regret next to it is drift rather than policy. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all.")
+	b.line("`Started at` is what the policy chose before the transfer taught it anything, and `Changes` how many times it moved the connection spread while the transfer ran, as `total (+up/-down)`: a step back leaves the connections open and hands the remaining files to fewer of them (issue #215). When the two coordinate columns agree, the run was decided entirely up front. The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the `auto` column means the two runs saw different conditions, and then the regret next to it is drift rather than policy. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all.")
 	m.autoWorkload(b)
 }
 
@@ -317,19 +330,20 @@ func (m Matrix) autoWorkload(b *buf) {
 	b.line("")
 	b.line("<details><summary>What the policy was looking at</summary>")
 	b.line("")
-	b.line("| Scenario | Profile | Files | Bytes | Largest file | Probes | RTT | Handshake |")
-	b.line("|---|---|---|---|---|---|---|---|")
+	b.line("| Scenario | Profile | Files | Bytes | p50 | p90 | Largest file | One-packet files | Probes | RTT | Handshake | BDP |")
+	b.line("|---|---|---|---|---|---|---|---|---|---|---|---|")
 	for _, a := range m.Result.Auto {
 		w := a.Workload
 		if w == nil {
 			continue
 		}
-		b.line("| %s | %s | %s | %s | %s | %s | %s ms | %s ms |",
-			a.Scenario, a.LinkProfile, raw(w.Files), raw(w.Bytes), raw(w.LargestBytes), raw(w.Probes),
-			raw(w.RTTMS), raw(w.HandshakeMS))
+		b.line("| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s ms | %s ms | %s |",
+			a.Scenario, a.LinkProfile, raw(w.Files), raw(w.Bytes),
+			raw(w.P50Bytes), raw(w.P90Bytes), raw(w.LargestBytes), raw(w.SmallFiles), raw(w.Probes),
+			raw(w.RTTMS), raw(w.HandshakeMS), raw(w.BDPBytes))
 	}
 	b.line("")
-	b.line("`Probes` are the remote round-trips that are not uploads, which is what an `advanced.skip_unchanged` redeploy is made of. The RTT and handshake here are easySFTP's own measurement, taken on its first connection; `The link` above is the same path measured by `cmd/linkprobe`, which does not go through the uploader. The two should agree, and where they do not, one of them is measuring something else.")
+	b.line("`p50` and `p90` are the median and ninetieth-percentile file size and `One-packet files` how many of them fit in a single 32 KiB SFTP write, which is what tells a tree of tiny files with one archive in it from a tree of large ones; the pipelining depth is sized against the distribution rather than against the largest file alone (issue #215). `BDP` is bandwidth times delay: how many bytes one stream has to keep in flight to fill this path. `Probes` are the remote round-trips that are not uploads, which is what an `advanced.skip_unchanged` redeploy is made of. The RTT and handshake here are easySFTP's own measurement, taken on its first connection; `The link` above is the same path measured by `cmd/linkprobe`, which does not go through the uploader. The two should agree, and where they do not, one of them is measuring something else.")
 	b.line("")
 	b.line("</details>")
 }

--- a/internal/benchmark/schema/matrix.go
+++ b/internal/benchmark/schema/matrix.go
@@ -217,6 +217,16 @@ type Chosen struct {
 	InitialConcurrency        *float64 `json:"initial_concurrency,omitzero"`
 	InitialRequestConcurrency *float64 `json:"initial_request_concurrency,omitzero"`
 	Changes                   *float64 `json:"changes,omitzero"`
+
+	// Where those changes went. Once a growth step can be taken back
+	// (issue #215, stage 5), "the run changed its mind twice" no longer says
+	// whether it ended up wider or back where it started: SpreadIncreases and
+	// SpreadDecreases split the count by direction and FinalConnections is the
+	// spread the last deployment settled on. The plain Connections above stays
+	// the high-water mark, which is what the server saw.
+	SpreadIncreases  *float64 `json:"spread_increases,omitzero"`
+	SpreadDecreases  *float64 `json:"spread_decreases,omitzero"`
+	FinalConnections *float64 `json:"final_connections,omitzero"`
 }
 
 // AutoWorkload is the input side of one policy decision: the features the run
@@ -236,12 +246,30 @@ type AutoWorkload struct {
 	LargestBytes *float64 `json:"largest_bytes"`
 	Probes       *float64 `json:"probes"`
 
+	// The shape of that transfer: the median and ninetieth-percentile file
+	// size and how many files fit in a single SFTP write packet. Totals and a
+	// largest file cannot tell a tree of 4 KiB files with one archive in it
+	// from a tree of megabyte files, and the two are pipelined differently
+	// (issue #215, stage 1).
+	P50Bytes   *float64 `json:"p50_bytes,omitzero"`
+	P90Bytes   *float64 `json:"p90_bytes,omitzero"`
+	SmallFiles *float64 `json:"small_files,omitzero"`
+
 	// RTTMS and HandshakeMS are what the run's own probe measured, which is
 	// not the same measurement as link.probes[]: those come from
 	// cmd/linkprobe, outside the code under test. Comparing the two is worth
 	// doing, which is why both are kept.
 	RTTMS       *float64 `json:"rtt_ms"`
 	HandshakeMS *float64 `json:"handshake_ms"`
+
+	// StreamBytesPerSecond is the per-connection throughput the pipelining was
+	// sized against, and BDPBytes the bandwidth-delay product that follows from
+	// it: how many bytes one stream has to keep in flight to fill this path
+	// (issue #215, stage 3). A zero throughput means nothing had been measured
+	// and the run used the built-in prior, which is the normal case for a plan
+	// taken before the first byte moves.
+	StreamBytesPerSecond *float64 `json:"stream_bytes_per_second,omitzero"`
+	BDPBytes             *float64 `json:"bdp_bytes,omitzero"`
 }
 
 // MatrixCompare pairs a build's cell with the reference build's cell at

--- a/internal/uploader/autotune_test.go
+++ b/internal/uploader/autotune_test.go
@@ -302,10 +302,11 @@ func TestRuntimeControllerWidensThePoolWhileTheTransferRuns(t *testing.T) {
 	tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
 
 	prog := &uploadProgress{totalFiles: 1000, totalBytes: 1000 << 20}
+	poolWork := autotune.Workload{Uploads: 1000, UploadBytes: 1000 << 20, LargestUpload: 1 << 20, P90Upload: 1 << 20}
 	start := autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16}
 	sess.setSpread(start.Connections)
 
-	stop := startTuningController(context.Background(), sess, start, prog, log)
+	stop := startTuningController(context.Background(), sess, poolWork, start, prog, log)
 	// Ten 1 MiB files through in the first window: one stream is carrying a
 	// fraction of what the remaining 990 MiB would need.
 	for range 10 {
@@ -364,12 +365,13 @@ func TestRuntimeControllerNarrowsTheSpreadWithoutClosingConnections(t *testing.T
 	tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
 
 	prog := &uploadProgress{totalFiles: 1000, totalBytes: 1000 << 20}
+	poolWork := autotune.Workload{Uploads: 1000, UploadBytes: 1000 << 20, LargestUpload: 1 << 20, P90Upload: 1 << 20}
 	start := autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16}
 	sess.setSpread(start.Connections)
 
 	// stop must run before the assertions read the log: it waits for the
 	// controller's goroutine, which is the only other writer.
-	stop := sync.OnceFunc(startTuningController(context.Background(), sess, start, prog, log))
+	stop := sync.OnceFunc(startTuningController(context.Background(), sess, poolWork, start, prog, log))
 	defer stop()
 
 	// A first window worth growing on.

--- a/internal/uploader/autotune_test.go
+++ b/internal/uploader/autotune_test.go
@@ -374,8 +374,11 @@ func TestRuntimeControllerNarrowsTheSpreadWithoutClosingConnections(t *testing.T
 	stop := sync.OnceFunc(startTuningController(context.Background(), sess, poolWork, start, prog, log))
 	defer stop()
 
-	// A first window worth growing on.
-	for range 10 {
+	// A first window worth growing on. The amount is deliberately far larger
+	// than the second window's: how long a window turns out to be depends on
+	// when a loaded machine got round to the tick, and the two rates have to
+	// be ordered by what this test is about rather than by the scheduler.
+	for range 100 {
 		prog.upload(1<<20, 1<<20)
 	}
 	if !waitForSpread(t, sess, func(n int) bool { return n > 1 }) {
@@ -390,10 +393,11 @@ func TestRuntimeControllerNarrowsTheSpreadWithoutClosingConnections(t *testing.T
 		t.Fatal("the widened pool handed out no client")
 	}
 
-	// A second window that is slower than the first, so the step bought
-	// nothing and the controller puts the spread back.
-	for range 6 {
-		prog.upload(1<<20, 1<<20)
+	// A second window that is far slower than the first, but still carries
+	// enough bytes over enough files to be an observation at all: the step
+	// bought nothing, so the controller puts the spread back.
+	for range 8 {
+		prog.upload(96<<10, 96<<10)
 	}
 	ok := waitForSpread(t, sess, func(n int) bool { return n == 1 })
 	stop()

--- a/internal/uploader/autotune_test.go
+++ b/internal/uploader/autotune_test.go
@@ -3,6 +3,7 @@ package uploader
 import (
 	"context"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -339,6 +340,101 @@ func TestRuntimeControllerWidensThePoolWhileTheTransferRuns(t *testing.T) {
 	if effective < 2 {
 		t.Errorf("the effective connection count stayed at %d; the benchmark reads this back", effective)
 	}
+}
+
+// TestRuntimeControllerNarrowsTheSpreadWithoutClosingConnections is the wiring
+// of stage 5 of issue #215. A growth step that does not pay for itself is taken
+// back, and "taken back" must mean that the next files go somewhere else, not
+// that a live SSH connection is torn down under the transfers running on it.
+func TestRuntimeControllerNarrowsTheSpreadWithoutClosingConnections(t *testing.T) {
+	defer func(v time.Duration) { tuningInterval = v }(tuningInterval)
+	tuningInterval = 10 * time.Millisecond
+
+	srv := startTestServer(t)
+	cfg := autoConfig(srv)
+	tune := newTuning(cfg)
+	tune.resolveRunWide(autotune.Workload{Uploads: 1000, UploadBytes: 1000 << 20, LargestUpload: 1 << 20})
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	sess, err := newSession(context.Background(), cfg, tune, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.close()
+	tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
+
+	prog := &uploadProgress{totalFiles: 1000, totalBytes: 1000 << 20}
+	start := autotune.Settings{Connections: 1, Concurrency: 64, RequestConcurrency: 16}
+	sess.setSpread(start.Connections)
+
+	// stop must run before the assertions read the log: it waits for the
+	// controller's goroutine, which is the only other writer.
+	stop := sync.OnceFunc(startTuningController(context.Background(), sess, start, prog, log))
+	defer stop()
+
+	// A first window worth growing on.
+	for range 10 {
+		prog.upload(1<<20, 1<<20)
+	}
+	if !waitForSpread(t, sess, func(n int) bool { return n > 1 }) {
+		stop()
+		t.Fatalf("the pool never widened; log: %v", log.infos)
+	}
+
+	// The second connection is now real: a worker lands on it and it is
+	// dialed. This is the connection the step back must leave alone.
+	client, _, _ := sess.acquire(1)
+	if client == nil {
+		t.Fatal("the widened pool handed out no client")
+	}
+
+	// A second window that is slower than the first, so the step bought
+	// nothing and the controller puts the spread back.
+	for range 6 {
+		prog.upload(1<<20, 1<<20)
+	}
+	ok := waitForSpread(t, sess, func(n int) bool { return n == 1 })
+	stop()
+	if !ok {
+		t.Fatalf("the spread never came back down; log: %v", log.infos)
+	}
+
+	if _, ok := findLine(log.infos, "without closing any"); !ok {
+		t.Errorf("a step back must say the connections stay open: %v", log.infos)
+	}
+	// The point of a logical spread: the connection is still there, still
+	// usable, and still carrying whatever was already on it.
+	if _, err := client.Getwd(); err != nil {
+		t.Errorf("the connection the spread stopped using was closed: %v", err)
+	}
+	tune.mu.Lock()
+	up, down, final, effective := tune.spreadUp, tune.spreadDown, tune.finalSpread, tune.effective.Connections
+	tune.mu.Unlock()
+	switch {
+	case up != 1 || down != 1:
+		t.Errorf("recorded %d increase(s) and %d decrease(s), want one of each", up, down)
+	case final != 1:
+		t.Errorf("the run settled at %d connection(s), want 1", final)
+	case effective < 2:
+		t.Errorf("effective connections = %d: the handshake the run paid for does not become unpaid", effective)
+	}
+}
+
+// waitForSpread waits for the session's spread to satisfy want, which is how a
+// test observes a decision taken on the controller's own goroutine.
+func waitForSpread(t *testing.T, sess *session, want func(int) bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		sess.mu.Lock()
+		spread := sess.spread
+		sess.mu.Unlock()
+		if want(spread) {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
 }
 
 // TestRuntimeControllerStaysOutOfDryRunsAndPinnedRuns: neither has anything to

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -99,7 +99,8 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 	// the transfer that is about to start (for sync, the changed set the
 	// manifest just produced), and the link is what the first connection
 	// measured. Everything the configuration pinned comes back unchanged.
-	settings := sess.tune.planFor(uploadWorkload(files, skipUnchanged))
+	work := uploadWorkload(files, skipUnchanged)
+	settings := sess.tune.planFor(work)
 	sess.setSpread(settings.Connections)
 	logTuning(cfg, sess, files, skipUnchanged, settings, log)
 
@@ -111,7 +112,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 		// Stage 3. A dry run moves no bytes, so there is nothing to measure
 		// and nothing a wider pool could carry.
 		env.progress = newUploadProgress(files)
-		defer startTuningController(ctx, sess, settings, env.progress, log)()
+		defer startTuningController(ctx, sess, work, settings, env.progress, log)()
 	}
 	// modeWarned is only armed when file-mode is an explicit override: a
 	// mirrored local mode (the default) stays silent on failure, as before.

--- a/internal/uploader/tuning.go
+++ b/internal/uploader/tuning.go
@@ -264,10 +264,11 @@ func (t *tuning) report() {
 }
 
 // planWorkload turns a set of planned files into the features the policy
-// reads: the totals, the size distribution stage 1 works on, and the remote
-// round-trips that are not uploads (the one stat per file advanced.
-// skip_unchanged costs). unknown marks a set whose members may turn out not to
-// be uploaded at all.
+// reads: the totals and the size distribution stage 1 works on. probes counts
+// the remote round-trips that are not uploads (the one stat per file
+// advanced.skip_unchanged costs) and unknown marks a set whose members may
+// turn out not to be uploaded at all; both are the caller's to say, since
+// neither is visible in a list of files.
 func planWorkload(files []fileItem, probes int, unknown bool) autotune.Workload {
 	w := autotune.SummarizeUploads(uploadSizes(files))
 	w.Probes, w.Unknown = probes, unknown

--- a/internal/uploader/tuning.go
+++ b/internal/uploader/tuning.go
@@ -49,6 +49,16 @@ type tuning struct {
 	haveInitial bool
 	effective   autotune.Settings
 	changes     int
+
+	// spreadUp and spreadDown count the runtime changes by direction, and
+	// finalSpread is the number of connections the last deployment ended up
+	// handing files to. effective stays a high-water mark (it answers "what did
+	// this run cost the server"); these answer "where did the policy settle",
+	// which is a different question once a step can be taken back
+	// (issue #215).
+	spreadUp    int
+	spreadDown  int
+	finalSpread int
 }
 
 // newTuning reads which settings the configuration pinned. Everything it does
@@ -157,6 +167,7 @@ func (t *tuning) planFor(w autotune.Workload) autotune.Settings {
 		// stored benchmark result explains the choice as well as recording it.
 		t.initial, t.seen, t.haveInitial = s, w, true
 	}
+	t.finalSpread = s.Connections
 	t.record(s)
 	return s
 }
@@ -168,11 +179,19 @@ func (t *tuning) record(s autotune.Settings) {
 	t.effective.RequestConcurrency = max(t.effective.RequestConcurrency, s.RequestConcurrency)
 }
 
-// grew notes one accepted runtime change.
-func (t *tuning) grew(s autotune.Settings) {
+// applied notes one accepted runtime change, in the direction it went. A step
+// back does not un-count the handshakes the step before it paid for, so
+// effective keeps its high-water mark either way.
+func (t *tuning) applied(s autotune.Settings, shrink bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.changes++
+	if shrink {
+		t.spreadDown++
+	} else {
+		t.spreadUp++
+	}
+	t.finalSpread = s.Connections
 	t.record(s)
 }
 
@@ -220,41 +239,66 @@ func (t *tuning) report() {
 	metrics.Set("auto_initial_concurrency", int64(t.initial.Concurrency))
 	metrics.Set("auto_initial_request_concurrency", int64(t.initial.RequestConcurrency))
 	metrics.Set("auto_changes", int64(t.changes))
+	// Direction and destination of those changes: a run that grew and then
+	// took the step back is not a run that never moved, and the difference is
+	// invisible in a single counter (issue #215, stages 5 and 6).
+	metrics.Set("auto_spread_increases", int64(t.spreadUp))
+	metrics.Set("auto_spread_decreases", int64(t.spreadDown))
+	metrics.Set("auto_final_connections", int64(max(t.finalSpread, 1)))
 	metrics.Set("workload_files", int64(t.seen.Uploads))
 	metrics.Set("workload_bytes", t.seen.UploadBytes)
 	metrics.Set("workload_largest_bytes", t.seen.LargestUpload)
+	metrics.Set("workload_p50_bytes", t.seen.P50Upload)
+	metrics.Set("workload_p90_bytes", t.seen.P90Upload)
+	metrics.Set("workload_small_files", int64(t.seen.SmallUploads))
 	metrics.Set("workload_probes", int64(t.seen.Probes))
 	metrics.Set("link_rtt_us", t.link.RTT.Microseconds())
 	metrics.Set("link_handshake_us", t.link.Handshake.Microseconds())
+	// The throughput the pipelining was sized against and the bandwidth-delay
+	// product that follows from it. A zero throughput is the normal case and
+	// says so explicitly: nothing observes one before the first byte moves, so
+	// the run used the built-in prior and link_bdp_bytes is what that prior
+	// works out to over the measured RTT.
+	metrics.Set("link_stream_bytes_per_second", int64(t.link.StreamBytesPerSecond))
+	metrics.Set("link_bdp_bytes", t.link.BDPBytes())
 }
 
 // planWorkload turns a set of planned files into the features the policy
-// reads. probes counts the remote round-trips that are not uploads (the one
-// stat per file advanced.skip_unchanged costs), and unknown marks a set whose
-// members may turn out not to be uploaded at all.
+// reads: the totals, the size distribution stage 1 works on, and the remote
+// round-trips that are not uploads (the one stat per file advanced.
+// skip_unchanged costs). unknown marks a set whose members may turn out not to
+// be uploaded at all.
 func planWorkload(files []fileItem, probes int, unknown bool) autotune.Workload {
-	w := autotune.Workload{Probes: probes, Unknown: unknown}
-	for _, f := range files {
-		w.Uploads++
-		w.UploadBytes += f.size
-		w.LargestUpload = max(w.LargestUpload, f.size)
-	}
+	w := autotune.SummarizeUploads(uploadSizes(files))
+	w.Probes, w.Unknown = probes, unknown
 	return w
+}
+
+// uploadSizes is the one slice the summary needs. It lives exactly as long as
+// the call: what the policy keeps afterwards is the handful of numbers
+// autotune.SummarizeUploads reduces it to.
+func uploadSizes(files []fileItem) []int64 {
+	sizes := make([]int64, 0, len(files))
+	for _, f := range files {
+		sizes = append(sizes, f.size)
+	}
+	return sizes
 }
 
 // runWorkload is every deployment's plan added together: the ceiling the run
 // is sized against before it knows what sync will narrow down. Deployments run
 // one after another, so their handshakes are shared and adding them up is what
 // the pool actually faces.
+//
+// The distribution is taken over the union rather than per deployment, for the
+// same reason: the connections and the pipelining depth are run-wide, so what
+// they have to serve is every file the run may send.
 func runWorkload(plans []plan) autotune.Workload {
-	var total autotune.Workload
+	var sizes []int64
 	for _, p := range plans {
-		w := planWorkload(p.files, 0, false)
-		total.Uploads += w.Uploads
-		total.UploadBytes += w.UploadBytes
-		total.LargestUpload = max(total.LargestUpload, w.LargestUpload)
+		sizes = append(sizes, uploadSizes(p.files)...)
 	}
-	return total
+	return autotune.SummarizeUploads(sizes)
 }
 
 // uploadWorkload is the workload of one deployment's transfer phase.
@@ -267,11 +311,19 @@ func runWorkload(plans []plan) autotune.Workload {
 // once the run has seen the real ratio.
 func uploadWorkload(files []fileItem, skipUnchanged bool) autotune.Workload {
 	if skipUnchanged {
-		w := autotune.Workload{Probes: len(files), Unknown: true}
-		for _, f := range files {
-			w.LargestUpload = max(w.LargestUpload, f.size)
+		// The sizes are the sizes of files that may or may not be sent, so
+		// they describe the shape of the work without claiming any of it will
+		// happen: the counts stay on the probe side and the byte total stays
+		// at zero.
+		shape := autotune.SummarizeUploads(uploadSizes(files))
+		return autotune.Workload{
+			Probes:        len(files),
+			Unknown:       true,
+			LargestUpload: shape.LargestUpload,
+			P50Upload:     shape.P50Upload,
+			P90Upload:     shape.P90Upload,
+			SmallUploads:  shape.SmallUploads,
 		}
-		return w
 	}
 	return planWorkload(files, 0, false)
 }
@@ -467,9 +519,12 @@ func startTuningController(ctx context.Context, sess *session, start autotune.Se
 			}
 			change, ok := ctrl.Observe(prog.snapshot(time.Since(began), sess.refusedConnection()))
 			if ok {
-				applied := sess.setSpread(change.To.Connections)
-				change.To.Connections = applied
-				sess.tune.grew(change.To)
+				// setSpread only ever points the *next* files somewhere else.
+				// Nothing in flight moves, and a narrowing spread leaves every
+				// connection it stops using open (issue #215, stage 5).
+				shrink := change.Shrinks()
+				change.To.Connections = sess.setSpread(change.To.Connections)
+				sess.tune.applied(change.To, shrink)
 				log.Infof("auto tuning: %s", change)
 			}
 			if stopped, why := ctrl.Stopped(); stopped {

--- a/internal/uploader/tuning.go
+++ b/internal/uploader/tuning.go
@@ -489,14 +489,20 @@ func (p *uploadProgress) snapshot(elapsed time.Duration, refused bool) autotune.
 
 // startTuningController runs stage 3 for one deployment: it watches the
 // transfer and widens the connection pool while the work that is left still
-// justifies another handshake. The returned function stops the watcher and
-// must be called before the phase ends.
+// justifies another handshake, then narrows it again if that turned out not to
+// help. The returned function stops the watcher and must be called before the
+// phase ends.
 //
 // Only the pool moves; see the comment on autotune.Controller for why the
-// other two settings are already where they belong. Growth is applied through
-// session.setSpread, which hands the next files to more slots without dialing
-// anything itself, so a decision that turns out to be unnecessary (the phase
-// ends first) costs nothing at all.
+// other two settings are already where they belong. Both directions go through
+// session.setSpread, which points the next files at a different number of
+// slots without dialing or closing anything itself, so a decision that turns
+// out to be unnecessary (the phase ends first, the step is taken back) costs
+// nothing at all.
+//
+// The workload goes in as well as the settings: what the controller may
+// conclude from the bytes it sees depends on what kind of files produced
+// them (autotune.Controller.bandwidthBound).
 func startTuningController(ctx context.Context, sess *session, w autotune.Workload, start autotune.Settings, prog *uploadProgress, log Logger) func() {
 	ctrl := autotune.NewController(w, start, sess.tune.currentLink(), sess.tune.fixed)
 	if stopped, _ := ctrl.Stopped(); stopped {

--- a/internal/uploader/tuning.go
+++ b/internal/uploader/tuning.go
@@ -497,8 +497,8 @@ func (p *uploadProgress) snapshot(elapsed time.Duration, refused bool) autotune.
 // session.setSpread, which hands the next files to more slots without dialing
 // anything itself, so a decision that turns out to be unnecessary (the phase
 // ends first) costs nothing at all.
-func startTuningController(ctx context.Context, sess *session, start autotune.Settings, prog *uploadProgress, log Logger) func() {
-	ctrl := autotune.NewController(start, sess.tune.currentLink(), sess.tune.fixed)
+func startTuningController(ctx context.Context, sess *session, w autotune.Workload, start autotune.Settings, prog *uploadProgress, log Logger) func() {
+	ctrl := autotune.NewController(w, start, sess.tune.currentLink(), sess.tune.fixed)
 	if stopped, _ := ctrl.Stopped(); stopped {
 		return func() {}
 	}


### PR DESCRIPTION
Closes #215.

Evolves the `auto` policy of #209 along the axes issue #215 names, keeping the
workload -> link -> runtime structure. Explicit numbers are still passed through
untouched at every stage; everything below only ever moves a setting left at
`auto`.

## What changed

**Stage 1, workload shape.** `autotune.Workload` gains `P50Upload`, `P90Upload`
and `SmallUploads` (files that fit in a single 32 KiB SFTP write packet, which
is protocol-derived rather than aesthetic). `autotune.SummarizeUploads` computes
them in one pass plus a sort and the sizes are dropped straight afterwards. The
issue's two shapes, "99 medium files plus one archive" and "many tiny files plus
several large ones", no longer look identical to the policy even when their
totals and largest file match.

**In-flight budget against the distribution.** This is the measurable win.
The 32 MiB buffer ceiling used to be `concurrency * request_concurrency`, i.e.
every file in flight assumed large enough to fill a whole pipeline. That is what
made the stored `mixed` sweep run at `request_concurrency: 18` (56 workers
divided into the budget, as if all 56 were the 2 MiB file). The bound is now
`0.9 * workers * packets(p90) + 0.1 * workers * requests`, which is a genuine
upper bound (no more than a tenth of the files can be above the ninetieth
percentile) and far tighter. `mixed` now plans `64`, and the stored grid says
that cell is 10% faster than 16 at 4 connections and a tie at 8. The result is
also quantized to a power of two: a pipeline depth of 18 invites a reader to
believe the 8 means something, and it keeps the choice on coordinates the sweeps
actually measure.

**Stage 3, BDP-aware `request_concurrency`.** `Link` gains a `ThroughputSource`
(prior / cached / runtime) and `BDPBytes()`. Where a throughput has really been
observed, the pipeline depth is sized against the bytes the path must hold in
flight (BDP x 4) and capped by the file; where it is still the built-in prior,
the conservative pre-#215 rule stands, exactly as the issue asks. **Nothing
measures a throughput before the first byte moves today**, so this path is
dormant in a normal run and is unit-tested rather than benchmark-tested. It is
the consumer side of #212.

**Stage 5, reversible spread.** The session already separated the pool ceiling
from the active spread, so no connection lifecycle changed. What is new is that
the controller may go *down*: a growth step that does not beat the window before
it is taken back to the previous spread. The connections stay open, nothing in
flight moves, and only the files that are left are assigned differently. Then
the controller settles: one correction is a correction, two would be an
oscillation.

**Stage 6, what counts as evidence.** Two changes, and the second is the one
that actually fixes `small`.

*A byte rate is only a bandwidth measurement when the files could produce one.*
The controller divided the observed bytes per second by the streams carrying
them and called it the link's per-stream throughput. For files that each fit in
a single 32 KiB write packet that is not a bandwidth: the transfer is bound by
four round-trips per file, so its MiB/s is its files/s in other units. Read as a
bandwidth it makes the link look dead, the remaining work look enormous, and
buys connections that measured *slower*. That is exactly the `small` miss. The
controller now takes the workload it is watching and only replaces the
throughput prior when `p90 > one packet`, so a tree of small files with archives
in it still gets its correction, and a tree of 4 KiB files keeps the plan whose
inputs (measured RTT, known file count) were already complete. The re-plan of
the work that is *left* still runs either way, which is what an unsettled
`skip_unchanged` set depends on.

*Window eligibility.* A report only counts as an observation when its
*window* (not the time since the phase started) is at least 750 ms, saw at least
4 files finish and carried at least 512 KiB. A report that fails any of these
does not become the new baseline, so the window widens instead of a thin one
deciding the pool. Before this, a 250 ms window carrying a few dozen kilobytes could
size the pool of a 1.2 MiB deployment.

Reaching the connection ceiling also no longer latches the controller *before*
it has judged the step that got it there, which was the other half of why an
over-wide pool could not be corrected: `4 -> 8` hit `MaxConnections` and stopped,
so the one step that could no longer be undone was also the one nobody checked.

**Observability.** New counters `workload_p50_bytes`, `workload_p90_bytes`,
`workload_small_files`, `auto_spread_increases`, `auto_spread_decreases`,
`auto_final_connections`, `link_stream_bytes_per_second`, `link_bdp_bytes`;
new optional fields in the matrix schema and two new columns in the sweep report
(`Changes` now reads `total (+up/-down)`). The debug line carries the shape and
the BDP, and a step back logs itself:

```text
auto tuning: 1.1 MiB/s is no better than the 1.1 MiB/s before the spread grew to 8; assigning the remaining files across 4 connection(s) instead, without closing any
```

## Stage 4, deliberately not changed

The issue asks to replace the unconditional `min(items, 64)` file concurrency
with a workload-aware policy. I looked for the rule in the seven sweeps under
`benchmarks/matrix/` and it is not there: at the connection count the policy
picks, the fastest concurrency is 32 or 64 for every payload-heavy scenario, and
the two cases that disagree (`small` at 4 connections, `mixed` at 8) disagree by
2-14% in *opposite* directions on grids whose own canary spread is around 7%.
Fitting a rule to that would be fitting noise, so `planConcurrency` keeps its
policy and its comment now records the evidence review. The two costs the issue
attributes to a worker are bounded elsewhere anyway: the buffers by the
distribution-aware budget above, and the pool by `planConnections`, which is
where the measured cost of over-provisioning actually lives.

## Validation

- `go test -race ./...` green, `go vet`, `gofmt` clean.
- The stored-sweep replay (`TestPolicyRegretAgainstStoredSweeps`, every
  committed matrix with >= 3 repeats) still passes and now feeds the real size
  distribution of each scenario into the policy. The only choice that moves is
  `mixed`: `6/56/18 -> 6/56/64`, regret `+2.6% -> +1.3%`. Nothing else changes,
  which is the point: the two fixes target the two misses and leave the
  scenarios that are already near optimum alone.
- The control test (a fixed 1/4/16 must still fail the same replay) is
  unaffected: 375% behind at worst.
- New tests: distribution summary and nearest-rank percentiles, the `mixed`
  budget case, power-of-two quantization, BDP at four link/throughput
  combinations, source provenance, controller grow -> reject -> settle,
  window eligibility, the byte-rate gate, the step that reaches the ceiling, and
  an end-to-end uploader test that the narrowed spread leaves the connection
  open and usable.
- `ci.yml`'s container self-test now asserts the new counters against a real
  OpenSSH server, including that `auto_changes` equals the sum of the two
  directions and that a normal run leaves the throughput at the prior.

### Measured against a real server

A short PR-shaped sweep, [run 32705329823](https://github.com/eiserv/easySFTP/actions/runs/32705329823), 3 repeats, not stored ([settings and reasoning](https://github.com/eiserv/easySFTP/pull/216#issuecomment-5392497917), [full read-out](https://github.com/eiserv/easySFTP/pull/216#issuecomment-5392747557)):

| Scenario | auto picked | changes | auto | Best cell | Regret | main (v3.6.0) |
|---|---|---|---:|---|---:|---:|
| `small` | 4/64/16 | 0 | 4057 ms | 4/64/default, 4439 ms | **-8.6%** | +27.7% |
| `deep` | 4/64/16 | 0 | 7109 ms | 4/64/default, 6946 ms | **+2.4%** | -7.6% |
| `mixed` | 8/56/64 | 1 | 17219 ms | 8/56/16, 12280 ms | +40.2% | +29.7% |

`small` is the issue's miss and it is fixed: `auto` is now faster than every cell
in the grid, and the grid confirms the diagnosis (8 connections measure
4908-5444 ms against 4439 ms at four). The mechanism that did it is the
byte-rate gate, which stops the growth being proposed at all; the step-back
never had to fire. `deep` was the regression risk of that gate and did not
regress: the grid puts 8 connections at 8007-8524 ms, so main's growth to 8 was
a loss that a lucky pass hid.

`mixed` is neither better nor worse in any way this PR can claim credit or blame
for, and the honest reading is in the linked comment: its `auto` run has been
~30% slower than the identical coordinates measured as a cell on **both**
builds, which is the `chosen_cell_median_ms` control saying the regret is not a
policy result. Filed as #217. The pipelining change itself is a wash on this
line (7% slower here, a tie and a 10% win in the previous sweep) - which is what
a bandwidth-delay product of ~5 KiB predicts, and why the budget change is
defended as an arithmetic bound rather than as a measurement.

**Not done here, and worth saying out loud:** the issue's shaped RTT/bandwidth
matrices. The harness supports them (`link-profiles`), but they multiply a
multi-hour sweep and nothing in this PR calibrates a new constant against the
house line: the budget change is an arithmetic bound, not a fit, and the BDP
path is inert until something measures a throughput. A shaped sweep is the right
gate for #212, when the cached prior starts changing decisions.

Refs #215
