### PR TITLE
fix(uploader): do not read a coarse SFTP status as a refusal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,32 @@ jobs:
           docker exec sftp test -f /home/demo/upload/index.html
           [ "${{ steps.clean-upload.outputs.files-deleted }}" -ge 1 ]
 
+      # The other clean-mode case: a target that does not exist yet, so the
+      # remote scan runs before there is anything to scan. Nothing to delete is
+      # the expected state of a first deployment, not a failure. Covered here
+      # because the unit tests reach it through a fake server; this is the same
+      # path against a real one (issue #152).
+      - name: Clean mode into a target that does not exist yet
+        id: fresh-clean
+        uses: ./
+        with:
+          host: localhost
+          port: 2222
+          username: demo
+          password: demopass
+          host-key: ${{ steps.hostkey.outputs.fingerprints }}
+          source: ./selftest-site/
+          target: /upload/fresh-clean/
+          exclude: "*.log"
+          mode: clean
+
+      - name: Verify the first clean deployment
+        run: |
+          docker exec sftp test -f /home/demo/upload/fresh-clean/index.html
+          docker exec sftp test -f /home/demo/upload/fresh-clean/assets/style.css
+          [ "${{ steps.fresh-clean.outputs.files-uploaded }}" = "2" ]
+          [ "${{ steps.fresh-clean.outputs.files-deleted }}" = "0" ]
+
       # config-mode end-to-end: unit tests set EASYSFTP_* variables directly
       # and never see action.yml's declared defaults; only a real composite
       # run does. This is how #62 (a declared default tripping the config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,14 @@ not that the test needs relaxing.
   pkg/sftp package-level variable, so it is process-global and restores itself
   via `t.Cleanup`; no test in this package runs in parallel, which is what
   makes that safe.
