### PR TITLE
feat(tuning): remember a measurement between runs, never a decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,8 @@ jobs:
             echo '    source: ./selftest-docs/'
             echo '    target: /upload/cfg-docs/'
             echo '    mode: clean'
+            echo 'advanced:'
+            echo '  auto_cache: selftest-cache/auto.json'
           } > selftest-config.yml
           cat selftest-config.yml
 
@@ -328,6 +330,37 @@ jobs:
             exit 1
           fi
           [ "${{ steps.cfgfile.outputs.files-uploaded }}" = "3" ]
+
+      # The auto-tuning cache (issue #212) end to end. Unit tests cover the
+      # record's rules against an in-process server that is a socket away and
+      # can therefore never produce a throughput; what only a real run can show
+      # is that the file is written at all, in a directory that did not exist,
+      # and that it carries the link the probe measured. A second deploy must
+      # update that one record rather than file another.
+      - name: Verify the auto-tuning cache was written
+        run: |
+          cat selftest-cache/auto.json
+          jq -e '.version == 1
+                 and (.records | length) == 1
+                 and .records[0].policy_version >= 1
+                 and .records[0].workload.files == 3
+                 and .records[0].link.rtt_ms > 0
+                 and .records[0].link.handshake_ms > 0
+                 and .records[0].settings.connections >= 1' selftest-cache/auto.json
+          # An atomic write leaves no debris next to the file; the whole
+          # directory is what a CI cache would carry between runs.
+          [ "$(ls selftest-cache | wc -l)" = "1" ]
+
+      - name: Deploy via config file again
+        uses: ./
+        with:
+          password: demopass
+          config: selftest-config.yml
+
+      - name: Verify the second run reused the same record
+        run: |
+          cat selftest-cache/auto.json
+          jq -e '(.records | length) == 1 and .records[0].workload.files == 3' selftest-cache/auto.json
 
       # sync round-trip against a real OpenSSH server: manifest written,
       # read back on the next run, deletions tracked, unchanged files skipped.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,44 @@ discriminating. **Changing a constant in `internal/autotune` means running that
 test**, and a new stored sweep that fails it means the policy needs refitting,
 not that the test needs relaxing.
 
