### PR TITLE
fix(uploader): stop counting on a runtime step no transfer can use

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,17 @@ The three stages and where they run:
 | 2, link | `newSession` via `probeLink` | the handshake it just paid, and an RTT from three `SSH_FXP_REALPATH` round-trips |
 | 3, runtime | `startTuningController` inside `uploadFiles` | the throughput the transfer is actually achieving |
 
+Stage 3 only reaches work that has not started (issue #217). A worker takes its
+connection in `session.acquire` when it picks up its file and keeps it for that
+file's whole transfer, so a spread change re-points the queue behind the workers
+and nothing else. Since `concurrency` is the item count capped at 64, a
+deployment of at most 64 files has no queue at all: `autotune.NewController`
+stops before a goroutine is started, `startTuningController` logs why at debug
+level, and stage 1 is the whole decision. That is also why `config_connections`
+(the spread the policy stood behind) and `connections_used` (the slots a file
+was really handed to) are different questions, and the benchmark's `auto[]`
+block records both.
+
 An overlay deployment with `advanced.skip_unchanged` is the case stage 1 cannot
 settle: the upload set is decided file by file while the run goes. It is
 planned as metadata only (`Workload.Unknown`), which is what keeps a redeploy

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -192,6 +192,7 @@ candidate build, and scores it against the grid:
 | `chosen` | the `connections`, `concurrency` and `request_concurrency` the run ended up using, read from its own counters rather than assumed |
 | `chosen.initial_*`, `chosen.changes` | what the policy picked before the transfer taught it anything, and how many times it moved the connection spread while the transfer ran; equal to `chosen` on a run the runtime stage left alone |
 | `chosen.spread_increases`, `chosen.spread_decreases`, `chosen.final_connections` | which way those changes went and where the run settled. A growth step that does not pay for itself is taken back without closing anything (issue #215), so the plain `connections` above is a high-water mark and this is the number the last deployment ran on |
+| `connections_opened`, `connections_used`, `connections_refused` | what the pool actually was: the handshakes the run paid, the slots a file was really handed to, and whether the server turned one down. A cell has carried these since #190; an auto row did not, which is how a spread nothing read could pass for a configuration that was measured (issue #217) |
 | `workload` | the features the policy was looking at: `files`, `bytes`, `largest_bytes`, `probes`, the shape of the set (`p50_bytes`, `p90_bytes`, `small_files`, the files that fit in one 32 KiB write packet), and the link it measured itself (`rtt_ms`, `handshake_ms`, and `stream_bytes_per_second` / `bdp_bytes` where a throughput was known) |
 | `median_ms`, `min_ms`, `max_ms`, `mad_ms`, `durations_ms`, `mib_per_s`, `files_per_s` | the same statistics a cell carries |
 | `best` | the fastest candidate cell of that scenario and profile |
@@ -205,7 +206,7 @@ a different measurement from `link.probes[]`, which comes from `cmd/linkprobe`
 and never goes through the uploader. Both are kept, because the interesting case
 is the one where they disagree.
 
-Four things about it:
+Five things about it:
 
 - **It is not a cell.** `auto` does not sit at a coordinate, it chooses one, so
   it stays out of `cells[]`, `scaling[]`, `comparison[]` and the CSV. A build
@@ -223,6 +224,15 @@ Four things about it:
   measured from its first byte, so there is nothing in it for the controller to
   react to. What `chosen.changes` records is that the controller acted; whether
   it acted well shows up in `median_ms` and nowhere else.
+- **`chosen.connections` is a setting, `connections_used` is an outcome.** A
+  file takes its connection when its worker picks it up and keeps it for the
+  whole transfer, so a spread raised after the last file started is a number no
+  transfer read. Where `connections_used` is below `chosen.connections` the
+  control cell is not the same configuration as the `auto` run and the regret
+  next to it is not measuring the policy: that is what the `mixed` row of
+  `matrix-20260821T123508Z-v3.6.0` turned out to be (issue #217). easySFTP no
+  longer takes such a step, so the two should now agree unless the server
+  refused a connection.
 
 The policy itself lives in `internal/autotune` (issues #209 and #215), and its own test
 replays it against every sweep committed here and fails when the regret goes

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -143,6 +143,30 @@ out that most files *are* changing, the ratio it observes in its first window
 tells it, and the pool widens: that correction is about how much work there
 turned out to be, so it applies whatever the files look like.
 
+#### What this stage cannot reach
+
+A file takes its connection when a worker picks it up and keeps it until that
+file is done. So what a change to the pool re-points is the *queue* behind the
+workers: the files that have not started yet. Nothing already transferring
+moves, in either direction.
+
+That decides when this stage matters at all. `concurrency` is the number of
+files being sent, capped at 64, so **a deployment of 64 files or fewer starts
+every one of them at once** and has no queue. Its pool is settled before the
+first byte moves and stays where the plan put it: there is nothing a new
+connection could be handed, and easySFTP stands the stage down rather than
+moving a number no transfer reads. With `log-level: debug` the run says so:
+
+```text
+auto tuning: no runtime changes this deployment (there are as many workers as files, so every file takes its connection at the start and the pool cannot grow into this deployment)
+```
+
+For those deployments stages 1 and 2 are the whole decision, and that includes
+a small `advanced.skip_unchanged` redeploy: the correction described just above
+needs files still waiting to be sent. The full decision is printed under
+`log-level: debug` (see "What you will see in the log"), and if the pool it
+chose is wrong for your server, `advanced.connections` overrides it.
+
 ## Overriding it
 
 Every setting is resolved on its own, so you can pin one and leave the rest
@@ -226,6 +250,11 @@ knowing:
   corrects the assumption. The cost of that is bounded by the handshakes
   themselves, which on a fast link are cheap, and a step that did not help is
   taken back within a window.
+- That correction is only available to deployments with more files than
+  workers, i.e. more than 64 files (see "What this stage cannot reach"). A
+  smaller deployment on a link the assumption fits badly keeps the pool its
+  plan chose for the whole transfer. It is bounded the same way, by a handful
+  of handshakes either way, but it is not corrected.
 - The bandwidth-delay product only sizes the pipelining once a throughput has
   been observed, and nothing observes one before the first byte moves. Today
   that means the conservative rule is what a normal run uses; the measured path

--- a/internal/autotune/autotune.go
+++ b/internal/autotune/autotune.go
@@ -30,6 +30,14 @@
 //     not pay for itself is taken back: the connections stay open, the files
 //     that are left simply stop being handed to them. See controller.go.
 //
+// Stage 3 only reaches work that has not started. A worker takes its connection
+// when it picks up its file and keeps it until that file is done, so a wider
+// pool is offered to the queue behind the workers and never to a transfer
+// already running. The worker count is the item count (capped), which means a
+// deployment of at most MaxConcurrency files starts every one of them at once
+// and has no queue at all: stage 1 is the whole decision there, and Controller
+// stands down instead of moving a number nothing reads (issue #217).
+//
 // # Why connections are the interesting knob
 //
 // Concurrency is free: a worker with no file to upload never starts, so the

--- a/internal/autotune/controller.go
+++ b/internal/autotune/controller.go
@@ -31,6 +31,13 @@ import (
 //     to be long enough, see enough files and carry enough bytes, and a byte
 //     rate is only read as a bandwidth when the files were large enough to
 //     produce one (issue #215, stage 6, and see bandwidthBound).
+//   - Neither direction reaches a file that is already on a connection. A
+//     worker takes its connection when it picks up its file and keeps it until
+//     that file is done, so what a spread change re-points is the *queue*
+//     behind the workers. A deployment whose worker count covers every file
+//     has no queue: it is decided before the first window closes, and this
+//     controller says so rather than reporting a step nobody could cash
+//     (issue #217, and see queued).
 //   - Concurrency never moves. Plan already sizes it to the number of
 //     independent items, which is the largest value that can ever be busy;
 //     there is nothing for a hill climb to find.
@@ -88,6 +95,11 @@ type Progress struct {
 	// have not. RemainingBytes is the planned size of those, which for an
 	// unsettled workload (skip_unchanged) is an upper bound rather than a
 	// promise.
+	//
+	// Remaining is the work that is left, not the work a wider pool could be
+	// given: most of it is already in flight on the connections it started on.
+	// What is still assignable is Remaining minus the workers, which is what
+	// Controller.queued computes (issue #217).
 	Uploaded       int
 	Skipped        int
 	Remaining      int
@@ -151,6 +163,11 @@ func NewController(w Workload, start Settings, l Link, f Fixed) *Controller {
 		c.stop("the pool is already at the policy maximum")
 	case start.Concurrency <= 1:
 		c.stop("only one file is in flight, so a second connection has nobody to serve")
+	case start.Concurrency >= w.Items():
+		// Every item starts at once, so every one of them is bound to a
+		// connection before this controller has seen anything. Growing the
+		// spread would move a number that no transfer reads (issue #217).
+		c.stop("there are as many workers as files, so every file takes its connection at the start and the pool cannot grow into this deployment")
 	}
 	return c
 }
@@ -246,15 +263,17 @@ func (c *Controller) Observe(p Progress) (Change, bool) {
 		}
 	}
 
-	if p.Remaining <= c.current.Connections {
-		// Fewer files left than connections in use: a new one would finish its
-		// handshake with nothing to carry. Checked after the validation above,
-		// so a step that has already been taken is still judged.
+	queued := c.queued(p)
+	if queued <= c.current.Connections {
+		// Nothing waiting behind the workers: every file that is left is
+		// already on the connection it started on, so a new one would finish
+		// its handshake with nothing to carry. Checked after the validation
+		// above, so a step that has already been taken is still judged.
 		return none, false
 	}
 
 	want := Plan(c.remaining(p), c.measuredLink(p, rate), c.fixed)
-	grown := min(want.Connections, c.current.Connections*growthFactor, MaxConnections, c.current.Concurrency, p.Remaining)
+	grown := min(want.Connections, c.current.Connections*growthFactor, MaxConnections, c.current.Concurrency, queued)
 	if grown <= c.current.Connections {
 		return none, false
 	}
@@ -263,6 +282,25 @@ func (c *Controller) Observe(p Progress) (Change, bool) {
 	c.current.Connections = grown
 	change.To = c.current
 	return change, true
+}
+
+// queued is how much of the work that is left a wider pool could still be
+// given: the files that have not been handed to a connection yet.
+//
+// A worker takes its connection when it picks up its file and keeps it for that
+// file's whole transfer, so a growth step re-points the queue and never a
+// transfer in flight. The upload loop keeps its workers full while anything is
+// left, which puts min(remaining, workers) files in flight and leaves the
+// difference queued behind them.
+//
+// Before issue #217 this read Remaining, the files that have not *finished*,
+// and so counted transfers that could not be moved as work a new connection
+// might take. That is how the stored 'mixed' sweep came to report a growth step
+// it never cashed: 56 files and 56 workers, every one of them bound to one of
+// six connections before the first window closed, and a spread raised to eight
+// that nothing ever read.
+func (c *Controller) queued(p Progress) int {
+	return max(p.Remaining-c.current.Concurrency, 0)
 }
 
 // eligible reports whether this report closes a window worth deciding on: long

--- a/internal/autotune/controller_test.go
+++ b/internal/autotune/controller_test.go
@@ -379,3 +379,85 @@ func TestAByteRateIsOnlyEvidenceWhenTheFilesCanFillAStream(t *testing.T) {
 		t.Error("600 MiB left over a link measured this slow is worth another connection")
 	}
 }
+
+// TestTheControllerStandsDownWhereItCannotBeCashed is issue #217. A spread
+// change re-points the files that have not been handed to a connection yet, so
+// a deployment with as many workers as files has nothing for it to re-point:
+// every file takes its connection when its worker starts, which is before the
+// first window can close.
+//
+// The stored 'mixed' sweep is the case. 56 files, 56 workers, six connections
+// chosen up front and a runtime step to eight that no transfer ever read: the
+// run reported connections=8 and took what six connections take.
+func TestTheControllerStandsDownWhereItCannotBeCashed(t *testing.T) {
+	mixed := autotune.Workload{
+		Uploads: 56, UploadBytes: 12 * MiB,
+		LargestUpload: 2 * MiB, P50Upload: 64 * KiB, P90Upload: MiB,
+	}
+
+	t.Run("as many workers as files", func(t *testing.T) {
+		c := autotune.NewController(mixed,
+			autotune.Settings{Connections: 6, Concurrency: 56, RequestConcurrency: 16},
+			house, autotune.Fixed{})
+		stopped, why := c.Stopped()
+		if !stopped {
+			t.Fatal("a deployment that starts every file at once has no queue for a wider pool to serve")
+		}
+		if !strings.Contains(why, "as many workers as files") {
+			t.Errorf("reason = %q, want it to name the worker count", why)
+		}
+		if _, ok := c.Observe(autotune.Progress{
+			Elapsed: 2 * time.Second, Uploaded: 20, Remaining: 36,
+			RemainingBytes: 8 * MiB, UploadedBytes: 4 * MiB,
+		}); ok {
+			t.Error("a stopped controller reported a change the transfer could not use")
+		}
+	})
+
+	// The same payload behind fewer workers does have a queue, and the runtime
+	// stage is worth running: this is what keeps the stop above from being a
+	// blanket switch-off.
+	t.Run("a queue behind the workers", func(t *testing.T) {
+		c := autotune.NewController(mixed,
+			autotune.Settings{Connections: 1, Concurrency: 8, RequestConcurrency: 16},
+			house, autotune.Fixed{})
+		if stopped, why := c.Stopped(); stopped {
+			t.Fatalf("48 files queued behind 8 workers is work a wider pool can take: %s", why)
+		}
+		if _, ok := c.Observe(autotune.Progress{
+			Elapsed: 2 * time.Second, Uploaded: 8, Remaining: 48,
+			RemainingBytes: 10 * MiB, UploadedBytes: 2 * MiB,
+		}); !ok {
+			t.Error("a stream this slow with 40 files still queued must widen the pool")
+		}
+	})
+}
+
+// TestGrowthNeedsFilesThatHaveNotStarted is the same rule inside a running
+// phase. A pool may not grow into the tail of a deployment whose remaining
+// files are all already in flight, however many of them there are: they are
+// bound to the connections they started on and cannot be moved.
+func TestGrowthNeedsFilesThatHaveNotStarted(t *testing.T) {
+	c := autotune.NewController(byteHeavy, start, house, autotune.Fixed{})
+
+	// 64 workers and 64 files left: the queue is empty even though the phase
+	// still has a tenth of its bytes to move.
+	if change, ok := c.Observe(autotune.Progress{
+		Elapsed: 2 * time.Second, Uploaded: 936, Remaining: 64,
+		RemainingBytes: 64 * MiB, UploadedBytes: 100 * MiB,
+	}); ok {
+		t.Errorf("the pool grew into files that are all already on a connection: %+v", change)
+	}
+	if c.Settings().Connections != start.Connections {
+		t.Errorf("connections = %d, want the pre-transfer choice left alone", c.Settings().Connections)
+	}
+
+	// One more file than there are workers, and the same window is worth
+	// acting on again.
+	if _, ok := c.Observe(autotune.Progress{
+		Elapsed: 4 * time.Second, Uploaded: 940, Remaining: 500,
+		RemainingBytes: 500 * MiB, UploadedBytes: 200 * MiB,
+	}); !ok {
+		t.Error("with files queued behind the workers the pool must still be allowed to grow")
+	}
+}

--- a/internal/autotune/regret_test.go
+++ b/internal/autotune/regret_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -41,6 +42,12 @@ import (
 // configuration measured from its first byte, so there is nothing in it for
 // the runtime controller to react to; what the controller adds is on top of
 // the numbers below, not in them.
+//
+// It also cannot score a coordinate the grid does not contain. nearest snaps to
+// the closest measured neighbour, ties going up, so a choice between two swept
+// values is credited with one of them; snapNote prints the bracket, and where
+// that bracket is wide the percentage next to it is not a measurement of the
+// policy (issue #217).
 //
 // When this fails after a policy change, read the per-scenario table it
 // prints: it names the cell the policy chose, the cell that won, and the two
@@ -88,10 +95,10 @@ func TestPolicyRegretAgainstStoredSweeps(t *testing.T) {
 				gap := time.Duration(at.MedianMS-best.MedianMS) * time.Millisecond
 				regret := at.MedianMS/best.MedianMS - 1
 
-				t.Logf("%-16s chose %d/%d/%s -> %s, best %d/%d/%s -> %s, regret %+.1f%%",
+				t.Logf("%-16s chose %d/%d/%s -> %s, best %d/%d/%s -> %s, regret %+.1f%%%s",
 					group.scenario, chosen.Connections, chosen.Concurrency, request(chosen.RequestConcurrency),
 					ms(at.MedianMS), best.Connections, best.Concurrency, requestOf(best.RequestConcurrency),
-					ms(best.MedianMS), regret*100)
+					ms(best.MedianMS), regret*100, group.snapNote(chosen, at))
 
 				if regret > regretTarget && gap > trivialGap {
 					t.Errorf("%s: the policy is %.1f%% (%s) behind the fastest cell, over the %.0f%% target",
@@ -292,6 +299,36 @@ func (g cellGroup) best() schema.Cell {
 // closest this replay can get to what the run would have done.
 func (g cellGroup) nearest(s autotune.Settings) (schema.Cell, bool) {
 	conns := axis(g.cells, func(c schema.Cell) int { return c.Connections })
+	return g.cellAt(snap(conns, s.Connections), s)
+}
+
+// snapNote says what a scored row is hiding when the policy's connection count
+// is not on the grid: which cell it was actually scored at, and what the cell
+// below the choice measured.
+//
+// It is a log line rather than a rule because the replay has no better answer
+// available, but a reader has to know it is reading one. The stored 'mixed'
+// sweep is why: 6 connections on a grid of 1/2/4/8 snapped up to the 8 column
+// and came out 1.3% behind the best cell, while the run really measured at
+// those settings was 30% behind it (issue #217). The bracket makes that gap
+// visible without inventing a number for a coordinate nobody swept.
+func (g cellGroup) snapNote(s autotune.Settings, at schema.Cell) string {
+	conns := axis(g.cells, func(c schema.Cell) int { return c.Connections })
+	if slices.Contains(conns, s.Connections) {
+		return ""
+	}
+	note := fmt.Sprintf("  [%d connections were not swept; scored at %d", s.Connections, at.Connections)
+	if lower, ok := largestBelow(conns, s.Connections); ok {
+		if cell, found := g.cellAt(lower, s); found {
+			note += fmt.Sprintf(", %d took %s", lower, ms(cell.MedianMS))
+		}
+	}
+	return note + "]"
+}
+
+// cellAt is the measured cell at one connection count, with the other two axes
+// snapped to values the grid has.
+func (g cellGroup) cellAt(connections int, s autotune.Settings) (schema.Cell, bool) {
 	concs := axis(g.cells, func(c schema.Cell) int { return c.Concurrency })
 	var requests []int
 	for _, c := range g.cells {
@@ -301,7 +338,7 @@ func (g cellGroup) nearest(s autotune.Settings) (schema.Cell, bool) {
 	}
 	requests = dedup(requests)
 
-	wantConn, wantConc := snap(conns, s.Connections), snap(concs, s.Concurrency)
+	wantConn, wantConc := connections, snap(concs, s.Concurrency)
 	var wantRequest *int
 	if len(requests) > 0 {
 		r := snap(requests, s.RequestConcurrency)
@@ -341,6 +378,18 @@ func dedup(values []int) []int {
 	}
 	sort.Ints(out)
 	return out
+}
+
+// largestBelow is the largest measured value strictly under want, which is the
+// neighbour a choice cannot claim the benefit of.
+func largestBelow(values []int, want int) (int, bool) {
+	best, found := 0, false
+	for _, v := range values {
+		if v < want && (!found || v > best) {
+			best, found = v, true
+		}
+	}
+	return best, found
 }
 
 func snap(values []int, want int) int {

--- a/internal/benchmark/aggregate_test.go
+++ b/internal/benchmark/aggregate_test.go
@@ -195,6 +195,59 @@ func TestAutoIsNotACell(t *testing.T) {
 	}
 }
 
+// TestAutoRecordsWhatCarriedTheTransfer is issue #217. The spread the policy
+// stood behind and the connections a file was really handed to are two
+// different numbers, and only the second one describes the transfer that was
+// measured. A cell has carried connections_opened/connections_used since #190;
+// without them on the auto row, a growth step no transfer could use reads
+// exactly like one that worked, and the control cell next to it silently
+// compares two different configurations.
+func TestAutoRecordsWhatCarriedTheTransfer(t *testing.T) {
+	// The stored 'mixed' shape: six connections chosen, a runtime step to eight
+	// taken after all 56 files had already taken their connection, six
+	// connections carrying the whole transfer.
+	autoRun := run("mixed", "candidate", 1, 15842, metrics(nil, map[string]float64{
+		"config_connections": 8, "config_concurrency": 56, "config_request_concurrency": 16,
+		"auto_initial_connections": 6, "auto_changes": 1, "auto_final_connections": 8,
+		"connections_opened": 6, "connections_used": 6, "connections_refused": 0,
+	}))
+	cell := func(conns int, duration float64) RunRecord {
+		conc := 56
+		r := run("mixed", "candidate", 1, duration, metrics(nil, map[string]float64{
+			"config_connections": float64(conns), "config_concurrency": float64(conc),
+			"config_request_concurrency": 16,
+		}))
+		r.Connections, r.Concurrency = &conns, &conc
+		return r
+	}
+
+	in := &Inputs{Runs: []RunRecord{cell(4, 15400), cell(8, 12478)}, Auto: []RunRecord{autoRun}}
+	result := BuildMatrix(&Manifest{Kind: schema.BenchmarkMatrix, ReferenceLabel: "candidate", Grid: &ManifestGrid{}}, in)
+
+	if len(result.Auto) != 1 {
+		t.Fatalf("got %d auto rows, want 1", len(result.Auto))
+	}
+	a := result.Auto[0]
+	if got := stats.Or(a.ConnectionsUsed, 0); got != 6 {
+		t.Errorf("connections_used = %v, want the 6 slots the run handed a file to", got)
+	}
+	if got := stats.Or(a.ConnectionsOpened, 0); got != 6 {
+		t.Errorf("connections_opened = %v, want the 6 handshakes the run paid", got)
+	}
+	if got := stats.Or(a.ConnectionsRefused, 0); got != 0 {
+		t.Errorf("connections_refused = %v, want 0: the server refused nothing here", got)
+	}
+	// And the gap is readable: the run reported eight and eight is on this grid,
+	// so the control fires against a cell the transfer never ran at.
+	if stats.Or(a.Chosen.Connections, 0) != 8 || !a.ChosenInGrid {
+		t.Fatalf("chosen = %v (in grid: %v), want the reported 8 found on the grid",
+			stats.Or(a.Chosen.Connections, 0), a.ChosenInGrid)
+	}
+	if stats.Or(a.ConnectionsUsed, 0) >= stats.Or(a.Chosen.Connections, 0) {
+		t.Error("the two numbers agree, so this row would not show the mismatch it exists to show")
+	}
+}
+
 // TestBestOnTheLargestSweptValueIsReported is the honesty check the auto-config
 // work rests on: an optimum sitting on the edge of an axis was cut off, not
 // measured. An axis with a single swept value has no edge and is not reported.

--- a/internal/benchmark/matrix.go
+++ b/internal/benchmark/matrix.go
@@ -350,9 +350,19 @@ func matrixAuto(runs []RunRecord, cells []schema.Cell) []schema.Auto {
 			MaxMS:       stats.Or(stats.Max(stats.Nums(durations)), 0),
 			MadMS:       stats.Mad(durations),
 			Chosen:      chosen,
-			Workload:    workload,
-			MiBPerS:     stats.MiBPerS(bytes, median),
-			FilesPerS:   stats.Ratio(files, median),
+
+			// What the pool turned out to be. Chosen.Connections is the
+			// spread the policy stood behind; these are the slots a file was
+			// handed to and the handshakes paid for them, which is not the
+			// same number when the spread moved after the last file had
+			// started (issue #217).
+			ConnectionsOpened:  stats.Median(counterValues(ms, "connections_opened")),
+			ConnectionsUsed:    stats.Median(counterValues(ms, "connections_used")),
+			ConnectionsRefused: stats.Median(counterValues(ms, "connections_refused")),
+
+			Workload:  workload,
+			MiBPerS:   stats.MiBPerS(bytes, median),
+			FilesPerS: stats.Ratio(files, median),
 		}
 
 		// Scored against the candidate build only: a regret against a baseline

--- a/internal/benchmark/report/matrix.go
+++ b/internal/benchmark/report/matrix.go
@@ -280,6 +280,29 @@ func changeSummary(c schema.Chosen) string {
 	return fmt.Sprintf("%s (+%s/-%s)", total, raw(c.SpreadIncreases), raw(c.SpreadDecreases))
 }
 
+// carriedSummary renders what the pool actually was: the slots a file was
+// handed to over the handshakes paid for them, flagged when that is short of
+// what the run reported picking.
+//
+// The two numbers are not decoration. An auto row whose Carried is below its
+// Picked did not run at its own coordinates, which makes the control cell next
+// to it a comparison between two different configurations; that is exactly how
+// the stored 'mixed' sweep came to read 30% slower than "the same" cell
+// (issue #217).
+func carriedSummary(a schema.Auto) string {
+	if a.ConnectionsUsed == nil && a.ConnectionsOpened == nil {
+		return "-"
+	}
+	out := raw(a.ConnectionsUsed) + "/" + raw(a.ConnectionsOpened)
+	if a.ConnectionsUsed != nil && a.Chosen.Connections != nil && *a.ConnectionsUsed < *a.Chosen.Connections {
+		out += " (short)"
+	}
+	if a.ConnectionsRefused != nil && *a.ConnectionsRefused > 0 {
+		out += " refused " + raw(a.ConnectionsRefused)
+	}
+	return out
+}
+
 func (m Matrix) autoCost(b *buf) {
 	b.line("")
 	b.line("### What `auto` costs (policy regret)")
@@ -288,8 +311,8 @@ func (m Matrix) autoCost(b *buf) {
 	// a bare string here as a format.
 	b.line("%s", "One run per scenario and profile with `connections`, `concurrency` and `request_concurrency` all set to `auto`, on the candidate build, measured next to the cells it is scored against. `Picked` is read out of the run's own counters, so it is what easySFTP did and not what this script assumes; `Best` is the fastest cell of the same scenario and profile. `Regret` is the gap between them: how much slower the policy is than the settings a sweep would have chosen. A policy within ~15% on every profile is defensible, one that only wins on the house line is not (issue #184, phase 5; the policy itself is #209).")
 	b.line("")
-	b.line("| Scenario | Profile | Picked (conn/conc/req) | Started at | Changes | auto | Best cell | Best | Regret | Same cell in grid |")
-	b.line("|---|---|---|---|---|---|---|---|---|---|")
+	b.line("| Scenario | Profile | Picked (conn/conc/req) | Started at | Changes | Carried | auto | Best cell | Best | Regret | Same cell in grid |")
+	b.line("|---|---|---|---|---|---|---|---|---|---|---|")
 	for _, a := range m.Result.Auto {
 		best := "-"
 		bestMS := "-"
@@ -302,15 +325,15 @@ func (m Matrix) autoCost(b *buf) {
 		if a.ChosenInGrid {
 			inGrid = raw(a.ChosenCellMedianMS) + " ms"
 		}
-		b.line("| %s | %s | %s/%s/%s | %s/%s/%s | %s | %s ms | %s | %s | %s | %s |",
+		b.line("| %s | %s | %s/%s/%s | %s/%s/%s | %s | %s | %s ms | %s | %s | %s | %s |",
 			a.Scenario, a.LinkProfile,
 			raw(a.Chosen.Connections), raw(a.Chosen.Concurrency), raw(a.Chosen.RequestConcurrency),
 			raw(a.Chosen.InitialConnections), raw(a.Chosen.InitialConcurrency), raw(a.Chosen.InitialRequestConcurrency),
-			changeSummary(a.Chosen),
+			changeSummary(a.Chosen), carriedSummary(a),
 			num(a.MedianMS), best, bestMS, percent(a.RegretPercent), inGrid)
 	}
 	b.line("")
-	b.line("`Started at` is what the policy chose before the transfer taught it anything, and `Changes` how many times it moved the connection spread while the transfer ran, as `total (+up/-down)`: a step back leaves the connections open and hands the remaining files to fewer of them (issue #215). When the two coordinate columns agree, the run was decided entirely up front. The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the `auto` column means the two runs saw different conditions, and then the regret next to it is drift rather than policy. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all.")
+	b.line("`Started at` is what the policy chose before the transfer taught it anything, and `Changes` how many times it moved the connection spread while the transfer ran, as `total (+up/-down)`: a step back leaves the connections open and hands the remaining files to fewer of them (issue #215). When the two coordinate columns agree, the run was decided entirely up front. `Carried` is how many pool slots a file was actually handed to, and the handshakes behind them, marked `(short)` where that is fewer than `Picked`: a file takes its connection when its worker picks it up, so a spread raised after the last file had started is a number no transfer read (issue #217). The last column is the same coordinates measured as an ordinary cell. It is a control, not a result: a large gap between it and the `auto` column means the two runs saw different conditions, or, where `Carried` is short of `Picked`, that the two are not the same configuration after all. Where it says \"not swept\", the settings easySFTP picked are not on this grid at all.")
 	m.autoWorkload(b)
 }
 

--- a/internal/benchmark/schema/matrix.go
+++ b/internal/benchmark/schema/matrix.go
@@ -180,6 +180,21 @@ type Auto struct {
 	// did rather than what the script believes it does.
 	Chosen Chosen `json:"chosen"`
 
+	// What the pool actually was, next to what Chosen says it was set to. A
+	// cell has carried these since #190; an auto row did not, and that is what
+	// let the stored 'mixed' sweep report eight connections for a transfer six
+	// of them carried (issue #217).
+	//
+	// ConnectionsUsed counts the pool slots a file was really handed to and
+	// ConnectionsOpened the handshakes behind them. Below Chosen.Connections
+	// they mean the spread moved after the last file had already taken its
+	// connection, or, with ConnectionsRefused above zero, that the server would
+	// not give the run what it asked for. Null for every result stored before
+	// this block read them.
+	ConnectionsOpened  *float64 `json:"connections_opened,omitzero"`
+	ConnectionsUsed    *float64 `json:"connections_used,omitzero"`
+	ConnectionsRefused *float64 `json:"connections_refused,omitzero"`
+
 	// Workload is what the policy was looking at when it chose (issue #209).
 	// Null for the sweeps stored before the policy existed, where "auto" was a
 	// fixed 1/4/16 and there was nothing to record.

--- a/internal/uploader/autotune_test.go
+++ b/internal/uploader/autotune_test.go
@@ -515,3 +515,92 @@ func TestTheLinkProbeMeasuresAServerFasterThanTheClock(t *testing.T) {
 		t.Errorf("RTT %v is longer than the whole handshake %v, which cannot be right", link.RTT, link.Handshake)
 	}
 }
+
+// TestAWiderPoolOnlyReachesFilesThatHaveNotStarted is the mechanism behind
+// issue #217, in the one place it lives: a file takes its connection in
+// session.acquire, once, when its worker picks it up, and keeps it for the
+// whole transfer. Raising the spread therefore points the *next* acquire
+// somewhere else and cannot move a byte of what is already running.
+//
+// The stored 'mixed' sweep is what that costs when it goes unnoticed. Its 56
+// files run under 56 workers, so all 56 are bound before the controller's first
+// window closes; the step from six connections to eight was recorded as a
+// change, dialed nothing, and the run took what six connections take while
+// reporting eight.
+func TestAWiderPoolOnlyReachesFilesThatHaveNotStarted(t *testing.T) {
+	srv := startTestServer(t)
+	cfg := autoConfig(srv)
+	tune := newTuning(cfg)
+	tune.resolveRunWide(autotune.Workload{Uploads: 56, UploadBytes: 12 << 20, LargestUpload: 2 << 20})
+
+	sess, err := newSession(context.Background(), cfg, tune, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.close()
+
+	// Six files handed out over the two connections the deployment started on.
+	sess.setSpread(2)
+	for i := range 6 {
+		if client, _, _ := sess.acquire(i); client == nil {
+			t.Fatalf("acquire(%d) returned no client", i)
+		}
+	}
+	bound := atomic.LoadInt32(&srv.accepted)
+	if bound != 2 {
+		t.Fatalf("the server saw %d connection(s) for a spread of 2, want 2", bound)
+	}
+
+	// The growth step the runtime stage would take. Nothing is dialed, because
+	// there is no file left to dial it for.
+	if got := sess.setSpread(4); got != 4 {
+		t.Fatalf("setSpread(4) = %d, want the pool to widen", got)
+	}
+	if got := atomic.LoadInt32(&srv.accepted); got != bound {
+		t.Errorf("widening the spread dialed %d connection(s) with every file already bound, want none", got-bound)
+	}
+
+	// And the same step lands the moment there is a file that has not started.
+	for i := 6; i < 8; i++ {
+		if client, _, _ := sess.acquire(i); client == nil {
+			t.Fatalf("acquire(%d) returned no client", i)
+		}
+	}
+	if got := atomic.LoadInt32(&srv.accepted); got != bound+2 {
+		t.Errorf("the server saw %d connection(s) after two more files, want %d: growth reaches the queue and only the queue",
+			got, bound+2)
+	}
+}
+
+// TestTheRuntimeStageDoesNotStartWhereItCannotHelp is the answer to that from
+// the policy's side: a deployment with as many workers as files is decided by
+// the plan alone, and a run that says so under debug is a run whose counters
+// can be believed (issue #217).
+func TestTheRuntimeStageDoesNotStartWhereItCannotHelp(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 6)
+
+	cfg := autoConfig(srv)
+	cfg.LogLevel = config.LogDebug
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	stats, err := Run(context.Background(), cfg, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesUploaded != 6 {
+		t.Fatalf("uploaded %d file(s), want 6", stats.FilesUploaded)
+	}
+	line, ok := findLine(log.infos, "no runtime changes this deployment")
+	if !ok {
+		t.Fatalf("a deployment the runtime stage cannot move must say so at debug level: %v", log.infos)
+	}
+	if !strings.Contains(line, "as many workers as files") {
+		t.Errorf("the reason does not name the cause: %s", line)
+	}
+	if _, ok := findLine(log.infos, "raising connections"); ok {
+		t.Errorf("a deployment with no queue reported a growth step: %v", log.infos)
+	}
+}

--- a/internal/uploader/tuning.go
+++ b/internal/uploader/tuning.go
@@ -494,6 +494,11 @@ func (p *uploadProgress) snapshot(elapsed time.Duration, refused bool) autotune.
 // help. The returned function stops the watcher and must be called before the
 // phase ends.
 //
+// For many deployments there is nothing to watch, and the controller says so
+// before a goroutine is started: the settings are pinned, the pool is already
+// at its ceiling, or the deployment hands every file to a connection the
+// moment it starts (issue #217, and see autotune.NewController).
+//
 // Only the pool moves; see the comment on autotune.Controller for why the
 // other two settings are already where they belong. Both directions go through
 // session.setSpread, which points the next files at a different number of
@@ -506,7 +511,15 @@ func (p *uploadProgress) snapshot(elapsed time.Duration, refused bool) autotune.
 // them (autotune.Controller.bandwidthBound).
 func startTuningController(ctx context.Context, sess *session, w autotune.Workload, start autotune.Settings, prog *uploadProgress, log Logger) func() {
 	ctrl := autotune.NewController(w, start, sess.tune.currentLink(), sess.tune.fixed)
-	if stopped, _ := ctrl.Stopped(); stopped {
+	if stopped, why := ctrl.Stopped(); stopped {
+		// A stage that never runs and a stage that ran and changed nothing
+		// leave the same counters behind, so the difference has to be said out
+		// loud somewhere. Debug level, because the answer is "the plan was the
+		// whole decision" and that is what the plan line above already says
+		// (issue #217).
+		if why != "" && sess.cfg.Debug() {
+			log.Infof("auto tuning: no runtime changes this deployment (%s)", why)
+		}
 		return func() {}
 	}
 	done := make(chan struct{})


### PR DESCRIPTION
Closes #217.

## What the hypothesis turned out to be

Confirmed, and it is the whole of the 30%.

A file takes its connection in `session.acquire`, once, when its worker picks it up, and keeps it for that file's whole transfer. So `setSpread` re-points the *queue* behind the workers and nothing else. `advanced.concurrency` at auto is the item count capped at 64, which means **a deployment of at most 64 files starts every one of them at once and has no queue at all**: the pool it starts with is the pool that carries it.

`mixed` has 56 files and 56 workers. It chose six connections, raised the spread to eight after every file had already taken its connection, and reported eight for a transfer six of them carried. Its `auto` row was then scored against the 8/56 cell, so `chosen_cell_median_ms` compared two different configurations and the 30% gap was the difference between them.

Three independent things say so:

- Every scenario whose auto row *beats* or matches its cell has more files than workers (`calib-100x64k` 100, `deep` 400, `bulk` 2000). The only one that does not is `mixed`.
- The measured 15842 ms sits between the 4-connection column (~15.4 s) and the 8-connection column (~13.1 s), which is what six connections look like.
- Replaying the policy against the stored grid but scoring `mixed` at the cell *below* its choice instead of the one above gives 17447 ms and +34.3% regret, bracketing the 15842 ms the run actually took. The current replay snaps 6 up to 8 and reports +1.3%, which is why the offline guard never saw this.

`internal/uploader.TestAWiderPoolOnlyReachesFilesThatHaveNotStarted` pins the mechanism directly, without the benchmark host: six files bound over a spread of two, the spread raised to four, nothing dialed, and then two more files and the two new connections appear.

## What this changes

**The policy stops taking a step it cannot cash.**

- `autotune.NewController` stands stage 3 down when the worker count covers every item, and says why. No goroutine, no phantom `changes: 1`, no spread that nothing reads.
- `Observe`'s "is there anything left for a new connection" check now reads the files that have not *started* (`remaining - workers`) rather than the files that have not *finished*, so the same rule holds inside a phase whose queue has drained. The growth step is capped by that number too.
- `startTuningController` logs the reason at debug level. A stage that never ran and a stage that ran and changed nothing leave identical counters behind, so the difference has to be said somewhere.

**The measurement stops overstating.**

- The `auto[]` block carries `connections_opened`, `connections_used` and `connections_refused`, which `cells[]` has had since #190. That asymmetry is what let a spread nothing read pass for a configuration that was measured; it works on re-aggregation of old artifacts too, since the counters were always in the per-run metrics.
- The Markdown auto table gains a `Carried` column, marked `(short)` when the pool was smaller than what the row reports picking, and the paragraph under it says what that means for the control cell next to it.
- The policy replay prints the bracket when it scores a connection count the grid never swept (`[6 connections were not swept; scored at 8, 4 took 17447 ms]`) instead of silently crediting the neighbour above it.

**And it is written down.** `docs/tuning.md` gains "What this stage cannot reach" under stage 3 and a bullet under Limits; `benchmarks/README.md` gains the field and a fifth bullet on `chosen.connections` being a setting while `connections_used` is an outcome; `CLAUDE.md` gains the same in two sentences next to the stage table.

## What this deliberately does not change

The remaining gap on `mixed` is the *initial* choice of six, and six is what `k = round(sqrt(W/H))` gives when `W` is computed from a throughput prior that is about 2.7x optimistic for that line. At the measured 0.36 MiB/s per stream the same formula gives 9, clamped to 8, which is the fastest cell. That is issue #212's cached prior, and refitting the prior here would be a policy change validated against a replay of two sweeps rather than against a measurement. The issue says the same thing, so this PR leaves it there and makes the run honest about what it did instead.

For the same reason the replay's `nearest` still snaps up: scoring `mixed` at its lower neighbour is the more truthful reading, but it turns `TestPolicyRegretAgainstStoredSweeps` red on a miss this PR is not fixing. The bracket is printed so the next one cannot hide.

One behaviour is genuinely given up: a deployment of at most 64 files no longer gets a runtime correction it could occasionally land, because the pool's handshakes are serialized under the session lock and a worker still blocked behind one would have picked up the new spread. That was worth nothing measurable (`mixed` recorded the change and took what six connections take) and cost a handshake in the run's critical path.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` are green. `go test -race` could not run here (`-race requires cgo`, and this machine has no C toolchain), so the race pass is CI's; the change adds no new shared state, only a different arithmetic in a struct the controller goroutine already owned.

New tests:

- `autotune.TestTheControllerStandsDownWhereItCannotBeCashed` (as many workers as files stands the stage down; the same payload behind fewer workers still runs it)
- `autotune.TestGrowthNeedsFilesThatHaveNotStarted` (the same rule inside a running phase)
- `uploader.TestAWiderPoolOnlyReachesFilesThatHaveNotStarted` (the mechanism)
- `uploader.TestTheRuntimeStageDoesNotStartWhereItCannotHelp` (a real run says so at debug level and reports no growth)
- `benchmark.TestAutoRecordsWhatCarriedTheTransfer` (the auto row reads the counters back, and the stored `mixed` shape is visible in it)

The stored results are untouched, and `schema`'s fixture test still decodes every one of them strictly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