+- `withCoarseStatus(code)` is the other half of a non-OpenSSH server: it
+  answers every "not there" with one generic status code (`SSH_FX_FAILURE`,
+  `SSH_FX_BAD_MESSAGE`) instead of `SSH_FX_NO_SUCH_FILE`, across all four
+  handler roles at once, so a missing path looks the same whether the run
+  listed, stat'd, removed or opened it. It intercepts exactly the errors that
+  satisfy `os.ErrNotExist` and passes real refusals through, which is what
+  makes `remoteAbsent`'s tie-break testable in both directions (issue #152).
+  Give it before `withFailOpen`/`withFailList` when a test needs both.
 - A run may hold more than one connection (`advanced.connections`, issue
   #158; how many is the policy's, issue #209). Only the per-file upload path
   spreads over them, by file index modulo `session.spread`; `session.do` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,14 @@ not that the test needs relaxing.
   pkg/sftp package-level variable, so it is process-global and restores itself
   via `t.Cleanup`; no test in this package runs in parallel, which is what
   makes that safe.
+- `withCoarseStatus(code)` is the other half of a non-OpenSSH server: it
+  answers every "not there" with one generic status code (`SSH_FX_FAILURE`,
+  `SSH_FX_BAD_MESSAGE`) instead of `SSH_FX_NO_SUCH_FILE`, across all four
+  handler roles at once, so a missing path looks the same whether the run
+  listed, stat'd, removed or opened it. It intercepts exactly the errors that
+  satisfy `os.ErrNotExist` and passes real refusals through, which is what
+  makes `remoteAbsent`'s tie-break testable in both directions (issue #152).
+  Give it before `withFailOpen`/`withFailList` when a test needs both.
 - A run may hold more than one connection (`advanced.connections`, issue
   #158; how many is the policy's, issue #209). Only the per-file upload path
   spreads over them, by file index modulo `session.spread`; `session.do` and

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -120,6 +120,26 @@ apart:
   as it was. easySFTP does not remove a live file to retry a rename the server
   has already declined.
 
+**Status codes.** SFTP version 3 has eight status codes, and implementations
+disagree on how precisely they use them. OpenSSH answers a path that is not
+there with `SSH_FX_NO_SUCH_FILE`; others answer the generic `SSH_FX_FAILURE`,
+which on its own does not say whether the path was missing or the request was
+refused. easySFTP does not take that for granted anywhere the difference
+decides whether a run continues:
+
+- **The first `clean` deployment**, whose scan of the target runs before the
+  target exists. A listing that fails is followed by a stat, and a target the
+  server has nothing at is scanned as empty rather than ending the run.
+- **Deleting a file that is already gone**, which `sync` does whenever
+  something it recorded was removed on the server since. That is the outcome
+  the delete wanted, so it counts as deleted.
+
+The stat is what tells the two apart, and it costs a round-trip only when the
+operation already failed. A directory that *is* there and that the server
+refuses to list still fails the run: a `clean` deployment that silently
+skipped its scan would leave behind exactly the stale files it exists to
+remove.
+
 **Large directories.** `sync` and `clean` list the whole target tree to work
 out what to delete. Servers that page or cap directory listings can therefore
 report fewer entries than are really there. `dry-run: true` prints the plan the

--- a/internal/uploader/delete.go
+++ b/internal/uploader/delete.go
@@ -38,15 +38,26 @@ func deleteRemoteFiles(ctx context.Context, cfg *config.Config, sess *session, p
 		}
 		err := sess.do(groupCtx, watch, func(client *sftp.Client) error {
 			// Already-gone counts as deleted: a retried delete may have
-			// landed before the connection died.
+			// landed before the connection died, and sync deletes what its
+			// manifest recorded, which someone may have removed on the server
+			// since. Servers that do not distinguish "not there" from
+			// "refused" in the status code are asked directly; see
+			// remoteAbsent.
 			done := metrics.Op("sftp_remove")
 			err := client.Remove(remotePath)
 			done(err)
 			watch.tick()
-			if err != nil && !errors.Is(err, os.ErrNotExist) {
-				return err
+			if err == nil || errors.Is(err, os.ErrNotExist) {
+				return nil
 			}
-			return nil
+			absent, aerr := remoteAbsent(client, remotePath, watch)
+			if aerr != nil {
+				return aerr
+			}
+			if absent {
+				return nil
+			}
+			return err
 		})
 		if err != nil {
 			return fmt.Errorf("deleting %q: %w", remotePath, err)

--- a/internal/uploader/interop_test.go
+++ b/internal/uploader/interop_test.go
@@ -1,0 +1,204 @@
+package uploader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pkg/sftp"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// The tests here cover servers that answer a missing path with a generic
+// status code instead of SSH_FX_NO_SUCH_FILE (issue #152). easySFTP has two
+// places where "not there" is the expected, benign state, and reading it as a
+// refusal ends the run: the remote scan a clean deployment does before its
+// target exists, and deleting a file that is already gone. Both are settled by
+// a stat now; see remoteAbsent.
+//
+// The pairs matter more than the individual cases: each tolerant case has a
+// strict sibling proving the tie-break did not turn into blanket tolerance,
+// because a server that really is refusing must still fail the run loudly.
+
+// genericStatuses are the codes a server with no specific answer for "not
+// there" gives instead, the same two the posix-rename fallback accepts.
+var genericStatuses = []struct {
+	name string
+	code error
+}{
+	{"SSH_FX_FAILURE", sftp.ErrSSHFxFailure},
+	{"SSH_FX_BAD_MESSAGE", sftp.ErrSSHFxBadMessage},
+}
+
+// TestCleanIntoMissingTargetOnCoarseServer verifies the first clean deployment
+// to a server that does not report a missing directory specifically. The scan
+// finds nothing to delete and the upload proceeds, instead of the run dying in
+// its remote scan before it has written anything.
+func TestCleanIntoMissingTargetOnCoarseServer(t *testing.T) {
+	for _, tc := range genericStatuses {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := startTestServer(t, withCoarseStatus(tc.code))
+			local := t.TempDir()
+			writeTree(t, local, map[string]string{
+				"index.html":       "<h1>hi</h1>",
+				"assets/style.css": "body{}",
+			})
+
+			cfg := baseConfig(srv)
+			cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategyClean}}
+
+			stats, err := Run(context.Background(), cfg, testLogger{t})
+			if err != nil {
+				t.Fatalf("clean deployment into a target that does not exist yet failed: %v", err)
+			}
+			if stats.FilesUploaded != 2 {
+				t.Errorf("expected 2 uploads, got %d", stats.FilesUploaded)
+			}
+			if stats.FilesDeleted != 0 {
+				t.Errorf("expected nothing to delete in an empty target, got %d", stats.FilesDeleted)
+			}
+			if got := readRemote(t, srv, "/www/index.html"); got != "<h1>hi</h1>" {
+				t.Errorf("unexpected content: %q", got)
+			}
+		})
+	}
+}
+
+// TestRefusedScanStillFailsTheRun is the strict half: a target that is there
+// and whose listing the server refuses must still fail, because a clean
+// deployment that silently skipped its scan would leave the stale files it
+// exists to remove.
+func TestRefusedScanStillFailsTheRun(t *testing.T) {
+	srv := startTestServer(t, withFailList("/www"))
+	seedRemoteFile(t, srv, "/www", "stale.html", "stale")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "<h1>hi</h1>"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategyClean}}
+
+	_, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "scanning remote directory") {
+		t.Fatalf("expected the refused scan to fail the run, got %v", err)
+	}
+	if !remoteExists(t, srv, "/www/stale.html") {
+		t.Error("the stale file was deleted by a run whose scan never succeeded")
+	}
+}
+
+// TestSyncDeletesAlreadyGoneFileOnCoarseServer verifies the second sync of a
+// deployment whose file was removed on the server out of band. The manifest
+// still lists it, so sync deletes it; the server answers that there is nothing
+// there, which is the outcome sync wanted rather than a failure.
+func TestSyncDeletesAlreadyGoneFileOnCoarseServer(t *testing.T) {
+	for _, tc := range genericStatuses {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := startTestServer(t, withCoarseStatus(tc.code))
+			local := t.TempDir()
+			writeTree(t, local, map[string]string{
+				"index.html": "<h1>hi</h1>",
+				"old.css":    "body{}",
+			})
+
+			cfg := baseConfig(srv)
+			cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategySync}}
+
+			if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+				t.Fatalf("first sync: %v", err)
+			}
+
+			// Gone locally (so sync deletes it) and gone remotely (so the
+			// delete finds nothing), which is what someone tidying up on the
+			// server between two deploys leaves behind.
+			if err := os.Remove(filepath.Join(local, "old.css")); err != nil {
+				t.Fatal(err)
+			}
+			if err := srv.verifyClient(t).Remove("/www/old.css"); err != nil {
+				t.Fatal(err)
+			}
+
+			stats, err := Run(context.Background(), cfg, testLogger{t})
+			if err != nil {
+				t.Fatalf("second sync: %v", err)
+			}
+			if stats.FilesDeleted != 1 {
+				t.Errorf("expected the already-gone file to count as deleted, got %d", stats.FilesDeleted)
+			}
+		})
+	}
+}
+
+// TestRefusedDeleteStillFailsTheRun is the strict half of the delete
+// tie-break: a file that is still there after the server refused to remove it
+// must fail the run, not be reported as deleted.
+func TestRefusedDeleteStillFailsTheRun(t *testing.T) {
+	faulty := &faultyPathCmd{method: "Remove", path: "/www/stale.html"}
+	faulty.enabled.Store(true)
+	srv := startTestServer(t, withFaultyPath(faulty))
+	seedRemoteFile(t, srv, "/www", "stale.html", "stale")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "<h1>hi</h1>"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategyClean}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), `deleting "/www/stale.html"`) {
+		t.Fatalf("expected the refused delete to fail the run, got %v", err)
+	}
+	if stats.FilesDeleted != 0 {
+		t.Errorf("a refused delete was counted as deleted: %d", stats.FilesDeleted)
+	}
+	if !remoteExists(t, srv, "/www/stale.html") {
+		t.Error("the file the server refused to remove is gone")
+	}
+}
+
+// TestFirstSyncIsQuietOnCoarseServer verifies the run says nothing about the
+// manifest on the one run where there cannot be one. The behaviour was always
+// right (an unreadable manifest degrades to a first sync), but a server that
+// does not report a missing file specifically made it warn about the expected
+// state on every first sync of every sync deployment.
+func TestFirstSyncIsQuietOnCoarseServer(t *testing.T) {
+	srv := startTestServer(t, withCoarseStatus(sftp.ErrSSHFxFailure))
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "<h1>hi</h1>"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategySync}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	for _, w := range log.warnings {
+		if strings.Contains(w, "sync manifest") {
+			t.Errorf("first sync warned about the manifest that cannot exist yet: %q", w)
+		}
+	}
+}
+
+// TestUnreadableManifestOnCoarseServerStillWarns is the strict half: a
+// manifest that is there and cannot be read is a real problem even on a server
+// whose status code does not say which of the two it is, and the run has to
+// say so before it re-uploads everything and deletes nothing.
+func TestUnreadableManifestOnCoarseServerStillWarns(t *testing.T) {
+	srv := startTestServer(t,
+		withCoarseStatus(sftp.ErrSSHFxFailure),
+		withFailOpen("/www/"+manifestName),
+	)
+	seedRemoteFile(t, srv, "/www", manifestName, `{"version":3,"files":{}}`)
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := readManifest(srv.verifyClient(t), "/www", manifestName, log); err != nil {
+		t.Fatalf("readManifest: %v", err)
+	}
+	if len(log.warnings) != 1 || !strings.Contains(log.warnings[0], "could not open sync manifest") {
+		t.Fatalf("expected one manifest open warning, got %v", log.warnings)
+	}
+}

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -2,6 +2,7 @@ package uploader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -124,6 +125,44 @@ func nonDirConflict(client *sftp.Client, dir string, watch *stallWatchdog) (stri
 	return "", nil
 }
 
