### PR TITLE
perf(action): keep the benchmark corpus out of the action download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,10 @@ LICENSE text eol=lf
 # Bash reads these verbatim; CRLF would break the version parser on Windows runners.
 *.sh text eol=lf
 .easysftp-version text eol=lf
+
+# The stored benchmark corpus is repository history, not part of the action.
+# Every consumer of `uses: eiserv/easySFTP@v3` downloads the tarball GitHub
+# builds with `git archive`, and export-ignore keeps 2.0 MB of measurements
+# out of it. CI checks the repository out rather than exporting it, so the
+# corpus stays fully available to the benchmark and analysis workflows.
+benchmarks/ export-ignore

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -504,6 +504,13 @@ If results are ever moved by hand, `KIND=reindex go run ./cmd/easysftp-bench sto
 rebuilds `index.json`, `trend.csv` and `latest.*` from whatever is on disk
 without storing anything new.
 
+This directory is `export-ignore`d in [`.gitattributes`](../.gitattributes), so
+it is absent from the tarball `git archive` produces and therefore from the
+download every `uses: eiserv/easySFTP@v3` job pays for. It is fully present in
+every clone and every `actions/checkout`, which is what the benchmark and
+analysis workflows use, so nothing that reads the corpus is affected. Keep the
+rule in mind when adding a path that the action itself needs at run time.
+
 ## Running a benchmark
 
 The **`SFTP benchmark`** workflow


### PR DESCRIPTION
Closes #226.

## What

One `export-ignore` line in `.gitattributes` plus the note in `benchmarks/README.md` that explains why it is there.

## Measured, before and after

`git archive` is what GitHub serves for an action ref, so this is the exact byte count every `uses: eiserv/easySFTP@v3` job downloads before the composite action starts:

| tarball | bytes | |
|---|---|---|
| `git archive --format=tar.gz origin/main` | 2,550,016 | before |
| `git archive --format=tar.gz HEAD` | **420,777** | after |

**83.5% smaller**, and `benchmarks/` contributes 0 entries to the export where it previously contributed 2,131,577 bytes (the difference is larger than the standalone figure because the corpus compresses differently in isolation).

## Verified the action still works from the export

The prebuilt path only needs `action.yml`, `scripts/` and `.easysftp-version`; the source-build path additionally needs `go.mod`, `go.sum`, `cmd/` and `internal/`. Extracted the post-change archive to a clean directory and ran the exact command `action.yml` runs:

```
--- action-critical files present? ---
ok  action.yml
ok  .easysftp-version
ok  go.mod
ok  go.sum
ok  scripts/prepare-action.sh
ok  scripts/action-lib.sh
--- build from the export ---
BUILD FROM EXPORT OK
```

Nothing else consumes an exported archive: every workflow uses `actions/checkout`, which does not apply `export-ignore`, so `analysis-tests`, the schema fixture test that decodes every stored result, and both benchmark workflows keep seeing the full corpus.

## Scope left out on purpose

- `docs/` (44.7 KB) and `site/` (9.6 KB) are also unnecessary at run time, as the issue notes, but together they are 2.1% of what `benchmarks/` was. Excluding them trades a real risk (a docs path referenced from a future composite step) for a rounding error, so this PR does not.
- Whether the matrix sweeps belong in the repository at all is the durable fix for the growth rate and is left open in #226's last paragraph. `export-ignore` removes the user-facing cost today regardless of how that is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)