+## Remembering a measurement between runs (`internal/autocache`)
+
+`advanced.auto_cache` names a local file where a run records what it measured
+about its server, so the next run plans from a measurement instead of from the
+prior. It is off unless the config file names a path, and it is the one place
+where a decision made in an earlier run can reach this one. Four rules keep
+that from turning into stale configuration (issue #212):
+
+1. **Settings are stored but never restored.** `autotune.Plan` is pure and
+   costs microseconds, so memoizing its output would save nothing and would
+   preserve an answer for a deploy that no longer exists. What a hit supplies
+   is an *input*: the per-connection throughput (as `autotune.SourceCached`,
+   which a runtime measurement of the transfer still outranks) and a
+   connection ceiling the cost model cannot derive, because it assumes perfect
+   scaling.
+2. **Records are anchored.** A record describes the workload its measurement
+   was taken on, and a run that only *uses* a record rewrites neither that
+   anchor nor the stored link; only a run that measures the link itself does
+   (`Store.Update`). Comparing each run against the one before it would hit
+   forever for a dataset that grows a per cent at a time, which is the failure
+   mode this whole package is shaped around.
+   `internal/autocache/drift_test.go` replays both readings over the same
+   sequence of deploys and is the acceptance test for it.
+3. **The RTT measured now is the validation.** `Candidate.Validate` compares
+   the probe's answer against the record's. It costs nothing (the probe runs
+   anyway) and it is the only gate backed by a measurement taken today.
+4. **A ceiling is let go.** A pool capped at a remembered limit never asks for
+   more and so never finds out whether the limit is still there, so an
+   untested ceiling is carried at most `MaxCeilingCarry` runs.
+
+Two more things to know before changing anything here. `request_concurrency`
+is deliberately outside the cache's reach: it is baked into an SFTP client at
+creation, so it must be resolved before there is a connection and therefore
+before a record can be checked against the link. And `autotune.PolicyVersion`
+is bumped when a change makes an older stored *measurement* mean something
+different (a different definition of what counts as one, a different meaning
+for a workload feature), not merely when it changes what the policy decides.
+
 ## Testing quirks
 
 - `internal/uploader/testserver_test.go` runs an in-process SSH/SFTP server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,44 @@ discriminating. **Changing a constant in `internal/autotune` means running that
 test**, and a new stored sweep that fails it means the policy needs refitting,
 not that the test needs relaxing.
 
+## Remembering a measurement between runs (`internal/autocache`)
+
+`advanced.auto_cache` names a local file where a run records what it measured
+about its server, so the next run plans from a measurement instead of from the
+prior. It is off unless the config file names a path, and it is the one place
+where a decision made in an earlier run can reach this one. Four rules keep
+that from turning into stale configuration (issue #212):
+
+1. **Settings are stored but never restored.** `autotune.Plan` is pure and
+   costs microseconds, so memoizing its output would save nothing and would
+   preserve an answer for a deploy that no longer exists. What a hit supplies
+   is an *input*: the per-connection throughput (as `autotune.SourceCached`,
+   which a runtime measurement of the transfer still outranks) and a
+   connection ceiling the cost model cannot derive, because it assumes perfect
+   scaling.
+2. **Records are anchored.** A record describes the workload its measurement
+   was taken on, and a run that only *uses* a record rewrites neither that
+   anchor nor the stored link; only a run that measures the link itself does
+   (`Store.Update`). Comparing each run against the one before it would hit
+   forever for a dataset that grows a per cent at a time, which is the failure
+   mode this whole package is shaped around.
+   `internal/autocache/drift_test.go` replays both readings over the same
+   sequence of deploys and is the acceptance test for it.
+3. **The RTT measured now is the validation.** `Candidate.Validate` compares
+   the probe's answer against the record's. It costs nothing (the probe runs
+   anyway) and it is the only gate backed by a measurement taken today.
+4. **A ceiling is let go.** A pool capped at a remembered limit never asks for
+   more and so never finds out whether the limit is still there, so an
+   untested ceiling is carried at most `MaxCeilingCarry` runs.
+
+Two more things to know before changing anything here. `request_concurrency`
+is deliberately outside the cache's reach: it is baked into an SFTP client at
+creation, so it must be resolved before there is a connection and therefore
+before a record can be checked against the link. And `autotune.PolicyVersion`
+is bumped when a change makes an older stored *measurement* mean something
+different (a different definition of what counts as one, a different meaning
+for a workload feature), not merely when it changes what the policy decides.
+
 ## Testing quirks
 
 - `internal/uploader/testserver_test.go` runs an in-process SSH/SFTP server

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 | Document | What's in it |
 |---|---|
 | [Configuration reference](configuration.md) | Every input, output, exclude patterns and the YAML config file. |
-| [Transfer tuning](tuning.md) | What `auto` does for `connections`, `concurrency` and `request_concurrency`, and when to override it. |
+| [Transfer tuning](tuning.md) | What `auto` does for `connections`, `concurrency` and `request_concurrency`, when to override it, and how `advanced.auto_cache` carries a measurement to the next run. |
 | [Strategies](strategies.md) | `overlay` vs. `sync` vs. `clean`, the sync manifest, delete guards, dry runs. |
 | [Examples & use cases](examples.md) | Copy-paste recipes: static sites, mirroring, multi-target deploys, PR previews, outputs. |
 | [Security guide](security.md) | Host key pinning, credential handling, least privilege, supply-chain safety. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,6 +166,7 @@ advanced:
   request_concurrency: auto
   connections: auto            # SSH connections uploads spread over
   skip_unchanged: false
+  # auto_cache: .easysftp-cache/auto.json   # off unless set; see below
 
 permissions:
   files: "0644"
@@ -224,6 +225,7 @@ sync:
 | `request_concurrency` | `auto` | Max in-flight SFTP requests per file (pipelining within one transfer). `auto` sizes it to the largest file and to what the whole set costs to hold in flight (see [transfer tuning](tuning.md)). |
 | `connections` | `auto` | SSH connections the parallel uploads spread over. Never more than `concurrency`. `auto` opens another one only while it would save more time than its handshake costs. See below. |
 | `skip_unchanged` | `false` | For `overlay`, skip a file whose remote counterpart has the same size (coarse; `sync` compares content hashes). |
+| `auto_cache` | unset (off) | Path to a file where easySFTP remembers what it measured about this server, so a later run can plan from a measurement instead of an assumption. Only affects settings left at `auto`. See below and [transfer tuning](tuning.md#remembering-what-it-measured). |
 
 ##### `connections`: more than one TCP flow
 
@@ -260,6 +262,39 @@ is not free:
 Pin a number when your host has a connection limit you already know, or when
 you measured something better than what `auto` picks. easySFTP's own numbers
 live in [`benchmarks/`](../benchmarks/README.md).
+
+##### `auto_cache`: keep what was measured
+
+`auto` has to guess one thing it cannot know before any bytes move: how fast
+the link actually is. `auto_cache` names a file where easySFTP writes what it
+measured instead, so the next run starts from the measurement.
+
+```yaml
+advanced:
+  auto_cache: .easysftp-cache/auto.json
+```
+
+On a GitHub-hosted runner the file has to be kept between runs, which
+`actions/cache` does:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: .easysftp-cache
+    key: easysftp-auto-${{ github.repository }}
+- uses: eiserv/easySFTP@v3
+  with:
+    config: .github/easysftp.yml
+    password: ${{ secrets.SFTP_PASSWORD }}
+```
+
+The file holds no credentials and does not name the server (the target is
+stored as a fingerprint). It only ever affects settings left at `auto`; a
+number you wrote always wins. A missing, unreadable or outdated file costs at
+most a warning, never the deploy. [Transfer
+tuning](tuning.md#remembering-what-it-measured) explains what is stored, what
+is restored (a measurement, never a decision) and when a record stops being
+used.
 
 #### `permissions`
 

--- a/docs/easysftp.example.yml
+++ b/docs/easysftp.example.yml
@@ -82,6 +82,12 @@ advanced:
   # a number if yours does.
   connections: auto
   skip_unchanged: false # overlay only: skip same-size remote files
+  # Remember what easySFTP measured about this server (round-trip time,
+  # throughput, any connection limit it ran into) so the next run plans from a
+  # measurement instead of an assumption. Off unless a path is given, and on
+  # an ephemeral CI runner the file has to be kept between runs, e.g. with
+  # actions/cache. See docs/tuning.md.
+  # auto_cache: .easysftp-cache/auto.json
 
 # Remote permission and timestamp handling (all best-effort).
 permissions:

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -74,7 +74,8 @@ assumption, `request_concurrency` stays on the rule above. Once a throughput
 has really been observed, the bandwidth-delay product is what sizes it: a long
 fat path is given every packet the channel window has, and a path that carries
 five kilobytes per round-trip is not asked to hold two megabytes of one file
-open for no reason.
+open for no reason. Which throughputs can reach that decision at all is
+bounded by when it has to be taken; see [Limits](#limits).
 
 ### 2. What the connection costs
 
@@ -167,6 +168,118 @@ needs files still waiting to be sent. The full decision is printed under
 `log-level: debug` (see "What you will see in the log"), and if the pool it
 chose is wrong for your server, `advanced.connections` overrides it.
 
+## Remembering what it measured
+
+Stage 3 exists because of one gap: nothing can observe a throughput before
+bytes move. Every run therefore starts from the conservative assumption, and
+every run that is large enough to correct it pays a window doing so. A run that
+is *not* large enough never corrects it at all.
+
+`advanced.auto_cache` closes that gap by keeping what a run measured:
+
+```yaml
+advanced:
+  auto_cache: .easysftp-cache/auto.json
+```
+
+It is off unless you name a path, and on an ephemeral CI runner the file has to
+be persisted between runs; the [configuration
+page](configuration.md#auto_cache-keep-what-was-measured) has the
+`actions/cache` snippet.
+
+### What is stored, and what is restored
+
+Those are two different lists, and the difference is the whole design.
+
+**Stored**, per server, in a small JSON file you can open:
+
+- the shape of the deploy the measurement was taken on (file count, bytes,
+  median and ninetieth-percentile file size, how many files are tiny),
+- the link: round-trip time, handshake, and the per-connection throughput,
+- the settings that run ended up using, and any connection limit it ran into,
+- the version of the tuning policy that measured it.
+
+**Restored**, on a hit:
+
+- the throughput, and
+- a connection ceiling, when an earlier run found one (the server refused an
+  extra connection, or a step that widened the pool measurably did not pay).
+
+**Never restored: the settings.** Choosing them is arithmetic over the plan and
+the link, it costs microseconds, and it is the part that has to describe
+*today's* deploy. So a hit hands the policy a better input and the policy
+decides again, from scratch, on the files in front of it. A deployment that has
+grown from 1,000 files to 5,000 gets a 5,000-file plan whatever the file says,
+because the file was never asked about the answer.
+
+The stored settings are there for you to read when a run picked a surprising
+number, not for easySFTP to replay.
+
+### When a record stops being used
+
+Before the first connection: the file is unreadable or from a newer easySFTP,
+the server is not in it, the policy version has changed, the measurement is
+older than 30 days, it has been reused 32 times without being taken again, or
+the deploy no longer looks like the one that was measured.
+
+After the first connection, and this is the strongest check of the lot: the
+round-trip time this run has *just measured* is compared with the one stored
+with the throughput. A path whose latency has moved by more than a factor of
+two is not the path that throughput came from, whatever the files look like. It
+costs nothing, because the probe runs anyway.
+
+Similarity is deliberately loose on size (a 980-file deploy reuses a
+1,000-file measurement, which is the point of a similarity rule) and strict on
+kind: a deploy of files too small to fill a stream and one of files that can
+are never comparable, because a byte rate measured on the first is a file rate
+in other units.
+
+### Why a slowly growing deploy does not keep hitting forever
+
+This is the failure mode a cache like this really has, and it does not need
+anything to go wrong to appear. A repository whose deploy grows a few per cent
+per run is, at every single step, almost identical to the run before it. A
+cache that asks "does this look like last time?" answers yes forever, and a
+hundred runs later it is still standing on something measured on a deploy a
+fraction of the current size. From inside, nothing ever looks wrong: every
+comparison it makes passes comfortably.
+
+Two things prevent it here.
+
+The first is that settings are never restored, so even a hit that should not
+have happened cannot preserve an old deploy's connection count.
+
+The second is what the comparison is made *against*. Each record is anchored to
+the deploy its measurement was taken on, and a run that merely uses a record
+does not move that anchor: only a run that measures the link for itself does,
+because only that run has something new to say. So the drift is measured from
+the measurement, it accumulates, and it eventually leaves the band, which is
+exactly what should happen. The same rule protects the round-trip time the
+record is validated against, so the link cannot creep either.
+
+A repository that really is growing keeps its cache working, because its larger
+runs measure the link again and re-anchor the record on what they measured.
+
+Nothing here is permanent. The connection ceiling is the one part that could
+quietly become configuration, since a run that inherits it never asks for more
+and so never finds out whether the limit is still there; it is carried at most
+16 runs before easySFTP asks again.
+
+### What you will see in the log
+
+A hit says what it is standing on and what it checked that against:
+
+```text
+auto tuning: reusing what an earlier run measured against this server (1.4 MiB/s per connection, reused 3 time(s) so far), checked against the link this run measured (13.4 ms now against 13.0 ms recorded)
+```
+
+A miss is a debug-level line naming the reason, because "the cache never seems
+to help" is a question with several different answers:
+
+```text
+auto tuning: not reusing the cached settings (this deploy no longer looks like the one that was measured (file count moved from 1e+03 to 4.2e+03))
+```
+
 ## Overriding it
 
 Every setting is resolved on its own, so you can pin one and leave the rest
@@ -254,11 +367,17 @@ knowing:
   workers, i.e. more than 64 files (see "What this stage cannot reach"). A
   smaller deployment on a link the assumption fits badly keeps the pool its
   plan chose for the whole transfer. It is bounded the same way, by a handful
-  of handshakes either way, but it is not corrected.
-- The bandwidth-delay product only sizes the pipelining once a throughput has
-  been observed, and nothing observes one before the first byte moves. Today
-  that means the conservative rule is what a normal run uses; the measured path
-  exists for the run that starts with a throughput it inherited.
+  of handshakes either way, but it is not corrected. `advanced.auto_cache` is
+  the way out of both limits: a remembered measurement is there before the
+  first file, so it reaches the deployments the runtime stage cannot.
+- **`request_concurrency` is outside the cache's reach.** It is baked into an
+  SFTP client when the client is created, so it has to be resolved before
+  there is a connection, and therefore before a remembered measurement can be
+  checked against the link this run is actually on. Restoring it there would
+  mean sizing the pipelining from evidence nothing had validated yet, so
+  easySFTP does not: it stays on the conservative rule above, and the
+  bandwidth-delay product still only sizes it from a throughput observed
+  during the transfer itself.
 
 If your deploy is slower than you expect, `log-level: debug` prints the whole
 decision, and [troubleshooting](troubleshooting.md) covers the failure modes

--- a/internal/autocache/autocache.go
+++ b/internal/autocache/autocache.go
@@ -1,0 +1,602 @@
+// Package autocache carries what one run measured about its server over to
+// the next one.
+//
+// internal/autotune is a cost model with exactly one input it cannot compute.
+// The files are known before the transfer, the round-trip time and the
+// handshake are measured a moment later, and everything else falls out of
+// arithmetic. Throughput does not: nothing observes a throughput before bytes
+// move. So the policy starts from a deliberately conservative prior and
+// corrects it while the transfer runs, which costs the first window of every
+// run that gets a correction at all, and which never reaches a deployment
+// whose files all start at once (issue #217).
+//
+// The thing worth remembering between runs is therefore the measurement, not
+// the decision. This package stores measurements.
+//
+// # Why not the settings
+//
+// Plan is a pure function of the workload, the link and whatever the user
+// pinned. It performs no I/O, reads no clock and costs microseconds, so
+// storing its output and replaying it would save nothing at all. It would only
+// buy the one failure mode a configuration cache really has: a stored answer
+// that outlives the question it answered.
+//
+// That failure mode is not hypothetical, and it does not need a sudden change
+// to appear. A dataset that grows by one per cent per deploy is similar to the
+// deploy before it every single time, and a hundred deploys later it is
+// nothing like the one the settings were chosen for. A cache that compares
+// each run against the run before it hits forever and answers with a decision
+// nobody would make today.
+//
+// Two rules rule that out here, and both are load-bearing:
+//
+//  1. Settings are never restored. What a hit supplies is an *input*; the
+//     policy then runs again, on today's files, and decides for itself. A
+//     deployment that grew from 1,000 files to 5,000 gets a 5,000-file plan
+//     whatever the record says, because the record was never consulted about
+//     the answer.
+//  2. Every record is anchored to the workload its measurement was taken on,
+//     and a run that merely *uses* a record does not rewrite that anchor. Only
+//     a run that measures the link afresh does, because only that run has new
+//     evidence. Similarity is therefore always judged against the deploy that
+//     was actually measured and never against yesterday's deploy, so a slow
+//     drift walks out of the band instead of dragging it along. See
+//     drift_test.go, which pins exactly that difference.
+//
+// # What a hit restores
+//
+// Two things, and both are evidence rather than opinion:
+//
+//   - The per-stream throughput, handed to the policy as autotune.SourceCached.
+//     A runtime measurement of the transfer being tuned still outranks it, so a
+//     stale number survives only until the run has something better to say.
+//   - A connection ceiling, when the previous run found one: a server that
+//     refused an extra connection, or a growth step that measurably did not pay
+//     for itself. The cost model assumes perfect scaling (T(k) = W/k + (k-1)*H)
+//     and cannot derive either of those; the only way to know is to have been
+//     told, and a run that was told should not have to be told again. A ceiling
+//     only ever lowers the pool, which is the direction that costs a server
+//     nothing.
+//
+// # What invalidates a record
+//
+// The format or policy version changed, the target changed, the record is too
+// old or has been leaned on too many times without being re-measured, the
+// workload no longer looks like the anchor, or the round-trip time measured
+// right now disagrees with the one that was measured then. The last of those
+// is the cheap validation issue #212 asks for, and it is free: the link probe
+// runs anyway, so comparing its answer with the stored one costs nothing and
+// is a direct measurement of the same path taken today.
+package autocache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
+)
+
+const (
+	// FormatVersion is the layout of the file on disk. A file written by a
+	// newer easySFTP is ignored rather than guessed at; see Load.
+	FormatVersion = 1
+
+	// MaxRecords is how many targets one file keeps. A repository that
+	// deploys to staging and production from one cache path should not have
+	// the two evict each other, and a file that grows without bound is a file
+	// nobody notices going wrong. Records past this are dropped least
+	// recently used first.
+	MaxRecords = 8
+
+	// MaxAge is how long a measurement is allowed to stand without being
+	// taken again. It is a safety stop rather than a measured half-life: a
+	// server that was re-provisioned, moved or resized announces none of
+	// that, and the only honest assumption about a month-old number is that
+	// nobody has checked it.
+	MaxAge = 30 * 24 * time.Hour
+
+	// MaxReuse is the same bound on the other clock. Age in days and age in
+	// runs are different things: a repository that deploys two hundred times
+	// a day burns a month of wall-clock freshness in a few hours, and every
+	// one of those runs may be too small to measure anything. Past this the
+	// record stops being restored and the run falls back to the prior, which
+	// is the state easySFTP shipped in before this cache existed.
+	MaxReuse = 32
+
+	// MaxCeilingCarry bounds a connection ceiling that keeps being inherited
+	// without ever being tested again.
+	//
+	// A ceiling caps the pool, so a run that inherits one never asks for more
+	// than it and therefore never finds out whether the limit is still there.
+	// Left alone that is a cache turning into permanent configuration, which
+	// is the one thing issue #212 asks it not to become. So an untested
+	// ceiling is carried a bounded number of runs and then dropped: the next
+	// run asks for what the policy wants, and either the server says no again
+	// (and the ceiling comes straight back) or it does not, and the cap was
+	// worth losing.
+	MaxCeilingCarry = 16
+)
+
+// The similarity bands. They are deliberately generous, because of what a hit
+// actually restores: a throughput is a property of the path, not of the files,
+// so a workload that is merely a bit larger than the anchor does not make a
+// measured bandwidth wrong. What the bands are there to catch is a run that is
+// no longer the same *kind* of work, where the stored number was never
+// evidence about this link in the first place.
+//
+// They are ratios rather than absolute tolerances so that they mean the same
+// thing at every scale, and the issue's own example (a 980-file deploy reusing
+// a 1,000-file result) is comfortably inside all of them.
+const (
+	// countBand covers the file count and the byte total. A deploy that
+	// doubled or halved is a different deploy.
+	countBand = 2.0
+
+	// sizeBand covers the median and the ninetieth percentile. The
+	// distribution is read for one thing (can a file fill a stream), so it is
+	// judged an order of magnitude at a time rather than by the digit.
+	sizeBand = 4.0
+
+	// smallShareBand is how far the share of files that fit in a single write
+	// packet may move, in absolute terms. A tree that went from a tenth tiny
+	// files to nine tenths tiny files is a different tree even when every
+	// other number survived.
+	smallShareBand = 0.25
+
+	// rttBand is how far the round-trip time measured now may be from the one
+	// measured then. A path whose latency doubled is not the path the
+	// throughput was measured over. It is the only gate that compares a
+	// measurement taken today against the record, which is what makes it the
+	// strongest one here.
+	rttBand = 2.0
+)
+
+// Store is the file on disk: a format version and a handful of records, most
+// recently used first.
+//
+// It is a slice rather than a map keyed by target because the file is a
+// document. A Go map re-encodes its keys in sorted order, so a run that
+// changed nothing would still rewrite the file in a different shape, and "most
+// recently used first" is information a sorted key order would throw away.
+type Store struct {
+	Version int      `json:"version"`
+	Records []Record `json:"records"`
+}
+
+// Record is one target's remembered measurement.
+//
+// Every field here is either the measurement, the context that says what the
+// measurement is evidence about, or provenance. Settings is the exception and
+// is written for the reader rather than for the policy: it records what the
+// run this measurement came from ended up using, so a stored record explains
+// itself. Nothing restores it. See the package comment.
+type Record struct {
+	// Target is a fingerprint of host, port, user and jump host, never the
+	// host itself. The file may end up in a CI cache that outlives the job
+	// and is restored into other workflows; a deployment target is not a
+	// secret, but it is not this file's to publish either.
+	Target string `json:"target"`
+
+	// PolicyVersion is the generation of internal/autotune that produced the
+	// measurement. Settings are not restored, but the evidence rules that
+	// decide what counts as a measurement are the policy's, so a record from
+	// a different generation is not comparable.
+	PolicyVersion int `json:"policy_version"`
+
+	// MeasuredAt is when the anchor below was measured, and Reused how many
+	// runs have leaned on it since. Neither moves when a run merely uses the
+	// record: that is the whole anti-drift rule, and LastUsed is what moves
+	// instead.
+	MeasuredAt time.Time `json:"measured_at"`
+	LastUsed   time.Time `json:"last_used"`
+	Reused     int       `json:"reused"`
+
+	// Workload is the anchor: the shape of the run whose transfer produced
+	// Link.StreamBytesPerSecond.
+	Workload Workload `json:"workload"`
+
+	// Link is what was measured about the path. StreamBytesPerSecond is zero
+	// for a record written by a run that had nothing to measure (a redeploy
+	// that sent almost nothing, a tree of files too small to fill a stream);
+	// such a record still carries the round-trip time and the ceiling, which
+	// are worth remembering on their own.
+	Link Link `json:"link"`
+
+	// Settings is what that run ran with, for the reader. See the type
+	// comment above.
+	Settings Settings `json:"settings"`
+
+	// ConnectionCeiling is the largest spread the server was observed to
+	// actually give, or to actually benefit from. Zero means nothing was
+	// observed and the policy is free up to its own maximum.
+	ConnectionCeiling int `json:"connection_ceiling,omitempty"`
+
+	// CeilingCarried counts the runs that inherited the ceiling above without
+	// putting it to the test, and is what MaxCeilingCarry bounds.
+	CeilingCarried int `json:"ceiling_carried,omitempty"`
+}
+
+// Workload is the shape of a deploy, reduced to the features a similarity
+// judgement can be made on. It mirrors autotune.Workload's upload side rather
+// than embedding it: this is a stored document, and a field added to an
+// internal struct must not silently change what is on disk.
+type Workload struct {
+	Files      int   `json:"files"`
+	Bytes      int64 `json:"bytes"`
+	P50        int64 `json:"size_p50"`
+	P90        int64 `json:"size_p90"`
+	Largest    int64 `json:"size_largest"`
+	SmallFiles int   `json:"small_files"`
+}
+
+// Link is what was measured about the path to the server. Milliseconds and
+// bytes per second, because this file is read by people as well as by
+// easySFTP.
+type Link struct {
+	RTTMillis            float64 `json:"rtt_ms"`
+	HandshakeMillis      float64 `json:"handshake_ms"`
+	StreamBytesPerSecond float64 `json:"stream_bytes_per_second"`
+}
+
+// Settings is one resolved transport configuration, recorded for the reader.
+type Settings struct {
+	Connections        int `json:"connections"`
+	Concurrency        int `json:"concurrency"`
+	RequestConcurrency int `json:"request_concurrency"`
+}
+
+// WorkloadOf reduces a planned workload to the stored features.
+func WorkloadOf(w autotune.Workload) Workload {
+	return Workload{
+		Files:      w.Uploads,
+		Bytes:      w.UploadBytes,
+		P50:        w.P50Upload,
+		P90:        w.P90Upload,
+		Largest:    w.LargestUpload,
+		SmallFiles: w.SmallUploads,
+	}
+}
+
+// LinkOf reduces a measured link to the stored features.
+func LinkOf(l autotune.Link) Link {
+	return Link{
+		RTTMillis:            millis(l.RTT),
+		HandshakeMillis:      millis(l.Handshake),
+		StreamBytesPerSecond: l.StreamBytesPerSecond,
+	}
+}
+
+// SettingsOf records what a run ran with.
+func SettingsOf(s autotune.Settings) Settings {
+	return Settings{
+		Connections:        s.Connections,
+		Concurrency:        s.Concurrency,
+		RequestConcurrency: s.RequestConcurrency,
+	}
+}
+
+func millis(d time.Duration) float64 {
+	if d <= 0 {
+		return 0
+	}
+	return float64(d) / float64(time.Millisecond)
+}
+
+// Fingerprint hashes a target identity into the value stored as Record.Target.
+// Truncated to 64 bits: this is a lookup key among at most MaxRecords entries,
+// not a signature.
+func Fingerprint(identity string) string {
+	sum := sha256.Sum256([]byte(identity))
+	return "sha256:" + hex.EncodeToString(sum[:8])
+}
+
+// Candidate is a record that passed every gate a run can check before it has
+// touched the network. It still has to survive Validate, which compares the
+// stored round-trip time against the one this run just measured.
+type Candidate struct {
+	record Record
+	found  bool
+}
+
+// Decision is the outcome of a lookup: what may be restored, and the sentence
+// that explains why. Reason is always set, for a hit as well as for a miss,
+// because "the cache did nothing again" is the question a user actually asks.
+type Decision struct {
+	Hit    bool
+	Reason string
+
+	// StreamBytesPerSecond is the remembered per-connection throughput, or
+	// zero when the record carries none.
+	StreamBytesPerSecond float64
+
+	// ConnectionCeiling is the remembered upper bound on the pool, or zero.
+	ConnectionCeiling int
+
+	// Reused is how many runs had already leaned on this record before this
+	// one, which is what the run reports and what MaxReuse bounds.
+	Reused int
+}
+
+// Restores reports whether a hit actually carries anything the policy will
+// read. A record written by a run that could measure nothing and met no
+// pushback is a valid hit that changes no decision, and saying so is more
+// useful than announcing a hit that does nothing.
+func (d Decision) Restores() bool {
+	return d.Hit && (d.StreamBytesPerSecond > 0 || d.ConnectionCeiling > 0)
+}
+
+// Lookup finds the record for target and checks everything that can be checked
+// before the first connection: the format, the policy generation, the age, the
+// reuse budget and the workload anchor.
+//
+// The round-trip time cannot be checked here, because measuring it needs the
+// connection this decision helps to size. That is what Validate is for, and it
+// is why a miss at this stage and a miss at that stage are two separate
+// sentences.
+func (s *Store) Lookup(target string, now Workload, at time.Time) (Candidate, Decision) {
+	if s == nil {
+		return Candidate{}, Decision{Reason: "no cache file was read"}
+	}
+	rec, ok := s.find(target)
+	if !ok {
+		return Candidate{}, Decision{Reason: "this server is not in the cache yet"}
+	}
+	if rec.PolicyVersion != autotune.PolicyVersion {
+		return Candidate{}, Decision{Reason: fmt.Sprintf(
+			"the record was written by auto-policy version %d and this easySFTP runs version %d",
+			rec.PolicyVersion, autotune.PolicyVersion)}
+	}
+	if age := at.Sub(rec.MeasuredAt); age > MaxAge {
+		return Candidate{}, Decision{Reason: fmt.Sprintf(
+			"the measurement is %d day(s) old and is only trusted for %d",
+			int(age.Hours()/24), int(MaxAge.Hours()/24))}
+	}
+	if rec.Reused >= MaxReuse {
+		return Candidate{}, Decision{Reason: fmt.Sprintf(
+			"the measurement has been reused %d time(s) without being taken again, which is the limit",
+			rec.Reused)}
+	}
+	if why, ok := similar(rec.Workload, now); !ok {
+		return Candidate{}, Decision{Reason: fmt.Sprintf(
+			"this deploy no longer looks like the one that was measured (%s)", why)}
+	}
+	return Candidate{record: rec, found: true}, Decision{}
+}
+
+// Validate is the cheap check the run makes once it has a connection: the
+// round-trip time it just measured, against the one the record was written
+// with. A path whose latency moved materially is not the path the throughput
+// came from, whatever the files look like.
+//
+// A run that did not measure an RTT (the probe is skipped when it cannot
+// change an answer, and a server may refuse it) gets no hit. That is
+// deliberate: the alternative is to restore a measurement with nothing at all
+// standing behind it, and the fallback is the prior easySFTP used before this
+// cache existed.
+func (c Candidate) Validate(rtt time.Duration) Decision {
+	if !c.found {
+		return Decision{Reason: "no usable record"}
+	}
+	stored := c.record.Link.RTTMillis
+	if rtt <= 0 || stored <= 0 {
+		return Decision{Reason: "the round-trip time could not be measured, so the record could not be checked against this link"}
+	}
+	now := millis(rtt)
+	if !withinBand(now, stored, rttBand) {
+		return Decision{Reason: fmt.Sprintf(
+			"the link measures %.1f ms now and measured %.1f ms when it was recorded", now, stored)}
+	}
+	return Decision{
+		Hit:                  true,
+		Reason:               fmt.Sprintf("%.1f ms now against %.1f ms recorded", now, stored),
+		StreamBytesPerSecond: c.record.Link.StreamBytesPerSecond,
+		ConnectionCeiling:    c.record.ConnectionCeiling,
+		Reused:               c.record.Reused,
+	}
+}
+
+// Observation is what a finished run has to say about its server.
+type Observation struct {
+	Target   string
+	Workload Workload
+	Link     Link
+	Settings Settings
+
+	// Measured reports whether Link.StreamBytesPerSecond is this run's own
+	// measurement. Only a run that says so may re-anchor a record: that is
+	// the rule the whole package rests on.
+	Measured bool
+
+	// Reused reports whether this run's plan actually stood on the stored
+	// record. A run that was offered one and rejected it did not.
+	Reused bool
+
+	// ConnectionCeiling is the bound this run found for itself: the server
+	// refused an extra connection, or a growth step was measurably not worth
+	// it. Zero means this run found none.
+	ConnectionCeiling int
+
+	// CeilingUntested says the run was held at a ceiling it inherited and met
+	// no pushback of its own, so it learned nothing about the limit either
+	// way. Such a ceiling is carried forward, but only MaxCeilingCarry times.
+	CeilingUntested bool
+}
+
+// Update folds one finished run into the store and reports whether anything
+// changed, so a run that learned nothing does not rewrite the file.
+//
+// The rule is one sentence: a stored measurement is replaced only by a new
+// measurement, and never merely by a newer run.
+//
+//   - This run measured the link, or there was no measurement stored to
+//     protect: the record is written from this run, anchor and all. New
+//     evidence, new anchor, reuse count back to zero.
+//   - This run did not measure, and a stored measurement is still standing:
+//     the anchor, the whole stored link and MeasuredAt are left exactly as
+//     they were. Only the provenance, the recorded settings and the ceiling
+//     move. This is the case that would otherwise let a dataset (or a
+//     round-trip time) drift a per cent at a time until the record described
+//     nothing that was ever measured.
+//
+// The link is kept whole rather than field by field on purpose. The stored
+// round-trip time is what the next run validates against, so letting today's
+// RTT overwrite it while the throughput stays would move the yardstick and
+// leave the measurement: the same slow drift, one axis over.
+func (s *Store) Update(obs Observation, at time.Time) bool {
+	if s == nil || obs.Target == "" {
+		return false
+	}
+	s.Version = FormatVersion
+	old, existed := s.find(obs.Target)
+
+	rec := Record{
+		Target:        obs.Target,
+		PolicyVersion: autotune.PolicyVersion,
+		MeasuredAt:    at,
+		LastUsed:      at,
+		Workload:      obs.Workload,
+		Link:          obs.Link,
+		Settings:      obs.Settings,
+	}
+	if existed && !obs.Measured && old.Link.StreamBytesPerSecond > 0 {
+		rec.MeasuredAt = old.MeasuredAt
+		rec.Workload = old.Workload
+		rec.Link = old.Link
+		rec.Reused = old.Reused
+		if obs.Reused {
+			rec.Reused++
+		}
+	}
+
+	// The ceiling is the one part of a record that is not about the
+	// measurement, so it has its own life: it is current evidence about the
+	// server, it is refreshed by every run that meets pushback, and it is let
+	// go when nothing has tested it for long enough. See MaxCeilingCarry.
+	switch {
+	case obs.ConnectionCeiling > 0:
+		rec.ConnectionCeiling = obs.ConnectionCeiling
+	case existed && obs.CeilingUntested && old.ConnectionCeiling > 0 && old.CeilingCarried < MaxCeilingCarry:
+		rec.ConnectionCeiling = old.ConnectionCeiling
+		rec.CeilingCarried = old.CeilingCarried + 1
+	}
+
+	if existed && rec.equal(old) {
+		return false
+	}
+	s.put(rec)
+	return true
+}
+
+// equal reports whether two records say the same thing. LastUsed is ignored:
+// rewriting the file to move a timestamp nobody reads is not a change worth
+// the write.
+func (r Record) equal(other Record) bool {
+	a, b := r, other
+	a.LastUsed, b.LastUsed = time.Time{}, time.Time{}
+	return a == b
+}
+
+func (s *Store) find(target string) (Record, bool) {
+	for _, r := range s.Records {
+		if r.Target == target {
+			return r, true
+		}
+	}
+	return Record{}, false
+}
+
+// put stores rec at the front (most recently used) and drops the tail past
+// MaxRecords.
+func (s *Store) put(rec Record) {
+	kept := make([]Record, 0, len(s.Records)+1)
+	kept = append(kept, rec)
+	for _, r := range s.Records {
+		if r.Target == rec.Target {
+			continue
+		}
+		kept = append(kept, r)
+	}
+	if len(kept) > MaxRecords {
+		kept = kept[:MaxRecords]
+	}
+	s.Records = kept
+}
+
+// similar reports whether now is close enough to the anchor for the anchor's
+// measurement to still be evidence about this run, and names the feature that
+// disagreed when it is not.
+//
+// Every feature has to pass. A workload is a shape, and a shape that matches
+// on three features out of four is not the same shape; taking a majority would
+// mean deciding which feature to be wrong about.
+func similar(anchor, now Workload) (string, bool) {
+	// The categorical one first, because it is the only feature that changes
+	// what the stored number *is* rather than how far off it might be. A byte
+	// rate measured on files that each fit in a single write packet is a file
+	// rate in other units (see autotune.BandwidthBound); a run on the other
+	// side of that line is not describable by it.
+	if bandwidthBound(anchor) != bandwidthBound(now) {
+		return "one of the two is made of files too small to fill a stream and the other is not", false
+	}
+	for _, f := range []struct {
+		name       string
+		then, this float64
+		band       float64
+	}{
+		{"file count", float64(anchor.Files), float64(now.Files), countBand},
+		{"total bytes", float64(anchor.Bytes), float64(now.Bytes), countBand},
+		{"median file size", float64(anchor.P50), float64(now.P50), sizeBand},
+		{"ninetieth percentile file size", float64(anchor.P90), float64(now.P90), sizeBand},
+	} {
+		if !withinBand(f.this, f.then, f.band) {
+			return fmt.Sprintf("%s moved from %s to %s", f.name, number(f.then), number(f.this)), false
+		}
+	}
+	if a, b := smallShare(anchor), smallShare(now); math.Abs(a-b) > smallShareBand {
+		return fmt.Sprintf("the share of very small files moved from %.0f%% to %.0f%%", a*100, b*100), false
+	}
+	return "", true
+}
+
+// bandwidthBound is autotune's question asked of a stored shape.
+func bandwidthBound(w Workload) bool {
+	return autotune.BandwidthBound(autotune.Workload{
+		Uploads:       w.Files,
+		LargestUpload: w.Largest,
+		P90Upload:     w.P90,
+	})
+}
+
+func smallShare(w Workload) float64 {
+	if w.Files <= 0 {
+		return 0
+	}
+	return float64(w.SmallFiles) / float64(w.Files)
+}
+
+// withinBand reports whether a and b are within a multiplicative band of each
+// other. Two zeroes match; a zero against a non-zero never does, because a
+// feature that appeared or vanished is a categorical change and no ratio
+// describes it.
+func withinBand(a, b, band float64) bool {
+	switch {
+	case a == b:
+		return true
+	case a <= 0 || b <= 0:
+		return false
+	}
+	ratio := a / b
+	return ratio <= band && ratio >= 1/band
+}
+
+// number renders a feature value for the miss message without pretending to a
+// precision the comparison does not have.
+func number(v float64) string {
+	if v >= 1024 {
+		return fmt.Sprintf("%.3g", v)
+	}
+	return fmt.Sprintf("%.0f", v)
+}

--- a/internal/autocache/autocache_test.go
+++ b/internal/autocache/autocache_test.go
@@ -1,0 +1,444 @@
+package autocache
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
+)
+
+// now is the fixed clock every test here reads. Nothing in this package calls
+// time.Now, which is what lets the age and reuse rules be tested by arithmetic
+// instead of by waiting.
+var now = time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+
+const target = "sha256:0123456789abcdef"
+
+// mediumTree is the anchor most of these tests use: a thousand files of a
+// quarter megabyte each, which is bandwidth-bound (its files can fill a
+// stream) and therefore the kind of deploy a throughput can be measured on.
+func mediumTree() Workload {
+	return Workload{Files: 1000, Bytes: 1000 * 256 * 1024, P50: 256 * 1024, P90: 256 * 1024, Largest: 4 << 20}
+}
+
+// stored builds a store holding one record for target, measured just now.
+func stored(w Workload, l Link, mutate ...func(*Record)) *Store {
+	rec := Record{
+		Target:        target,
+		PolicyVersion: autotune.PolicyVersion,
+		MeasuredAt:    now,
+		LastUsed:      now,
+		Workload:      w,
+		Link:          l,
+		Settings:      Settings{Connections: 4, Concurrency: 64, RequestConcurrency: 32},
+	}
+	for _, m := range mutate {
+		m(&rec)
+	}
+	return &Store{Version: FormatVersion, Records: []Record{rec}}
+}
+
+func measuredLink() Link {
+	return Link{RTTMillis: 13, HandshakeMillis: 380, StreamBytesPerSecond: 8 << 20}
+}
+
+// TestLookupRestoresAMeasurement is the whole point of the package: a run that
+// looks like the one that was measured, over a link that still measures the
+// same, gets the throughput and the ceiling handed to it.
+func TestLookupRestoresAMeasurement(t *testing.T) {
+	s := stored(mediumTree(), measuredLink(), func(r *Record) { r.ConnectionCeiling = 4 })
+
+	cand, dec := s.Lookup(target, mediumTree(), now)
+	if dec.Reason != "" {
+		t.Fatalf("pre-connection gates rejected an identical workload: %s", dec.Reason)
+	}
+	dec = cand.Validate(13 * time.Millisecond)
+	switch {
+	case !dec.Hit:
+		t.Fatalf("an unchanged link was rejected: %s", dec.Reason)
+	case !dec.Restores():
+		t.Fatalf("a hit carrying a throughput and a ceiling restores nothing: %+v", dec)
+	case dec.StreamBytesPerSecond != 8<<20:
+		t.Errorf("restored %.0f B/s, want %d", dec.StreamBytesPerSecond, 8<<20)
+	case dec.ConnectionCeiling != 4:
+		t.Errorf("restored ceiling %d, want 4", dec.ConnectionCeiling)
+	}
+}
+
+// TestLookupAcceptsTheIssuesOwnExample: issue #212 asks for similarity, not
+// equality, and names the case. 980 files must still reuse a result measured
+// on 1,000.
+func TestLookupAcceptsTheIssuesOwnExample(t *testing.T) {
+	anchor := mediumTree()
+	s := stored(anchor, measuredLink())
+
+	nearly := anchor
+	nearly.Files = 980
+	nearly.Bytes = int64(980) * 256 * 1024
+
+	if _, dec := s.Lookup(target, nearly, now); dec.Reason != "" {
+		t.Fatalf("980 files did not match an anchor of 1,000: %s", dec.Reason)
+	}
+}
+
+// TestLookupGates walks the reasons a record is not reused. Each one is a
+// separate sentence in the log, because "the cache never helps" is a question
+// with several different answers.
+func TestLookupGates(t *testing.T) {
+	anchor := mediumTree()
+
+	doubled := anchor
+	doubled.Files = 2500
+	doubled.Bytes = int64(2500) * 256 * 1024
+
+	tiny := Workload{Files: 1000, Bytes: 1000 * 4096, P50: 4096, P90: 4096, Largest: 4096, SmallFiles: 1000}
+
+	mostlyTiny := anchor
+	mostlyTiny.SmallFiles = 900
+
+	for _, tc := range []struct {
+		name   string
+		store  *Store
+		now    Workload
+		at     time.Time
+		expect string
+	}{
+		{
+			name:   "unknown target",
+			store:  &Store{Version: FormatVersion},
+			now:    anchor,
+			at:     now,
+			expect: "not in the cache yet",
+		},
+		{
+			name:   "a different policy generation",
+			store:  stored(anchor, measuredLink(), func(r *Record) { r.PolicyVersion = autotune.PolicyVersion + 1 }),
+			now:    anchor,
+			at:     now,
+			expect: "auto-policy version",
+		},
+		{
+			name:   "older than the trust window",
+			store:  stored(anchor, measuredLink()),
+			now:    anchor,
+			at:     now.Add(MaxAge + time.Hour),
+			expect: "day(s) old",
+		},
+		{
+			name:   "leaned on too often",
+			store:  stored(anchor, measuredLink(), func(r *Record) { r.Reused = MaxReuse }),
+			now:    anchor,
+			at:     now,
+			expect: "has been reused",
+		},
+		{
+			name:   "the deploy more than doubled",
+			store:  stored(anchor, measuredLink()),
+			now:    doubled,
+			at:     now,
+			expect: "file count moved",
+		},
+		{
+			name:   "the files are now too small to fill a stream",
+			store:  stored(anchor, measuredLink()),
+			now:    tiny,
+			at:     now,
+			expect: "too small to fill a stream",
+		},
+		{
+			name:   "the same files, mostly tiny ones now",
+			store:  stored(anchor, measuredLink()),
+			now:    mostlyTiny,
+			at:     now,
+			expect: "share of very small files",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cand, dec := tc.store.Lookup(target, tc.now, tc.at)
+			if dec.Reason == "" {
+				t.Fatalf("the record was accepted, want a miss mentioning %q", tc.expect)
+			}
+			if !strings.Contains(dec.Reason, tc.expect) {
+				t.Errorf("miss reason %q does not mention %q", dec.Reason, tc.expect)
+			}
+			if dec := cand.Validate(13 * time.Millisecond); dec.Hit {
+				t.Errorf("a rejected candidate validated anyway: %+v", dec)
+			}
+		})
+	}
+}
+
+// TestValidateChecksTheLinkAgainstTodaysMeasurement is the cheap validation
+// issue #212 asks for. It is the strongest gate here, because unlike every
+// other one it compares the record against a measurement taken now.
+func TestValidateChecksTheLinkAgainstTodaysMeasurement(t *testing.T) {
+	s := stored(mediumTree(), measuredLink())
+
+	for _, tc := range []struct {
+		name string
+		rtt  time.Duration
+		hit  bool
+	}{
+		{"the same link", 13 * time.Millisecond, true},
+		{"a little slower", 20 * time.Millisecond, true},
+		{"four times as far away", 52 * time.Millisecond, false},
+		{"a different, much closer path", 1 * time.Millisecond, false},
+		{"unmeasurable", 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cand, dec := s.Lookup(target, mediumTree(), now)
+			if dec.Reason != "" {
+				t.Fatalf("unexpected pre-connection miss: %s", dec.Reason)
+			}
+			if got := cand.Validate(tc.rtt); got.Hit != tc.hit {
+				t.Errorf("hit = %v, want %v (%s)", got.Hit, tc.hit, got.Reason)
+			}
+		})
+	}
+}
+
+// TestHitWithNothingToRestore: a record written by a run that could measure
+// nothing is still a valid record (it carries the round-trip time the next run
+// checks against), but it must not be announced as if it changed a decision.
+func TestHitWithNothingToRestore(t *testing.T) {
+	s := stored(mediumTree(), Link{RTTMillis: 13, HandshakeMillis: 380})
+
+	cand, dec := s.Lookup(target, mediumTree(), now)
+	if dec.Reason != "" {
+		t.Fatalf("unexpected miss: %s", dec.Reason)
+	}
+	dec = cand.Validate(13 * time.Millisecond)
+	if !dec.Hit {
+		t.Fatalf("the record was rejected: %s", dec.Reason)
+	}
+	if dec.Restores() {
+		t.Errorf("a record with no throughput and no ceiling claims to restore something: %+v", dec)
+	}
+}
+
+// TestUpdateReanchorsOnlyOnAMeasurement is the anti-drift rule, stated
+// directly: a run that used a stored measurement does not get to say what that
+// measurement describes.
+func TestUpdateReanchorsOnlyOnAMeasurement(t *testing.T) {
+	anchor := mediumTree()
+	s := stored(anchor, measuredLink())
+	later := now.Add(24 * time.Hour)
+
+	grown := anchor
+	grown.Files = 1400
+	grown.Bytes = int64(1400) * 256 * 1024
+
+	// A run that reused the record and measured nothing of its own.
+	s.Update(Observation{
+		Target:   target,
+		Workload: grown,
+		Link:     Link{RTTMillis: 15, HandshakeMillis: 390},
+		Settings: Settings{Connections: 6, Concurrency: 64, RequestConcurrency: 32},
+		Reused:   true,
+	}, later)
+
+	rec, _ := s.find(target)
+	switch {
+	case rec.Workload != anchor:
+		t.Errorf("the anchor followed the run that only used it: %+v", rec.Workload)
+	case rec.Link != measuredLink():
+		t.Errorf("the stored link was overwritten by a run that measured nothing: %+v", rec.Link)
+	case !rec.MeasuredAt.Equal(now):
+		t.Errorf("measured_at moved to %v without a measurement", rec.MeasuredAt)
+	case rec.Reused != 1:
+		t.Errorf("reuse count is %d, want 1", rec.Reused)
+	case rec.Settings.Connections != 6:
+		t.Errorf("the recorded settings did not follow the run that ran them: %+v", rec.Settings)
+	}
+
+	// A run that measured the link replaces all of it, anchor included.
+	s.Update(Observation{
+		Target:   target,
+		Workload: grown,
+		Link:     Link{RTTMillis: 15, HandshakeMillis: 390, StreamBytesPerSecond: 3 << 20},
+		Measured: true,
+		Reused:   true,
+	}, later)
+
+	rec, _ = s.find(target)
+	switch {
+	case rec.Workload != grown:
+		t.Errorf("a measurement did not re-anchor the record: %+v", rec.Workload)
+	case rec.Link.StreamBytesPerSecond != 3<<20:
+		t.Errorf("the new measurement was not stored: %+v", rec.Link)
+	case !rec.MeasuredAt.Equal(later):
+		t.Errorf("measured_at is %v, want the time of the measurement", rec.MeasuredAt)
+	case rec.Reused != 0:
+		t.Errorf("reuse count is %d, want it reset by the new measurement", rec.Reused)
+	}
+}
+
+// TestUpdateWritesARecordWithNoMeasurementToProtect: a record that never held
+// a throughput has no anchor worth freezing, so a later run may replace it
+// outright. This is what keeps a first run's round-trip time from ageing out
+// while the deploys keep coming.
+func TestUpdateWritesARecordWithNoMeasurementToProtect(t *testing.T) {
+	s := stored(mediumTree(), Link{RTTMillis: 13, HandshakeMillis: 380})
+	later := now.Add(48 * time.Hour)
+
+	grown := mediumTree()
+	grown.Files = 1400
+
+	s.Update(Observation{
+		Target:   target,
+		Workload: grown,
+		Link:     Link{RTTMillis: 14, HandshakeMillis: 400},
+		Reused:   true,
+	}, later)
+
+	rec, _ := s.find(target)
+	if rec.Workload != grown || !rec.MeasuredAt.Equal(later) {
+		t.Errorf("a record with nothing measured in it was preserved anyway: %+v", rec)
+	}
+}
+
+// TestUpdateKeepsAMeasurementItCouldNotUse: a run whose workload walked out of
+// the band has nothing better to offer, so the stored measurement stays. A
+// cache that threw evidence away every time it did not apply would be
+// permanently empty for anyone with two different deploys.
+func TestUpdateKeepsAMeasurementItCouldNotUse(t *testing.T) {
+	anchor := mediumTree()
+	s := stored(anchor, measuredLink())
+
+	other := Workload{Files: 20, Bytes: 20 * 4096, P50: 4096, P90: 4096, Largest: 4096, SmallFiles: 20}
+	s.Update(Observation{Target: target, Workload: other, Link: Link{RTTMillis: 13}}, now.Add(time.Hour))
+
+	rec, _ := s.find(target)
+	if rec.Workload != anchor || rec.Link.StreamBytesPerSecond != 8<<20 {
+		t.Errorf("a run that could not use the record threw it away: %+v", rec)
+	}
+	if rec.Reused != 0 {
+		t.Errorf("a run that did not use the record counted as a reuse (%d)", rec.Reused)
+	}
+}
+
+// TestUpdateSkipsAWriteWhenNothingChanged keeps a cache file from being
+// rewritten (and, in CI, re-uploaded) by runs that learned nothing new.
+func TestUpdateSkipsAWriteWhenNothingChanged(t *testing.T) {
+	s := stored(mediumTree(), measuredLink())
+	obs := Observation{
+		Target:   target,
+		Workload: mediumTree(),
+		Link:     measuredLink(),
+		Settings: Settings{Connections: 4, Concurrency: 64, RequestConcurrency: 32},
+	}
+	if s.Update(obs, now.Add(time.Hour)) {
+		t.Error("a run that repeated what the record already said asked for a write")
+	}
+}
+
+// TestCeilingIsCarriedButNotForever. A ceiling caps the pool, so a run that
+// inherits one never tests it; carried without a bound that is a cache that
+// has turned into configuration, which issue #212 explicitly rules out.
+func TestCeilingIsCarriedButNotForever(t *testing.T) {
+	s := stored(mediumTree(), measuredLink(), func(r *Record) { r.ConnectionCeiling = 2 })
+
+	for i := 1; i <= MaxCeilingCarry; i++ {
+		s.Update(Observation{
+			Target:          target,
+			Workload:        mediumTree(),
+			Link:            measuredLink(),
+			Reused:          true,
+			CeilingUntested: true,
+		}, now.Add(time.Duration(i)*time.Hour))
+		rec, _ := s.find(target)
+		if rec.ConnectionCeiling != 2 {
+			t.Fatalf("run %d: the untested ceiling was dropped early", i)
+		}
+		if rec.CeilingCarried != i {
+			t.Fatalf("run %d: carried count is %d", i, rec.CeilingCarried)
+		}
+	}
+
+	s.Update(Observation{
+		Target:          target,
+		Workload:        mediumTree(),
+		Link:            measuredLink(),
+		Reused:          true,
+		CeilingUntested: true,
+	}, now.Add(time.Duration(MaxCeilingCarry+1)*time.Hour))
+	if rec, _ := s.find(target); rec.ConnectionCeiling != 0 {
+		t.Errorf("the ceiling survived %d runs without ever being tested", MaxCeilingCarry+1)
+	}
+}
+
+// TestCeilingFollowsWhatTheServerJustDid: a run that met pushback replaces the
+// stored bound and resets the carry count, and a run that asked for everything
+// and met none drops it.
+func TestCeilingFollowsWhatTheServerJustDid(t *testing.T) {
+	s := stored(mediumTree(), measuredLink(), func(r *Record) {
+		r.ConnectionCeiling = 4
+		r.CeilingCarried = 3
+	})
+
+	s.Update(Observation{
+		Target: target, Workload: mediumTree(), Link: measuredLink(),
+		Reused: true, ConnectionCeiling: 2,
+	}, now.Add(time.Hour))
+	rec, _ := s.find(target)
+	if rec.ConnectionCeiling != 2 || rec.CeilingCarried != 0 {
+		t.Errorf("a fresh refusal did not replace the stored ceiling: %+v", rec)
+	}
+
+	s.Update(Observation{
+		Target: target, Workload: mediumTree(), Link: measuredLink(), Reused: true,
+	}, now.Add(2*time.Hour))
+	if rec, _ := s.find(target); rec.ConnectionCeiling != 0 {
+		t.Errorf("a run that met no pushback kept a ceiling of %d", rec.ConnectionCeiling)
+	}
+}
+
+// TestStoreKeepsSeveralTargets: one cache file has to serve a repository that
+// deploys to staging and production, and must not grow without bound.
+func TestStoreKeepsSeveralTargets(t *testing.T) {
+	s := &Store{Version: FormatVersion}
+	for i := 0; i < MaxRecords+3; i++ {
+		s.Update(Observation{
+			Target:   Fingerprint(string(rune('a' + i))),
+			Workload: mediumTree(),
+			Link:     measuredLink(),
+			Measured: true,
+		}, now.Add(time.Duration(i)*time.Minute))
+	}
+	if len(s.Records) != MaxRecords {
+		t.Fatalf("stored %d record(s), want the file capped at %d", len(s.Records), MaxRecords)
+	}
+	if s.Records[0].Target != Fingerprint(string(rune('a'+MaxRecords+2))) {
+		t.Errorf("the most recent record is not first: %s", s.Records[0].Target)
+	}
+	if _, ok := s.find(Fingerprint("a")); ok {
+		t.Error("the oldest record survived the cap")
+	}
+}
+
+// TestFingerprintNeverNamesTheHost. The file can end up in a CI cache that
+// outlives the job and is restored into other workflows.
+func TestFingerprintNeverNamesTheHost(t *testing.T) {
+	fp := Fingerprint("sftp.example.com:22:deploy")
+	switch {
+	case strings.Contains(fp, "example.com") || strings.Contains(fp, "deploy"):
+		t.Fatalf("the fingerprint carries the identity: %s", fp)
+	case fp == Fingerprint("sftp.example.com:2222:deploy"):
+		t.Error("a different port fingerprints the same")
+	case fp == Fingerprint("sftp.example.com:22:other"):
+		t.Error("a different user fingerprints the same")
+	}
+}
+
+// TestWorkloadOfReadsThePlan pins the one conversion between the policy's
+// workload and the stored one, which is what a similarity judgement is made
+// on.
+func TestWorkloadOfReadsThePlan(t *testing.T) {
+	w := autotune.SummarizeUploads([]int64{4096, 4096, 1 << 20, 8 << 20})
+	got := WorkloadOf(w)
+	want := Workload{Files: 4, Bytes: 4096 + 4096 + (1 << 20) + (8 << 20), P50: 4096, P90: 8 << 20, Largest: 8 << 20, SmallFiles: 2}
+	if got != want {
+		t.Errorf("WorkloadOf = %+v, want %+v", got, want)
+	}
+}

--- a/internal/autocache/drift_test.go
+++ b/internal/autocache/drift_test.go
@@ -1,0 +1,193 @@
+package autocache
+
+import (
+	"testing"
+	"time"
+)
+
+// The failure mode this file exists for.
+//
+// A deployment that grows a few per cent per run is, at every single step,
+// almost identical to the run before it. A cache that asks "does this look
+// like last time?" therefore answers yes forever, and a hundred runs later it
+// is still handing back something measured on a deploy a fraction of the
+// current size. Nothing ever looks wrong from inside such a cache: every
+// comparison it makes passes, comfortably.
+//
+// The rule that prevents it is not a tighter band (there is no band that
+// separates 100 files from 103), it is what the comparison is made against.
+// A record is anchored to the deploy its measurement was taken on, and a run
+// that merely *uses* the record does not move that anchor. So the drift is
+// measured from the measurement, accumulates, and eventually leaves the band,
+// which is exactly what should happen.
+//
+// TestDriftLeavesTheBandInsteadOfDraggingItAlong runs both readings side by
+// side on the same sequence of deploys.
+func TestDriftLeavesTheBandInsteadOfDraggingItAlong(t *testing.T) {
+	const (
+		runs       = 120
+		growth     = 1.03 // three per cent per deploy
+		firstFiles = 400
+	)
+
+	// growingTree is the deploy on run n: the same kind of files, more of them
+	// every time. A quarter of a megabyte each, so the deploy stays the kind
+	// of work a throughput can be measured on and the categorical gate never
+	// fires; what moves is only the size of it.
+	growingTree := func(n int) Workload {
+		files := firstFiles
+		for i := 0; i < n; i++ {
+			files = int(float64(files) * growth)
+		}
+		return Workload{
+			Files:   files,
+			Bytes:   int64(files) * 256 * 1024,
+			P50:     256 * 1024,
+			P90:     256 * 1024,
+			Largest: 4 << 20,
+		}
+	}
+
+	anchored := stored(growingTree(0), measuredLink())
+	lastHit := -1
+	for n := 1; n < runs; n++ {
+		at := now.Add(time.Duration(n) * time.Hour)
+		w := growingTree(n)
+
+		// Consecutive deploys are indistinguishable, which is the whole trap:
+		// a cache comparing each run with the one before it never sees a
+		// reason to stop.
+		if why, ok := similar(growingTree(n-1), w); !ok {
+			t.Fatalf("run %d already differs from run %d (%s); pick a slower growth for this test", n, n-1, why)
+		}
+
+		cand, dec := anchored.Lookup(target, w, at)
+		if dec.Reason == "" {
+			dec = cand.Validate(13 * time.Millisecond)
+		}
+		if dec.Hit {
+			lastHit = n
+		}
+		// A run too small to measure anything, which is the case that can
+		// carry a record forward at all.
+		anchored.Update(Observation{
+			Target:   target,
+			Workload: w,
+			Link:     Link{RTTMillis: 13, HandshakeMillis: 380},
+			Reused:   dec.Hit,
+		}, at)
+
+		if rec, _ := anchored.find(target); rec.Workload != growingTree(0) {
+			t.Fatalf("run %d moved the anchor to %+v without measuring anything", n, rec.Workload)
+		}
+	}
+
+	switch {
+	case lastHit < 0:
+		t.Fatal("the cache never hit at all, so this test proves nothing about drift")
+	case lastHit >= runs-1:
+		t.Fatalf("the cache still hit on the last run, with the deploy %.1fx its original size",
+			float64(growingTree(runs-1).Files)/firstFiles)
+	}
+	grown := float64(growingTree(lastHit).Files) / firstFiles
+	if grown > 2.1 {
+		t.Errorf("the cache kept hitting until the deploy was %.1fx its original size", grown)
+	}
+	t.Logf("the anchored cache stopped hitting at run %d, with the deploy %.2fx its original size", lastHit+1, grown)
+
+	// The same sequence read the way an unclean implementation would read it:
+	// compare against the previous run and re-anchor every time. It never
+	// stops hitting, however far the deploy has travelled.
+	naive := stored(growingTree(0), measuredLink())
+	for n := 1; n < runs; n++ {
+		w := growingTree(n)
+		if _, dec := naive.Lookup(target, w, now.Add(time.Duration(n)*time.Hour)); dec.Reason != "" {
+			t.Fatalf("comparing against the previous run missed at run %d (%s), which the trap does not do", n, dec.Reason)
+		}
+		naive.put(Record{
+			Target:        target,
+			PolicyVersion: 1,
+			MeasuredAt:    now.Add(time.Duration(n) * time.Hour),
+			Workload:      w,
+			Link:          measuredLink(),
+		})
+	}
+	if float64(growingTree(runs-1).Files)/firstFiles < 10 {
+		t.Fatal("the deploy did not grow far enough for the contrast to mean anything")
+	}
+}
+
+// TestDriftOnTheLinkAxis is the same trap one axis over. The round-trip time
+// stored in a record is the yardstick the next run is validated against, so a
+// record that took today's RTT along while keeping yesterday's throughput
+// would let the path move as far as it liked, a per cent at a time.
+func TestDriftOnTheLinkAxis(t *testing.T) {
+	s := stored(mediumTree(), measuredLink())
+
+	rtt := 13.0
+	hits := 0
+	for n := 1; n < 200; n++ {
+		at := now.Add(time.Duration(n) * time.Hour)
+		rtt *= 1.03
+
+		cand, dec := s.Lookup(target, mediumTree(), at)
+		if dec.Reason == "" {
+			dec = cand.Validate(time.Duration(rtt * float64(time.Millisecond)))
+		}
+		if !dec.Hit {
+			break
+		}
+		hits++
+		s.Update(Observation{
+			Target:   target,
+			Workload: mediumTree(),
+			Link:     Link{RTTMillis: rtt, HandshakeMillis: 380},
+			Reused:   true,
+		}, at)
+
+		if rec, _ := s.find(target); rec.Link.RTTMillis != 13 {
+			t.Fatalf("run %d moved the stored round-trip time to %.1f ms without measuring a throughput", n, rec.Link.RTTMillis)
+		}
+	}
+	if hits == 0 {
+		t.Fatal("the cache never hit, so this proves nothing")
+	}
+	if rtt < 26 {
+		t.Errorf("the cache stopped at %.1f ms, before the path had doubled; the band is meant to allow that much", rtt)
+	}
+	t.Logf("the cache stopped reusing after %d runs, at %.1f ms against the 13.0 ms it was measured at", hits, rtt)
+}
+
+// TestAMeasuringRunIsAllowedToMoveTheAnchor is the other half of the rule, and
+// the reason it is about evidence rather than about age. A run that measures
+// the link afresh describes the deploy it measured, so its anchor is the
+// current one and the cache keeps working for a repository that really is
+// growing.
+func TestAMeasuringRunIsAllowedToMoveTheAnchor(t *testing.T) {
+	files := 400
+	s := stored(Workload{Files: files, Bytes: int64(files) * 256 * 1024, P50: 256 * 1024, P90: 256 * 1024, Largest: 4 << 20}, measuredLink())
+
+	for n := 1; n < 60; n++ {
+		at := now.Add(time.Duration(n) * time.Hour)
+		files = int(float64(files) * 1.03)
+		w := Workload{Files: files, Bytes: int64(files) * 256 * 1024, P50: 256 * 1024, P90: 256 * 1024, Largest: 4 << 20}
+
+		cand, dec := s.Lookup(target, w, at)
+		if dec.Reason == "" {
+			dec = cand.Validate(13 * time.Millisecond)
+		}
+		if !dec.Hit {
+			t.Fatalf("run %d missed (%s), although every run measured the link for itself", n, dec.Reason)
+		}
+		s.Update(Observation{
+			Target:   target,
+			Workload: w,
+			Link:     Link{RTTMillis: 13, HandshakeMillis: 380, StreamBytesPerSecond: 8 << 20},
+			Measured: true,
+			Reused:   true,
+		}, at)
+	}
+	if rec, _ := s.find(target); rec.Workload.Files != files {
+		t.Errorf("the anchor is %d files, want the %d the last measurement was taken on", rec.Workload.Files, files)
+	}
+}

--- a/internal/autocache/store.go
+++ b/internal/autocache/store.go
@@ -1,0 +1,96 @@
+package autocache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// fileMode is what the cache file is created with. It holds no secrets (the
+// target is a fingerprint, see Record.Target), but it describes somebody's
+// deployment and there is no reason for it to be world readable.
+const fileMode = 0o600
+
+// ErrEmpty reports a path that holds no usable store yet: the file does not
+// exist, or it is empty. It is the normal state of a first run and the caller
+// says so at debug level rather than warning about it.
+var ErrEmpty = errors.New("no auto-tuning cache yet")
+
+// Load reads the store at path.
+//
+// Every failure mode here is recoverable by design, because the cache is an
+// optimisation and must never be able to fail a deploy (issue #212). A missing
+// file is ErrEmpty. A file that cannot be parsed, or that was written by a
+// newer easySFTP, comes back as an error together with an empty usable store,
+// so the caller can warn once and carry on with the built-in prior. The one
+// thing Load will not do is guess: a version it does not know is not read
+// field by field in the hope that the fields still mean what they meant.
+func Load(path string) (*Store, error) {
+	if path == "" {
+		return &Store{Version: FormatVersion}, ErrEmpty
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &Store{Version: FormatVersion}, ErrEmpty
+		}
+		return &Store{Version: FormatVersion}, err
+	}
+	if len(data) == 0 {
+		return &Store{Version: FormatVersion}, ErrEmpty
+	}
+	var s Store
+	if err := json.Unmarshal(data, &s); err != nil {
+		return &Store{Version: FormatVersion}, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if s.Version != FormatVersion {
+		return &Store{Version: FormatVersion}, fmt.Errorf(
+			"%s is version %d and this easySFTP writes version %d", path, s.Version, FormatVersion)
+	}
+	s.Version = FormatVersion
+	return &s, nil
+}
+
+// Save writes the store to path, creating the directory if it is missing (a
+// cache path pointed at a directory a CI cache has not restored yet is the
+// normal first run, not an error).
+//
+// The write is atomic: a temporary sibling, then a rename. A cache file
+// truncated by a cancelled job would be read back as corrupt on the next run,
+// which costs a warning and a re-measure; it is cheap to make that impossible.
+func Save(path string, s *Store) error {
+	if path == "" || s == nil {
+		return nil
+	}
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	s.Version = FormatVersion
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	defer os.Remove(name) // no-op once the rename succeeded
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(name, fileMode); err != nil {
+		return err
+	}
+	return os.Rename(name, path)
+}

--- a/internal/autocache/store_test.go
+++ b/internal/autocache/store_test.go
@@ -1,0 +1,157 @@
+package autocache
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRoundTrip is the file contract: what Save writes, Load reads back
+// unchanged, including the fields a hit is decided on.
+func TestRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auto.json")
+	want := stored(mediumTree(), measuredLink(), func(r *Record) {
+		r.ConnectionCeiling = 2
+		r.CeilingCarried = 1
+		r.Reused = 3
+	})
+	if err := Save(path, want); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Records) != 1 {
+		t.Fatalf("read %d record(s), want 1", len(got.Records))
+	}
+	a, b := want.Records[0], got.Records[0]
+	if !a.MeasuredAt.Equal(b.MeasuredAt) || !a.LastUsed.Equal(b.LastUsed) {
+		t.Errorf("timestamps did not survive: %v / %v", b.MeasuredAt, b.LastUsed)
+	}
+	a.MeasuredAt, a.LastUsed = time.Time{}, time.Time{}
+	b.MeasuredAt, b.LastUsed = time.Time{}, time.Time{}
+	if a != b {
+		t.Errorf("record changed on the way through the file:\n got %+v\nwant %+v", b, a)
+	}
+}
+
+// TestSaveCreatesTheDirectory: a cache path under a directory a CI cache has
+// not restored yet is a first run, not a failure.
+func TestSaveCreatesTheDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "deeper", "auto.json")
+	if err := Save(path, stored(mediumTree(), measuredLink())); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSaveLeavesNoDebris: the write goes through a temporary sibling, and the
+// sibling must not survive it. A stray file next to the cache would be
+// restored along with it by every CI cache hit from then on.
+func TestSaveLeavesNoDebris(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auto.json")
+	for i := 0; i < 3; i++ {
+		if err := Save(path, stored(mediumTree(), measuredLink())); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "auto.json" {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("the cache directory holds %v, want only auto.json", names)
+	}
+}
+
+// TestLoadDegradesCleanly. Every one of these is a state a deploy has to
+// survive: the cache is an optimisation, and an optimisation that can fail a
+// deploy is not one (issue #212).
+func TestLoadDegradesCleanly(t *testing.T) {
+	newer, err := json.Marshal(Store{Version: FormatVersion + 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		write   []byte
+		empty   bool
+		mention string
+	}{
+		{name: "missing file", empty: true},
+		{name: "empty file", write: []byte{}, empty: true},
+		{name: "truncated json", write: []byte(`{"version": 1, "records": [`), mention: "parsing"},
+		{name: "not json at all", write: []byte("nope"), mention: "parsing"},
+		{name: "a newer format", write: newer, mention: "version"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "auto.json")
+			if tc.write != nil {
+				if err := os.WriteFile(path, tc.write, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			s, err := Load(path)
+			if s == nil {
+				t.Fatal("Load returned no store; every caller would have to nil-check")
+			}
+			if len(s.Records) != 0 || s.Version != FormatVersion {
+				t.Errorf("the fallback store is not empty: %+v", s)
+			}
+			switch {
+			case tc.empty:
+				if !errors.Is(err, ErrEmpty) {
+					t.Errorf("err = %v, want ErrEmpty so the caller stays quiet about a first run", err)
+				}
+			case err == nil:
+				t.Errorf("a %s was accepted silently", tc.name)
+			case !strings.Contains(err.Error(), tc.mention):
+				t.Errorf("error %q does not mention %q", err, tc.mention)
+			}
+		})
+	}
+}
+
+// TestLoadWithoutAPathIsOff: an unconfigured cache reads nothing and reports
+// the same "nothing here" as a missing file, so the caller has one path.
+func TestLoadWithoutAPathIsOff(t *testing.T) {
+	s, err := Load("")
+	if !errors.Is(err, ErrEmpty) || s == nil || len(s.Records) != 0 {
+		t.Errorf("Load(\"\") = %+v, %v", s, err)
+	}
+	if err := Save("", stored(mediumTree(), measuredLink())); err != nil {
+		t.Errorf("Save(\"\") = %v, want a no-op", err)
+	}
+}
+
+// TestSavedFileIsReadable keeps the file something a person can open when a
+// deploy picked a surprising number. It is a small document, not a blob.
+func TestSavedFileIsReadable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auto.json")
+	if err := Save(path, stored(mediumTree(), measuredLink())); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"\n  \"version\"", "policy_version", "stream_bytes_per_second", "measured_at"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("the stored file does not contain %q:\n%s", want, data)
+		}
+	}
+}

--- a/internal/autotune/autotune.go
+++ b/internal/autotune/autotune.go
@@ -74,6 +74,18 @@ import (
 	"time"
 )
 
+// PolicyVersion is the generation of this policy. Bump it whenever a change
+// here makes an observation taken by an older easySFTP no longer comparable:
+// a different definition of what counts as a measurement, a different meaning
+// for one of the Workload features, a different cost model.
+//
+// It exists for internal/autocache, which stores measurements taken under this
+// policy and must refuse the ones taken under another (issue #212). Adding a
+// constant, refitting one against a new sweep or changing a clamp does not
+// need a bump: those change what the policy decides, not what a stored
+// measurement means.
+const PolicyVersion = 1
+
 // Hard bounds on what the policy may choose. A user who writes a number gets
 // that number; these only ever bound "auto".
 const (

--- a/internal/autotune/controller.go
+++ b/internal/autotune/controller.go
@@ -399,13 +399,44 @@ func (c *Controller) measuredLink(p Progress, rate float64) Link {
 // file, so a tree of small files with a few archives in it, where the bytes
 // really do come from files that can fill a stream, still gets a runtime
 // correction.
-func (c *Controller) bandwidthBound() bool {
-	size := c.workload.P90Upload
+func (c *Controller) bandwidthBound() bool { return BandwidthBound(c.workload) }
+
+// BandwidthBound reports whether a transfer of this workload produces a byte
+// rate that says something about the link's bandwidth. See the comment on
+// Controller.bandwidthBound for why the answer is not simply "it moved bytes",
+// and internal/autocache, which asks the same question of a stored shape
+// before reusing what was measured on it.
+func BandwidthBound(w Workload) bool {
+	size := w.P90Upload
 	if size == 0 {
 		// A workload with no distribution: the largest file is all there is.
-		size = c.workload.LargestUpload
+		size = w.LargestUpload
 	}
 	return size > packetBytes
+}
+
+// Measure turns one finished transfer into a per-connection throughput, or
+// reports that the transfer was not a measurement of the link at all.
+//
+// It is the same judgement Controller makes on one of its windows, asked of a
+// whole phase instead: enough time, enough bytes, and files large enough for a
+// byte rate to be a bandwidth. The aggregate is divided by the streams that
+// were really carrying files, not by the pool size, for the reason
+// Controller.measuredLink gives.
+//
+// A phase includes what a window deliberately excludes (the ramp-up, the tail
+// where most workers have finished), so this is the more conservative of the
+// two numbers. That is the right direction for something that will be stored
+// and reused: a throughput remembered slightly low costs a handshake, one
+// remembered high costs a pool that is too small for the work.
+func Measure(w Workload, bytes int64, window time.Duration, streams int) (float64, bool) {
+	switch {
+	case !BandwidthBound(w):
+		return 0, false
+	case bytes < minWindowBytes || window < minObservation || streams < 1:
+		return 0, false
+	}
+	return float64(bytes) / window.Seconds() / float64(streams), true
 }
 
 // remaining is the workload the run still has in front of it. For a settled

--- a/internal/autotune/controller_test.go
+++ b/internal/autotune/controller_test.go
@@ -461,3 +461,80 @@ func TestGrowthNeedsFilesThatHaveNotStarted(t *testing.T) {
 		t.Error("with files queued behind the workers the pool must still be allowed to grow")
 	}
 }
+
+// TestMeasureJudgesAWholePhaseTheWayAWindowIsJudged. internal/autocache stores
+// what a run measured, and what counts as a measurement has to be the policy's
+// rule rather than the storage layer's, or the two would drift apart. This is
+// that rule, asked of a whole upload phase (issue #212).
+func TestMeasureJudgesAWholePhaseTheWayAWindowIsJudged(t *testing.T) {
+	tiny := autotune.Workload{
+		Uploads: 2000, UploadBytes: 8 * MiB,
+		LargestUpload: 4096, P50Upload: 4096, P90Upload: 4096, SmallUploads: 2000,
+	}
+
+	for _, tc := range []struct {
+		name    string
+		w       autotune.Workload
+		bytes   int64
+		window  time.Duration
+		streams int
+		want    float64
+	}{
+		{
+			name: "a real transfer over four connections",
+			w:    byteHeavy, bytes: 40 * MiB, window: 10 * time.Second, streams: 4,
+			// The aggregate is 4 MiB/s; what a *connection* carried, which is
+			// what the model is expressed in, is a quarter of that.
+			want: MiB,
+		},
+		{
+			name: "files too small for a byte rate to be a bandwidth",
+			w:    tiny, bytes: 8 * MiB, window: 10 * time.Second, streams: 4,
+		},
+		{
+			name: "over in a moment",
+			w:    byteHeavy, bytes: 40 * MiB, window: 100 * time.Millisecond, streams: 4,
+		},
+		{
+			name: "barely any bytes",
+			w:    byteHeavy, bytes: 64 * 1024, window: 10 * time.Second, streams: 4,
+		},
+		{
+			name: "nothing was carrying it",
+			w:    byteHeavy, bytes: 40 * MiB, window: 10 * time.Second, streams: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := autotune.Measure(tc.w, tc.bytes, tc.window, tc.streams)
+			if ok != (tc.want > 0) {
+				t.Fatalf("Measure reported ok = %v, want %v", ok, tc.want > 0)
+			}
+			if got != tc.want {
+				t.Errorf("Measure = %.0f B/s, want %.0f", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBandwidthBoundReadsTheDistribution: the ninetieth percentile decides,
+// falling back to the largest file when a workload carries no distribution at
+// all. autocache asks the same question of a stored shape, so it is exported.
+func TestBandwidthBoundReadsTheDistribution(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		w    autotune.Workload
+		want bool
+	}{
+		{"a megabyte each", byteHeavy, true},
+		{"4 KiB each", autotune.Workload{Uploads: 100, P90Upload: 4096, LargestUpload: 4096}, false},
+		{"small files with a few archives", autotune.Workload{Uploads: 100, P90Upload: 2 * MiB, LargestUpload: 8 * MiB}, true},
+		{"no distribution, one big file", autotune.Workload{Uploads: 1, LargestUpload: 8 * MiB}, true},
+		{"nothing at all", autotune.Workload{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := autotune.BandwidthBound(tc.w); got != tc.want {
+				t.Errorf("BandwidthBound = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,6 +187,17 @@ type Config struct {
 	// issue #209.
 	Auto AutoSettings
 
+	// AutoCachePath, when set, is a local file where easySFTP remembers what
+	// it measured about this server, so the next run can plan from a
+	// measurement instead of its built-in assumption. Empty (the default)
+	// switches the cache off entirely: nothing is read and nothing is
+	// written.
+	//
+	// It only ever feeds settings left at "auto", and it only ever supplies
+	// inputs; the policy still decides. See internal/autocache, docs/tuning.md
+	// and issue #212.
+	AutoCachePath string
+
 	Retries      int
 	Timeout      time.Duration
 	SyncFastPath bool

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -70,6 +70,7 @@ type yamlAdvanced struct {
 	RequestConcurrency autoInt `yaml:"request_concurrency"`
 	Connections        autoInt `yaml:"connections"`
 	SkipUnchanged      bool    `yaml:"skip_unchanged"`
+	AutoCache          string  `yaml:"auto_cache"`
 }
 
 type yamlPermissions struct {
@@ -127,7 +128,7 @@ var allowedKeys = map[string][]string{
 	"defaults":         {"mode", "exclude"},
 	"deployments.*":    {"source", "target", "mode", "exclude"},
 	"safety":           {"max_deletes"},
-	"advanced":         {"retries", "timeout", "stall_timeout", "concurrency", "request_concurrency", "connections", "skip_unchanged"},
+	"advanced":         {"retries", "timeout", "stall_timeout", "concurrency", "request_concurrency", "connections", "skip_unchanged", "auto_cache"},
 	"permissions":      {"files", "directories", "preserve_times"},
 	"sync":             {"fast_path", "manifest"},
 }
@@ -365,6 +366,7 @@ func applyYAML(cfg *Config, yc *yamlConfig) error {
 		RequestConcurrency: yc.Advanced.RequestConcurrency.auto(),
 	}
 	cfg.SkipUnchanged = yc.Advanced.SkipUnchanged
+	cfg.AutoCachePath = strings.TrimSpace(yc.Advanced.AutoCache)
 
 	var err error
 	if cfg.FileMode, err = parseMode(yc.Permissions.Files, "permissions.files"); err != nil {

--- a/internal/config/configfile_test.go
+++ b/internal/config/configfile_test.go
@@ -204,3 +204,39 @@ func TestEditDistance(t *testing.T) {
 		}
 	}
 }
+
+// TestConfigFileAutoCache: advanced.auto_cache is a path and nothing else, and
+// leaving it out keeps the cache off, which is what every run did before it
+// existed (issue #212).
+func TestConfigFileAutoCache(t *testing.T) {
+	const base = `version: 3
+connection:
+  host: h
+  username: u
+  allow_any_host_key: true
+deployments:
+  web:
+    source: a
+    target: /b
+`
+	cfg, err := loadFile(t, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AutoCachePath != "" {
+		t.Errorf("a file that does not mention the cache enabled it at %q", cfg.AutoCachePath)
+	}
+
+	cfg, err = loadFile(t, base+"advanced:\n  auto_cache: \"  .easysftp/auto.json  \"\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AutoCachePath != ".easysftp/auto.json" {
+		t.Errorf("auto_cache = %q, want the trimmed path", cfg.AutoCachePath)
+	}
+
+	if _, err := loadFile(t, base+"advanced:\n  auto_cach: x\n"); err == nil ||
+		!strings.Contains(err.Error(), `did you mean "auto_cache"?`) {
+		t.Errorf("a typo next to auto_cache was not suggested against: %v", err)
+	}
+}

--- a/internal/uploader/autocache.go
+++ b/internal/uploader/autocache.go
@@ -1,0 +1,177 @@
+package uploader
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autocache"
+	"github.com/eiserv/easySFTP/internal/config"
+	"github.com/eiserv/easySFTP/internal/metrics"
+)
+
+// autoCache is the run's side of internal/autocache: it reads the file once
+// before the network is touched, offers the record to the policy when the link
+// probe has confirmed it, and writes back what this run learned.
+//
+// Everything here is best effort by construction. The cache exists to save a
+// run from planning against a guess; a cache that could fail a deploy would be
+// a bad trade at any hit rate, so every path below degrades to "carry on
+// without it" and says so once (issue #212).
+type autoCache struct {
+	path  string
+	store *autocache.Store
+
+	// target is the fingerprint this run reads and writes under. It is
+	// derived from the connection, never from the deployment: what a record
+	// describes is a path to a server.
+	target string
+
+	// candidate survives the pre-connection gates and is waiting for the link
+	// probe to confirm or reject it; decision is the answer, once there is
+	// one.
+	candidate autocache.Candidate
+	decision  autocache.Decision
+}
+
+// enabled reports whether this run has a cache at all.
+func (c *autoCache) enabled() bool { return c != nil && c.path != "" }
+
+// targetIdentity is what a record is keyed by: where this run connects and as
+// whom, plus the jump host when there is one, because a different bastion is a
+// different path even to the same server. It is hashed before it is stored;
+// see autocache.Record.Target.
+func targetIdentity(cfg *config.Config) string {
+	id := fmt.Sprintf("%s:%d:%s", cfg.Server, cfg.Port, cfg.Username)
+	if p := cfg.Proxy; p != nil {
+		id += fmt.Sprintf(" via %s:%d:%s", p.Server, p.Port, p.Username)
+	}
+	return id
+}
+
+// openAutoCache loads the cache file, if the configuration named one. A run
+// without advanced.auto_cache gets a value that answers false to enabled() and
+// does nothing from then on.
+//
+// A file that is missing is the normal first run. A file that cannot be read
+// or understood costs one warning: the user asked for a cache and is entitled
+// to know it is not working, and the run continues exactly as it would have
+// without one.
+func openAutoCache(cfg *config.Config, log Logger) *autoCache {
+	if cfg.AutoCachePath == "" {
+		return &autoCache{}
+	}
+	c := &autoCache{path: cfg.AutoCachePath, target: autocache.Fingerprint(targetIdentity(cfg))}
+	store, err := autocache.Load(cfg.AutoCachePath)
+	c.store = store
+	switch {
+	case errors.Is(err, autocache.ErrEmpty):
+		if cfg.Debug() {
+			log.Infof("auto tuning: no cache at %s yet; this run will write one", cfg.AutoCachePath)
+		}
+	case err != nil:
+		log.Warningf("could not use the auto-tuning cache at %s (%v); planning from easySFTP's own assumptions and rewriting it at the end of this run", cfg.AutoCachePath, err)
+	}
+	return c
+}
+
+// lookup runs the gates that need no connection: the format, the policy
+// generation, the age, the reuse budget and the workload anchor. The workload
+// is the whole run's plan, which is also what a write-back stores as the
+// anchor: a lookup and an anchor have to be the same kind of number or the
+// comparison means nothing.
+func (c *autoCache) lookup(w autocache.Workload) {
+	if !c.enabled() {
+		return
+	}
+	c.candidate, c.decision = c.store.Lookup(c.target, w, time.Now())
+}
+
+// confirm is the second half of the lookup and the validation issue #212 asks
+// for: the round-trip time this run has just measured, against the one the
+// record was written with. It is as cheap as validation gets, because the
+// probe runs anyway.
+//
+// It returns the decision so the caller can hand it to the policy. A run
+// without a cache, or one that already missed, gets a decision that restores
+// nothing.
+func (c *autoCache) confirm(rtt time.Duration, log Logger, debug bool) autocache.Decision {
+	if !c.enabled() {
+		return c.decision
+	}
+	if c.decision.Reason == "" {
+		// Nothing rejected the record before the connection, so this is the
+		// gate it still has to pass. A record that already missed keeps the
+		// sentence it missed with, which is the one worth logging.
+		c.decision = c.candidate.Validate(rtt)
+	}
+	switch {
+	case c.decision.Restores():
+		log.Infof("auto tuning: reusing what an earlier run measured against this server (%s), checked against the link this run measured (%s)",
+			restored(c.decision), c.decision.Reason)
+	case debug && c.decision.Hit:
+		log.Infof("auto tuning: the cached record for this server matches (%s) but carries nothing to reuse", c.decision.Reason)
+	case debug:
+		log.Infof("auto tuning: not reusing the cached settings (%s)", c.decision.Reason)
+	}
+	return c.decision
+}
+
+// restored describes what a hit actually hands the policy, for the log line.
+func restored(d autocache.Decision) string {
+	parts := make([]string, 0, 3)
+	if d.StreamBytesPerSecond > 0 {
+		parts = append(parts, fmt.Sprintf("%s/s per connection", HumanSize(int64(d.StreamBytesPerSecond))))
+	}
+	if d.ConnectionCeiling > 0 {
+		parts = append(parts, fmt.Sprintf("at most %d connection(s)", d.ConnectionCeiling))
+	}
+	if d.Reused > 0 {
+		parts = append(parts, fmt.Sprintf("reused %d time(s) so far", d.Reused))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// save writes back what this run learned. It is called once, at the end of the
+// run, whether or not the run succeeded: a refused connection and a measured
+// throughput are both worth remembering, and a deploy that failed halfway
+// still met the same server over the same path.
+func (c *autoCache) save(obs autocache.Observation, log Logger, debug bool) {
+	if !c.enabled() {
+		return
+	}
+	obs.Target = c.target
+	obs.Reused = c.decision.Hit
+	if !c.store.Update(obs, time.Now()) {
+		if debug {
+			log.Infof("auto tuning: the cache at %s already says everything this run learned", c.path)
+		}
+		return
+	}
+	if err := autocache.Save(c.path, c.store); err != nil {
+		log.Warningf("could not write the auto-tuning cache at %s (%v); the next run plans from easySFTP's own assumptions", c.path, err)
+		return
+	}
+	if debug {
+		log.Infof("auto tuning: recorded this run's measurements in %s", c.path)
+	}
+}
+
+// report writes what the cache did into the run counters, so a benchmark (and
+// a bug report) can tell a run that planned from a measurement apart from one
+// that planned from the prior. A run without a cache reports nothing at all,
+// which is how every other optional feature behaves here.
+func (c *autoCache) report() {
+	if !c.enabled() {
+		return
+	}
+	hit := int64(0)
+	if c.decision.Restores() {
+		hit = 1
+	}
+	metrics.Set("auto_cache_hit", hit)
+	metrics.Set("auto_cache_stream_bytes_per_second", int64(c.decision.StreamBytesPerSecond))
+	metrics.Set("auto_cache_connection_ceiling", int64(c.decision.ConnectionCeiling))
+	metrics.Set("auto_cache_reused", int64(c.decision.Reused))
+}

--- a/internal/uploader/autocache_test.go
+++ b/internal/uploader/autocache_test.go
@@ -1,0 +1,364 @@
+package uploader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autocache"
+	"github.com/eiserv/easySFTP/internal/autotune"
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// readCache loads the cache file a run left behind and fails the test if there
+// is not exactly one record in it.
+func readCache(t *testing.T, path string) autocache.Record {
+	t.Helper()
+	store, err := autocache.Load(path)
+	if err != nil {
+		t.Fatalf("reading the cache at %s: %v", path, err)
+	}
+	if len(store.Records) != 1 {
+		t.Fatalf("the cache holds %d record(s), want 1", len(store.Records))
+	}
+	return store.Records[0]
+}
+
+// TestAutoCacheRecordsWhatARunMeasured is the end-to-end wiring: a run with
+// advanced.auto_cache set writes what it learned about the server, and a
+// second run against the same server reads it back rather than starting a new
+// one.
+//
+// What it cannot assert is a throughput. The in-process server is a socket
+// away, so no upload phase here is long enough or large enough to be a
+// measurement of a link (autotune.Measure says so, and that is the same rule
+// the controller applies to its windows). What is asserted is everything a run
+// against a real server would build on: the record exists, it describes this
+// target and this deploy, and it carries the link the probe measured.
+func TestAutoCacheRecordsWhatARunMeasured(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 40)
+	path := filepath.Join(t.TempDir(), "cache", "auto.json")
+
+	cfg := autoConfig(srv)
+	cfg.AutoCachePath = path
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := readCache(t, path)
+	switch {
+	case rec.Target != autocache.Fingerprint(targetIdentity(cfg)):
+		t.Errorf("the record is filed under %q, not under this run's target", rec.Target)
+	case rec.PolicyVersion != autotune.PolicyVersion:
+		t.Errorf("policy version %d, want %d", rec.PolicyVersion, autotune.PolicyVersion)
+	case rec.Workload.Files != 40:
+		t.Errorf("the anchor describes %d file(s), want the 40 this run deployed", rec.Workload.Files)
+	case rec.Link.HandshakeMillis <= 0:
+		t.Error("the handshake this run paid was not recorded")
+	case rec.Link.RTTMillis <= 0:
+		t.Error("the round-trip time the probe measured was not recorded")
+	case rec.Settings.Connections < 1 || rec.Settings.Concurrency < 1:
+		t.Errorf("the settings this run used were not recorded: %+v", rec.Settings)
+	}
+
+	// A second run against the same server updates the one record rather than
+	// filing another.
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	readCache(t, path)
+}
+
+// TestAutoCacheIsOffWithoutAPath: the default is no cache at all, and a run
+// without one must not create files anywhere.
+func TestAutoCacheIsOffWithoutAPath(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 4)
+	dir := t.TempDir()
+
+	cfg := autoConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("a run without advanced.auto_cache wrote %d file(s)", len(entries))
+	}
+}
+
+// TestAutoCacheSurvivesAnUnreadableFile. The cache is an optimisation; one
+// that could fail a deploy would be a bad trade at any hit rate. A broken file
+// costs one warning and is replaced by what this run learned.
+func TestAutoCacheSurvivesAnUnreadableFile(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 4)
+	path := filepath.Join(t.TempDir(), "auto.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := autoConfig(srv)
+	cfg.AutoCachePath = path
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	stats, err := Run(context.Background(), cfg, log)
+	if err != nil {
+		t.Fatalf("an unreadable cache failed the deploy: %v", err)
+	}
+	if stats.FilesUploaded != 4 {
+		t.Errorf("uploaded %d file(s), want 4", stats.FilesUploaded)
+	}
+	if !hasLine(log.warnings, "auto-tuning cache") {
+		t.Errorf("no warning about the broken cache: %v", log.warnings)
+	}
+	if rec := readCache(t, path); rec.Workload.Files != 4 {
+		t.Errorf("the broken file was not replaced: %+v", rec)
+	}
+}
+
+// TestAutoCacheSeedsThePolicy is what a hit is for. A remembered throughput
+// fills the one input the policy cannot compute, and it is tagged as
+// remembered so that a runtime measurement of this transfer still outranks it.
+func TestAutoCacheSeedsThePolicy(t *testing.T) {
+	cfg := &config.Config{Auto: config.AutoSettings{Connections: true, Concurrency: true, RequestConcurrency: true}}
+	tune := newTuning(cfg)
+	tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
+
+	files := make([]fileItem, 400)
+	for i := range files {
+		files[i] = fileItem{size: 1 << 20}
+	}
+	work := uploadWorkload(files, false)
+	assumed := tune.planFor(work)
+
+	tune.applyCache(autocache.Decision{Hit: true, StreamBytesPerSecond: 32 << 20})
+	if got := tune.currentLink().Source(); got != autotune.SourceCached {
+		t.Fatalf("the link reports its throughput as %s, want it marked as remembered", got)
+	}
+	remembered := tune.planFor(work)
+
+	// 400 MiB at 32 MiB/s is a fraction of the work the 1 MiB/s prior implies,
+	// and a smaller W wants a smaller pool: that is the whole point of
+	// remembering the number.
+	if remembered.Connections >= assumed.Connections {
+		t.Errorf("planning with a measured 32 MiB/s chose %d connection(s), no fewer than the %d the prior chose",
+			remembered.Connections, assumed.Connections)
+	}
+}
+
+// TestAutoCacheCeilingBoundsThePool: a server that refused a connection, or a
+// growth step that measurably did not pay, is evidence the cost model cannot
+// derive for itself. It bounds the plan and the runtime controller alike,
+// because both go through the same clamp.
+func TestAutoCacheCeilingBoundsThePool(t *testing.T) {
+	srv := startTestServer(t)
+	cfg := autoConfig(srv)
+	tune := newTuning(cfg)
+	tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
+	tune.applyCache(autocache.Decision{Hit: true, ConnectionCeiling: 2})
+
+	files := make([]fileItem, 2000)
+	for i := range files {
+		files[i] = fileItem{size: 4096}
+	}
+	if got := tune.planFor(uploadWorkload(files, false)); got.Connections != 2 {
+		t.Errorf("a 2000-file deploy over a 13 ms line planned %d connection(s), want the remembered ceiling of 2", got.Connections)
+	}
+
+	sess := &session{cfg: cfg, tune: tune, log: testLogger{t}, conns: make([]*conn, autotune.MaxConnections), spread: 1}
+	if got := sess.setSpread(autotune.MaxConnections); got != 2 {
+		t.Errorf("the runtime controller widened the spread to %d past the remembered ceiling", got)
+	}
+}
+
+// TestPinnedConnectionsBeatTheCache. "Explicit configuration always overrides
+// cached values" is the first line of issue #212's behaviour list, and a
+// remembered ceiling is the one thing in a record that could quietly contradict
+// a number the user wrote.
+func TestPinnedConnectionsBeatTheCache(t *testing.T) {
+	cfg := &config.Config{
+		Connections: 6,
+		Auto:        config.AutoSettings{Concurrency: true, RequestConcurrency: true},
+	}
+	tune := newTuning(cfg)
+	tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
+	tune.applyCache(autocache.Decision{Hit: true, ConnectionCeiling: 2, StreamBytesPerSecond: 32 << 20})
+
+	files := make([]fileItem, 2000)
+	for i := range files {
+		files[i] = fileItem{size: 4096}
+	}
+	if got := tune.planFor(uploadWorkload(files, false)); got.Connections != 6 {
+		t.Errorf("advanced.connections: 6 resolved to %d against a remembered ceiling of 2", got.Connections)
+	}
+}
+
+// TestCacheObservationReadsTheServersAnswer covers the three ways a run ends up
+// with a connection ceiling to record, which is the one piece of a record that
+// is not about the measurement.
+func TestCacheObservationReadsTheServersAnswer(t *testing.T) {
+	work := autotune.SummarizeUploads([]int64{1 << 20, 1 << 20})
+	adaptive := func() *config.Config {
+		return &config.Config{Auto: config.AutoSettings{Connections: true, Concurrency: true, RequestConcurrency: true}}
+	}
+
+	t.Run("the server refused one", func(t *testing.T) {
+		tune := newTuning(adaptive())
+		obs := tune.cacheObservation(work, 3, true)
+		if obs.ConnectionCeiling != 3 || obs.CeilingUntested {
+			t.Errorf("obs = %+v, want a ceiling of 3", obs)
+		}
+	})
+
+	t.Run("a growth step was taken back", func(t *testing.T) {
+		tune := newTuning(adaptive())
+		tune.applied(autotune.Settings{Connections: 4}, true)
+		obs := tune.cacheObservation(work, 8, false)
+		if obs.ConnectionCeiling != 4 || obs.CeilingUntested {
+			t.Errorf("obs = %+v, want the spread the run settled on", obs)
+		}
+	})
+
+	t.Run("held at an inherited ceiling", func(t *testing.T) {
+		tune := newTuning(adaptive())
+		tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
+		tune.applyCache(autocache.Decision{Hit: true, ConnectionCeiling: 2})
+		files := make([]fileItem, 2000)
+		for i := range files {
+			files[i] = fileItem{size: 4096}
+		}
+		tune.planFor(uploadWorkload(files, false))
+
+		obs := tune.cacheObservation(work, 2, false)
+		if obs.ConnectionCeiling != 0 || !obs.CeilingUntested {
+			t.Errorf("obs = %+v, want an untested ceiling: this run never asked for more", obs)
+		}
+	})
+
+	t.Run("nothing pushed back", func(t *testing.T) {
+		tune := newTuning(adaptive())
+		obs := tune.cacheObservation(work, 4, false)
+		if obs.ConnectionCeiling != 0 || obs.CeilingUntested {
+			t.Errorf("obs = %+v, want no ceiling at all", obs)
+		}
+	})
+}
+
+// TestTargetIdentityDistinguishesPaths: a record describes a path to a server,
+// so two runs that reach different servers, or the same server through
+// different bastions, must not share one.
+func TestTargetIdentityDistinguishesPaths(t *testing.T) {
+	base := &config.Config{Server: "sftp.example.com", Port: 22, Username: "deploy"}
+	same := &config.Config{Server: "sftp.example.com", Port: 22, Username: "deploy"}
+	viaJump := &config.Config{Server: "sftp.example.com", Port: 22, Username: "deploy",
+		Proxy: &config.Proxy{Server: "bastion.example.com", Port: 22, Username: "jump"}}
+
+	if targetIdentity(base) != targetIdentity(same) {
+		t.Error("the same connection produced two identities")
+	}
+	if targetIdentity(base) == targetIdentity(viaJump) {
+		t.Error("a run through a jump host shares an identity with the direct one")
+	}
+}
+
+func hasLine(lines []string, substr string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAutoCacheRejectsARecordFromADifferentLink is the validation issue #212
+// asks for, end to end: the run measures the link it is on and compares it
+// with the one the record was written against. Driven by taking the record a
+// real run wrote and moving only its round-trip time, so everything else about
+// it still matches exactly.
+func TestAutoCacheRejectsARecordFromADifferentLink(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	poolTree(t, local, 40)
+	path := filepath.Join(t.TempDir(), "auto.json")
+
+	cfg := autoConfig(srv)
+	cfg.AutoCachePath = path
+	cfg.LogLevel = config.LogDebug
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The same record, from a link a hundred times further away, with a
+	// throughput on it so that a hit would have something to restore.
+	store, err := autocache.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.Records[0].Link.RTTMillis = 100
+	store.Records[0].Link.StreamBytesPerSecond = 4 << 20
+	if err := autocache.Save(path, store); err != nil {
+		t.Fatal(err)
+	}
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatal(err)
+	}
+	if !hasLine(log.infos, "not reusing the cached settings") {
+		t.Errorf("the run did not say why it ignored the record: %v", log.infos)
+	}
+	if hasLine(log.infos, "reusing what an earlier run measured") {
+		t.Error("a record from a 100 ms link was reused on a loopback connection")
+	}
+
+	// The measurement is kept rather than thrown away: the run that could not
+	// use it had nothing better to offer.
+	if rec := readCache(t, path); rec.Link.StreamBytesPerSecond != 4<<20 {
+		t.Errorf("the stored measurement was discarded by a run that could not use it: %+v", rec.Link)
+	}
+}
+
+// TestAutoCacheConfirmSaysWhatItDid pins the two sentences a user reads, on a
+// link injected rather than measured so the assertion is about the wiring and
+// not about how far away a loopback socket happens to be.
+func TestAutoCacheConfirmSaysWhatItDid(t *testing.T) {
+	work := autocache.WorkloadOf(autotune.SummarizeUploads([]int64{1 << 20, 1 << 20, 1 << 20}))
+	store := &autocache.Store{Version: autocache.FormatVersion}
+	store.Update(autocache.Observation{
+		Target:            "sha256:abc",
+		Workload:          work,
+		Link:              autocache.Link{RTTMillis: 13, HandshakeMillis: 380, StreamBytesPerSecond: 1 << 20},
+		Measured:          true,
+		ConnectionCeiling: 2,
+	}, time.Now())
+
+	cache := &autoCache{path: "auto.json", store: store, target: "sha256:abc"}
+	cache.lookup(work)
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	dec := cache.confirm(14*time.Millisecond, log, false)
+	if !dec.Restores() || dec.ConnectionCeiling != 2 || dec.StreamBytesPerSecond != 1<<20 {
+		t.Fatalf("decision = %+v, want the throughput and the ceiling restored", dec)
+	}
+	if !hasLine(log.infos, "reusing what an earlier run measured") ||
+		!hasLine(log.infos, "at most 2 connection(s)") {
+		t.Errorf("the hit was not reported: %v", log.infos)
+	}
+}

--- a/internal/uploader/session.go
+++ b/internal/uploader/session.go
@@ -146,17 +146,45 @@ func poolCeiling(tune *tuning, log Logger) int {
 // until a worker lands on a fresh slot, and lowering it simply stops handing
 // files to connections that are already open.
 //
-// The spread never exceeds the allocated slots, and never grows again once the
-// server has refused one.
+// The spread never exceeds the allocated slots, never exceeds a ceiling an
+// earlier run against this server left behind (issue #212), and never grows
+// again once the server has refused one.
+//
+// The ceiling is applied here rather than only in the plan because this is the
+// one place every change goes through, the runtime controller's growth
+// included: the pool is allocated to the policy's own maximum before the cache
+// has been validated (slots are lazy, so that costs nothing), so the bound has
+// to live where the spread moves.
 func (s *session) setSpread(n int) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	n = min(max(n, 1), len(s.conns))
+	if s.tune != nil {
+		n = s.tune.clampConnections(n)
+	}
 	if s.refused && n > s.spread {
 		return s.spread
 	}
 	s.spread = n
 	return s.spread
+}
+
+// currentSpread is how many connections the current deployment is handing
+// files to, which is how many streams a throughput measurement has to be
+// divided by.
+func (s *session) currentSpread() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return max(s.spread, 1)
+}
+
+// granted reports how many connections the server actually gave this run, and
+// whether it ever said no. Together they are the evidence a connection ceiling
+// is written from; see tuning.cacheObservation.
+func (s *session) granted() (int, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.openSlots(), s.refused
 }
 
 // workers is how many of items one phase may have in flight. With

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -104,6 +104,7 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 	sess.setSpread(settings.Connections)
 	logTuning(cfg, sess, files, skipUnchanged, settings, log)
 
+	uploadStart := time.Now()
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(settings.Concurrency)
 	results := make([]int64, len(files))
@@ -173,6 +174,8 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 		})
 	}
 	runErr := g.Wait()
+	var sent int64
+	var sentFiles int
 	for i, n := range results {
 		switch {
 		case skipped[i]:
@@ -180,7 +183,18 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 		case completed[i]:
 			stats.FilesUploaded++
 			stats.BytesUploaded += n
+			sent += n
+			sentFiles++
 		}
+	}
+	if !cfg.DryRun {
+		// What this phase turned out to achieve, which is the one input the
+		// policy could not have before it started. It is kept for the *next*
+		// run (internal/autocache); within this one the controller has already
+		// acted on its own windows. A dry run moved no bytes and is skipped
+		// above: its results hold planned sizes, not transferred ones.
+		streams := min(sess.currentSpread(), settings.Concurrency, sentFiles)
+		sess.tune.observe(work, sent, time.Since(uploadStart), streams)
 	}
 	return completed, runErr
 }

--- a/internal/uploader/tuning.go
+++ b/internal/uploader/tuning.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/sftp"
 
+	"github.com/eiserv/easySFTP/internal/autocache"
 	"github.com/eiserv/easySFTP/internal/autotune"
 	"github.com/eiserv/easySFTP/internal/config"
 	"github.com/eiserv/easySFTP/internal/metrics"
@@ -59,6 +60,30 @@ type tuning struct {
 	spreadUp    int
 	spreadDown  int
 	finalSpread int
+
+	// ceiling is an upper bound on the pool that came from an earlier run
+	// against this server: it refused a connection, or a growth step
+	// measurably did not pay. Zero is the normal case and means the policy is
+	// free up to its own maximum. capped latches when the bound actually held
+	// something back, which is what tells the write-back that this run did
+	// not put the limit to the test (issue #212, and see
+	// autocache.MaxCeilingCarry).
+	ceiling int
+	capped  bool
+
+	// observed is what this run's own transfers measured about the link, per
+	// connection, and observedBytes the size of the transfer that produced it.
+	// The largest transfer wins: both are measurements, and the one with more
+	// bytes behind it is the better one.
+	//
+	// It is deliberately not folded back into link. Within a deployment the
+	// runtime controller already acts on its own measurement, and re-planning
+	// the *next* deployment of the same run against a number the first one
+	// produced would change what a multi-deployment run does today for
+	// reasons that belong to issue #209, not here. What this is for is the
+	// next run.
+	observed      float64
+	observedBytes int64
 }
 
 // newTuning reads which settings the configuration pinned. Everything it does
@@ -152,6 +177,105 @@ func (t *tuning) currentLink() autotune.Link {
 	return t.link
 }
 
+// applyCache hands the policy what an earlier run against this server
+// measured, once the link probe has confirmed the record still describes this
+// path (see autoCache.confirm).
+//
+// Only two things come out of a record, and neither is a setting. The
+// throughput fills the one input the policy cannot compute for itself, tagged
+// as cached so that a runtime measurement of this transfer still outranks it.
+// The ceiling bounds the pool at whatever the server was last seen to allow or
+// to benefit from, which the cost model cannot derive because it assumes
+// perfect scaling. Everything else is planned from scratch, on this run's
+// files, which is what keeps a growing dataset from inheriting an old
+// deployment's answer (issue #212).
+func (t *tuning) applyCache(d autocache.Decision) {
+	if !d.Restores() {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if d.StreamBytesPerSecond > 0 {
+		t.link.StreamBytesPerSecond = d.StreamBytesPerSecond
+		t.link.ThroughputSource = autotune.SourceCached
+	}
+	t.ceiling = d.ConnectionCeiling
+}
+
+// clampConnections applies the inherited ceiling to a connection count, and
+// notes when it actually held one back. Every path that decides how many
+// connections files go over runs through here: the per-deployment plan and,
+// via session.setSpread, the runtime controller.
+func (t *tuning) clampConnections(n int) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.clampLocked(n)
+}
+
+// clampLocked is clampConnections with the lock already held.
+//
+// A number the user wrote is never clamped. The cache exists to fill in what
+// easySFTP would otherwise have to guess, and advanced.connections is not a
+// guess: explicit configuration wins over anything remembered, which is the
+// first thing issue #212 asks for.
+func (t *tuning) clampLocked(n int) int {
+	if t.fixed.Connections > 0 || t.ceiling <= 0 || n <= t.ceiling {
+		return n
+	}
+	t.capped = true
+	return t.ceiling
+}
+
+// observe folds one finished transfer into what this run knows about the link.
+// A transfer that is not a measurement (too short, too few bytes, or files too
+// small for a byte rate to be a bandwidth) is not one, and autotune.Measure is
+// the single place that judgement is made.
+func (t *tuning) observe(w autotune.Workload, bytes int64, window time.Duration, streams int) {
+	rate, ok := autotune.Measure(w, bytes, window, streams)
+	if !ok {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if bytes <= t.observedBytes {
+		return
+	}
+	t.observed, t.observedBytes = rate, bytes
+}
+
+// cacheObservation is what this run has to tell the next one: the shape it
+// deployed, what it measured about the path, what it ran with, and any bound
+// the server put on the pool.
+//
+// The ceiling is worked out here because this is the only place that can see
+// all three of its causes at once. A refusal is the server saying no outright,
+// and the number it granted is the answer. A step the runtime controller took
+// back is the server saying no in slower words: the growth was measured and it
+// did not pay. A run that was simply held at a ceiling it inherited learned
+// neither, and says so, so that the bound is carried forward as untested
+// rather than as fresh evidence.
+func (t *tuning) cacheObservation(runWork autotune.Workload, granted int, refused bool) autocache.Observation {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	link := t.link
+	link.StreamBytesPerSecond = t.observed
+	obs := autocache.Observation{
+		Workload: autocache.WorkloadOf(runWork),
+		Link:     autocache.LinkOf(link),
+		Settings: autocache.SettingsOf(t.effective),
+		Measured: t.observed > 0,
+	}
+	switch {
+	case refused:
+		obs.ConnectionCeiling = max(granted, 1)
+	case t.spreadDown > 0:
+		obs.ConnectionCeiling = max(t.finalSpread, 1)
+	case t.capped:
+		obs.CeilingUntested = true
+	}
+	return obs
+}
+
 // planFor resolves one deployment's transfer against the work it really has.
 // For sync that is the changed set the manifest just produced, not the tree
 // that was scanned.
@@ -160,6 +284,7 @@ func (t *tuning) planFor(w autotune.Workload) autotune.Settings {
 	defer t.mu.Unlock()
 	s := autotune.Plan(w, t.link, t.fixed)
 	s.RequestConcurrency = t.requests // fixed with the connection; see resolveRunWide
+	s.Connections = t.clampLocked(s.Connections)
 	if !t.haveInitial {
 		// The first transfer's choice is the one worth reporting as "what the
 		// policy picked": it is the decision taken purely from the plan and
@@ -261,6 +386,12 @@ func (t *tuning) report() {
 	// works out to over the measured RTT.
 	metrics.Set("link_stream_bytes_per_second", int64(t.link.StreamBytesPerSecond))
 	metrics.Set("link_bdp_bytes", t.link.BDPBytes())
+	// What this run's own transfers turned out to carry, per connection. It is
+	// a different number from the one above: that is what the pipelining was
+	// sized against (a prior, or something remembered), this is what actually
+	// happened, and it is zero for a deployment no byte rate could be read
+	// from (see autotune.Measure).
+	metrics.Set("link_observed_stream_bytes_per_second", int64(t.observed))
 }
 
 // planWorkload turns a set of planned files into the features the policy

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -18,6 +18,7 @@ import (
 
 	ignore "github.com/sabhiram/go-gitignore"
 
+	"github.com/eiserv/easySFTP/internal/autocache"
 	"github.com/eiserv/easySFTP/internal/config"
 	"github.com/eiserv/easySFTP/internal/metrics"
 )
@@ -69,6 +70,13 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	tune := newTuning(cfg)
 	defer tune.report()
 
+	// What an earlier run measured against this server, if the configuration
+	// named a file to keep it in. Read before anything else so a broken cache
+	// file is reported next to the run's other setup problems, and applied
+	// only much later, once the link probe has confirmed it still describes
+	// this path (issue #212).
+	cache := openAutoCache(cfg, log)
+
 	// Build the full local plan first so config/path errors surface before
 	// we touch the network.
 	endScan := metrics.Phase("local_scan")
@@ -106,7 +114,13 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	// both are sized here, against every deployment's plan, before the first
 	// handshake. Stage 2 (the link) happens inside newSession, stage 3 during
 	// each transfer.
-	tune.resolveRunWide(runWorkload(plans))
+	runWork := runWorkload(plans)
+	tune.resolveRunWide(runWork)
+
+	// The gates a cached record can face before the network is touched. The
+	// run-wide plan is both what a lookup is judged against and what a
+	// write-back stores as the anchor, so the two are the same kind of number.
+	cache.lookup(autocache.WorkloadOf(runWork))
 
 	endConnect := metrics.Phase("connect")
 	sess, err := newSession(ctx, cfg, tune, log)
@@ -117,6 +131,18 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	defer func() {
 		defer metrics.Phase("cleanup")()
 		sess.close()
+	}()
+
+	// Stage 2 has just measured this link, so the record can now be checked
+	// against it and, if it survives, handed to the policy before any
+	// deployment is planned. Everything this run learns goes back at the end,
+	// including from a run that fails: a refused connection is evidence about
+	// the server whether or not the deploy finished.
+	tune.applyCache(cache.confirm(tune.currentLink().RTT, log, cfg.Debug()))
+	defer func() {
+		granted, refused := sess.granted()
+		cache.report()
+		cache.save(tune.cacheObservation(runWork, granted, refused), log, cfg.Debug())
 	}()
 
 	keepaliveCtx, stopKeepalives := context.WithCancel(ctx)

--- a/schema/easysftp.schema.json
+++ b/schema/easysftp.schema.json
@@ -167,6 +167,11 @@
         "skip_unchanged": {
           "description": "For overlay deployments, skip uploading a file when the remote file already exists with the same size (coarse; use mode sync for exact content comparison).",
           "type": "boolean"
+        },
+        "auto_cache": {
+          "description": "Path to a local file where easySFTP remembers what it measured about this server (round-trip time, per-connection throughput, any connection limit the server showed), so a later run can plan from a measurement instead of its built-in assumption. Unset (the default) switches the cache off. It only affects settings left at \"auto\", it never restores stored settings, and a stale or unreadable file costs a warning rather than the deploy. On ephemeral CI runners the file has to be persisted between runs, e.g. with actions/cache.",
+          "type": "string",
+          "minLength": 1
         }
       }
     },


### PR DESCRIPTION
Closes #212.

## The short version

The auto policy has exactly one input it cannot compute before the transfer
starts: how fast the link is. Everything else is either known from the plan or
measured in the first round-trips. So every run starts from a deliberately
conservative prior, and only a run big enough for the runtime controller to
close a window ever corrects it (which, per #217, excludes every deployment of
64 files or fewer).

`advanced.auto_cache` names a local file where a run keeps what it measured, so
the next run plans from a measurement instead.

```yaml
advanced:
  auto_cache: .easysftp-cache/auto.json
```

Off unless a path is given. Config-file only, like the three settings it feeds.

## The design decision: memoize the measurement, not the decision

The issue asks to memoize the auto *decision*. In this codebase the honest way
to do that is to memoize the input that is missing, because `autotune.Plan` is
a pure function with no I/O and no clock: replaying its output would save
nothing measurable and would buy the one failure mode a configuration cache
really has.

So a hit restores exactly two things, and neither is a setting:

* **the per-connection throughput**, handed to the policy as
  `autotune.SourceCached`, which a runtime measurement of the current transfer
  still outranks;
* **a connection ceiling**, when an earlier run met one: the server refused an
  extra connection, or a growth step measurably did not pay. The cost model
  assumes perfect scaling (`T(k) = W/k + (k-1)*H`) and cannot derive either;
  the only way to know is to have been told. A ceiling only ever lowers the
  pool.

The settings the previous run used *are* stored, so a record explains itself
when somebody opens it, but nothing replays them. The policy runs again, on
today's files.

## The drift problem, and why it cannot happen here

This is the part worth reviewing closely, and it was the explicit worry behind
the task.

A deploy that grows a few per cent per run is, at every single step, almost
identical to the run before it. A cache that asks "does this look like last
time?" answers yes forever, and a hundred runs later it is still standing on
something measured on a deploy a fraction of the current size. Nothing ever
looks wrong from the inside: every comparison it makes passes comfortably.
There is no threshold that fixes this, because no threshold separates 1,000
files from 1,030.

Two independent defences:

1. **Settings are never restored.** Even a hit that should not have happened
   cannot preserve an old deploy's connection count: a deployment that grew
   from 1,000 files to 5,000 gets a 5,000-file plan, because the record was
   never consulted about the answer.
2. **Records are anchored.** A record describes the workload *its measurement
   was taken on*, and a run that merely uses a record rewrites neither that
   anchor nor the stored link. Only a run that measures the link for itself
   re-anchors, because only that run has new evidence. So drift is measured
   from the measurement, accumulates, and leaves the band. The same rule covers
   the round-trip time the record is validated against, so the link cannot
   creep either.

`internal/autocache/drift_test.go` replays both readings over the same sequence
of deploys (3% growth per run, 120 runs):

```text
the anchored cache stopped hitting at run 25, with the deploy 1.99x its original size
the cache stopped reusing after 23 runs, at 26.4 ms against the 13.0 ms it was measured at
```

and asserts, in the same test, that a "compare against the previous run"
implementation never misses over that whole sequence, with the deploy ending up
19x its original size. A third test pins the other half of the rule: a
repository that really is growing *and* measures the link each time keeps
hitting, because its evidence is current.

## Validation and invalidation

Before the connection: unreadable or newer file format, unknown target, a
different `autotune.PolicyVersion`, older than 30 days, reused 32 times without
being re-measured, or the workload no longer resembles the anchor.

After the connection, and this is the strongest gate: **the round-trip time
this run has just measured** against the one stored with the throughput. Free,
because the link probe runs anyway, and it is the only check backed by a
measurement taken today.

Similarity is loose on size (the issue's own 980-vs-1,000 example hits) and
strict on kind: a deploy whose files cannot fill a stream and one whose files
can are never comparable, since a byte rate measured on the first is a file
rate in other units (`autotune.BandwidthBound`, which the controller already
used and which is now exported so both sides ask one question).

An inherited connection ceiling is the one part that could quietly become
configuration, since a capped run never asks for more and so never learns
whether the limit is still there. It is carried at most 16 runs, then dropped
so the next run finds out.

## Behaviour guarantees from the issue

* Explicit configuration always wins: a pinned `advanced.connections` is never
  clamped by a remembered ceiling (`TestPinnedConnectionsBeatTheCache`).
* Only `auto` settings are affected.
* A miss falls back to exactly today's behaviour.
* A missing, unreadable, outdated or unwritable cache costs at most a warning,
  never the deploy (`TestAutoCacheSurvivesAnUnreadableFile`,
  `TestLoadDegradesCleanly`).
* The file names no host: the target is a truncated SHA-256 of
  host/port/user/jump host, because the file may end up in a CI cache that
  outlives the job.

## One deliberate limitation

`request_concurrency` is outside the cache's reach. It is baked into an SFTP
client when the client is created, so it must be resolved before there is a
connection, and therefore before a record can be checked against the link this
run is actually on. Restoring it there would mean sizing the pipelining from
evidence nothing had validated yet, which is precisely what the rest of this
change refuses to do. Documented in `docs/tuning.md` under "Limits".

## What else moved

* `autotune.PolicyVersion`, `autotune.BandwidthBound` and `autotune.Measure`:
  the evidence rules stay in the policy, so the storage layer cannot drift away
  from what the controller means by a measurement.
* A finished upload phase is now judged as a measurement the same way a
  controller window is, and the run's own number lands in a new
  `link_observed_stream_bytes_per_second` counter (distinct from
  `link_stream_bytes_per_second`, which is what the pipelining was *sized*
  against).
* `session.setSpread` is where the ceiling is applied, so the runtime
  controller is bounded by the same clamp as the plan.
* Docs: `docs/tuning.md` ("Remembering what it measured"),
  `docs/configuration.md` (row, subsection and the `actions/cache` recipe),
  the example config, the JSON schema, and a section in `CLAUDE.md` /
  `AGENTS.md` with the four invariants a future change here must not break.

## Testing

`go test ./...` is green. `-race` could not be run locally (no C toolchain on
this machine, `-race requires cgo`); CI runs it.

The CI self-test gains an auto-cache round-trip against the real OpenSSH
container: the file is written into a directory that did not exist, carries the
link the probe measured, leaves no debris next to itself, and a second deploy
updates that one record rather than filing another. Unit tests cannot cover
that, because they never run `action.yml`'s composite wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