+// remoteAbsent reports whether the server has nothing at p. It is the
+// tie-breaker for an operation that failed without saying why.
+//
+// OpenSSH answers a missing path with SSH_FX_NO_SUCH_FILE, which pkg/sftp
+// turns into os.ErrNotExist, so "it was not there" is normally visible in the
+// error itself. Other implementations answer the generic SSH_FX_FAILURE,
+// which on its own is indistinguishable from a refusal, and easySFTP has two
+// places where reading the one as the other ends the run: listing a clean
+// deployment's target before it exists, and deleting a file that is already
+// gone (issue #152). A stat settles it, and only on the error path, so a
+// server that does say SSH_FX_NO_SUCH_FILE never pays the round-trip.
+//
+// Lstat, not Stat: a dangling symlink is still an entry, and a delete that
+// reported it gone would leave it behind.
+//
+// The stat's own answer is read the same way round. A connection-class
+// failure is returned as an error, so sess.do redials and reruns the
+// idempotent operation rather than reading a dead connection as an empty
+// server. SSH_FX_PERMISSION_DENIED counts as present: a server with a
+// specific code for a refusal that chose to use it is being specific, not
+// coarse, and the caller's original error is the one worth reporting.
+// Everything else counts as absent, which is the safe direction for both
+// callers, since a listing that finds nothing deletes nothing.
+func remoteAbsent(client *sftp.Client, p string, watch *stallWatchdog) (bool, error) {
+	_, err := client.Lstat(p)
+	watch.tick()
+	switch {
+	case err == nil:
+		return false, nil
+	case isConnError(err):
+		return false, err
+	case errors.Is(err, os.ErrPermission):
+		return false, nil
+	default:
+		return true, nil
+	}
+}
+
 // checkRemoteRoot refuses a destructive mode whose target resolves to the
 // filesystem root or an unspecific path: the one guard that is always on.
 func checkRemoteRoot(remote string) error {
@@ -163,7 +202,19 @@ func listRemoteContents(ctx context.Context, sess *session, root string, watch *
 				listed, err := client.ReadDir(dir)
 				done(err)
 				if err != nil {
+					// A directory that is not there has nothing to list: a
+					// clean deployment whose target does not exist yet, or a
+					// subdirectory removed between its parent's listing and
+					// this one. Servers that do not say so in the status code
+					// are asked directly; see remoteAbsent.
 					if os.IsNotExist(err) {
+						return nil
+					}
+					absent, aerr := remoteAbsent(client, dir, watch)
+					if aerr != nil {
+						return aerr
+					}
+					if absent {
 						return nil
 					}
 					return err

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -247,13 +247,24 @@ func writeRecoveryManifest(ctx context.Context, cfg *config.Config, sess *sessio
 // older manifest costs one full re-hash and then writes v3 from then on.
 func readManifest(client *sftp.Client, dir, name string, log Logger) (manifest, error) {
 	empty := manifest{Version: manifestVersion, Files: map[string]manifestEntry{}}
-	f, err := client.Open(path.Join(dir, name))
+	manifestPath := path.Join(dir, name)
+	f, err := client.Open(manifestPath)
 	if err != nil {
 		if isConnError(err) {
 			return empty, err
 		}
 		if !errors.Is(err, os.ErrNotExist) {
-			log.Warningf("could not open sync manifest in %s (%v); treating as first sync", dir, err)
+			// A server that answers a missing file with the generic
+			// SSH_FX_FAILURE would otherwise warn on every first sync, which
+			// is the one run where no manifest is the expected state. Asking
+			// costs a round-trip only when the open already failed.
+			absent, aerr := remoteAbsent(client, manifestPath, nil)
+			if aerr != nil {
+				return empty, aerr
+			}
+			if !absent {
+				log.Warningf("could not open sync manifest in %s (%v); treating as first sync", dir, err)
+			}
 		}
 		return empty, nil
 	}

--- a/internal/uploader/sync_test.go
+++ b/internal/uploader/sync_test.go
@@ -30,6 +30,11 @@ func syncConfig(srv *testServer, local string) *config.Config {
 
 func TestReadManifestWarnsWhenOpenFails(t *testing.T) {
 	srv := startTestServer(t, withFailOpen("/www/"+manifestName))
+	// The manifest has to be there for this to be the case it names: a
+	// manifest that cannot be opened *and is not there* is a first sync, and
+	// is silent whether or not the server says so in its status code
+	// (issue #152).
+	seedRemoteFile(t, srv, "/www", manifestName, `{"version":3,"files":{}}`)
 	log := &recordingLogger{testLogger: testLogger{t}}
 
 	got, err := readManifest(srv.verifyClient(t), "/www", manifestName, log)

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -474,6 +475,69 @@ func unadvertisePosixRename(t *testing.T) {
 			t.Errorf("restoring the advertised SFTP extensions: %v", err)
 		}
 	})
+}
+
+// coarseStatus answers every "not there" with one fixed generic status code
+// instead of SSH_FX_NO_SUCH_FILE, simulating a server that does not map its
+// errors onto the specific version-3 status codes the way OpenSSH does. It
+// wraps all four handler roles, so a missing path looks the same whether the
+// run listed it, stat'd it, removed it or opened it (issue #152).
+//
+// pkg/sftp's statusFromError puts an sftp.ErrSSHFx* value on the wire as that
+// exact code, and the in-memory handler reports every missing path with an
+// error satisfying os.ErrNotExist, which is what this intercepts. Everything
+// else, including a real refusal, passes through untouched.
+type coarseStatus struct {
+	cmd  sftp.FileCmder
+	list sftp.FileLister
+	get  sftp.FileReader
+	put  sftp.FileWriter
+	code error // an sftp.ErrSSHFx* code
+}
+
+func withCoarseStatus(code error) serverOption {
+	return func(s *testServer) {
+		c := &coarseStatus{
+			cmd:  s.handlers.FileCmd,
+			list: s.handlers.FileList,
+			get:  s.handlers.FileGet,
+			put:  s.handlers.FilePut,
+			code: code,
+		}
+		s.handlers.FileCmd = c
+		s.handlers.FileList = c
+		s.handlers.FileGet = c
+		s.handlers.FilePut = c
+	}
+}
+
+// coarsen replaces a "no such file" with the generic status this server gives.
+func (c *coarseStatus) coarsen(err error) error {
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return c.code
+	}
+	return err
+}
+
+func (c *coarseStatus) Filecmd(r *sftp.Request) error { return c.coarsen(c.cmd.Filecmd(r)) }
+
+func (c *coarseStatus) PosixRename(r *sftp.Request) error {
+	return c.coarsen(posixRenamePassthrough(c.cmd, r))
+}
+
+func (c *coarseStatus) Filelist(r *sftp.Request) (sftp.ListerAt, error) {
+	l, err := c.list.Filelist(r)
+	return l, c.coarsen(err)
+}
+
+func (c *coarseStatus) Fileread(r *sftp.Request) (io.ReaderAt, error) {
+	f, err := c.get.Fileread(r)
+	return f, c.coarsen(err)
+}
+
+func (c *coarseStatus) Filewrite(r *sftp.Request) (io.WriterAt, error) {
+	f, err := c.put.Filewrite(r)
+	return f, c.coarsen(err)
 }
 
 // faultySetstat wraps a FileCmder and fails every chmod (Setstat) request,


### PR DESCRIPTION
Closes nothing on its own; `Refs #152`, whose step 3 stays open (see the end).

## What the issue claimed, and what is left of it

Issue #152 says every test talks to OpenSSH or an OpenSSH-shaped fake, and
names four assumptions that hold there and are not guaranteed elsewhere. Two
of them are already settled: `posix-rename@openssh.com` was fixed in #203, and
SETSTAT is best effort with a warn-once message per deployment. The remaining
two (directory semantics, paged `ReadDir`) I could not reproduce as a defect.

The class the issue is really about, though, does still bite, in a place it
did not name: **easySFTP accepted only OpenSSH's answer for "that path is not
there".** `SSH_FX_NO_SUCH_FILE` is what pkg/sftp turns into `os.ErrNotExist`,
and three code paths keyed off exactly that. On a server that answers the
generic `SSH_FX_FAILURE` instead, two of the three end the run:

| Case | Before |
| --- | --- |
| First `clean` deployment (the remote scan runs before the target exists) | fails with `scanning remote directory "<target>": ...`, having written nothing |
| `sync` deleting a file already removed on the server | fails with `deleting "<path>": ...`, leaving the deployment half done |
| First `sync` reading the manifest that cannot exist yet | warns `could not open sync manifest ...`, on every sync deployment, every run |

I reproduced all three against the in-process server before changing anything;
the first two are hard failures on a user's very first deploy.

## The fix

The same shape #203 chose: a second question rather than blanket tolerance. A
failed operation is followed by an `Lstat`, and only a server that has nothing
at the path gets the benign reading (`remoteAbsent` in
[remote.go](internal/uploader/remote.go)). Deliberate details:

- **`Lstat`, not `Stat`**: a dangling symlink is still an entry, and a delete
  that reported it gone would leave it behind.
- **A connection-class stat failure is returned, not answered**, so `sess.do`
  redials and reruns the idempotent operation instead of reading a dead
  connection as an empty server.
- **`SSH_FX_PERMISSION_DENIED` counts as present.** A server with a specific
  code for a refusal that chose to use it is being specific, not coarse, so
  the caller's original error is the one reported.
- **The stat runs only after something already failed**, so a server that does
  say `SSH_FX_NO_SUCH_FILE` pays no extra round-trip. Nothing in the sampled
  operation counts changes.

## Tests

Each tolerant case has a strict sibling, because the risk of this change is
that it degrades into "ignore every failure":

| Tolerant | Strict |
| --- | --- |
| clean into a target that is not there succeeds | a target that *is* there and will not be listed still fails the run, and its stale file survives |
| a delete that finds nothing counts as deleted | a file still present after a refused remove still fails the run and is not counted |
| a first sync says nothing about the manifest | a manifest that is there and cannot be read still warns |

New test-server profile `withCoarseStatus(code)` answers every missing path
with one generic code across all four handler roles, so a missing path looks
the same whether the run listed, stat'd, removed or opened it; the tolerant
cases run as a table over `SSH_FX_FAILURE` and `SSH_FX_BAD_MESSAGE`. Verified
the three tolerant tests fail on `main` and pass here.

One existing test moved: `TestReadManifestWarnsWhenOpenFails` never created
the manifest it expected a warning about, so its scenario was really "missing
*and* unreadable". It now seeds the file, which is the case its name means.

`ci.yml`'s self-test gains a first `clean` deployment into a target that does
not exist, against the real OpenSSH container: the fake server profile cannot
stand in for that path, and CI never covered it.

## What this is not

It is not issue #152's step 3 (one non-OpenSSH server in the self-test). The
maintainer's condition there was a pinned, maintainable image that catches
what protocol-level tests cannot, and I did not want to make that image choice
without being able to run it. What this does do is shrink the gap: the status
code divergence, which is what the two concrete failures above came from, is
now covered at the protocol level in both directions. #152 should stay open
for the container question.

`docs/providers.md` gains a "Status codes" paragraph under "What easySFTP
needs from a server", describing easySFTP's own behaviour only, with no
provider-specific claims.

## Verification

`gofmt`, `go vet ./...` and `go test ./...` are clean. **`go test -race` did
not run**: no C toolchain on this machine (`-race requires cgo`, then
`gcc not found`), so the race pass is CI's. Per `CLAUDE.md` this package is
the likely spot for races, though the change adds no concurrency: the new
round-trip runs inside an existing `sess.do` op on that op's own client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
