### PR TITLE
docs(readme): stop claiming the alternatives are unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ with `allow-any-host-key: true`, but that allows man-in-the-middle attacks.)
 ## Why easySFTP?
 
 I needed an SFTP upload step for a GitHub Actions deploy, and none of the
-existing options really fit. They were either no longer actively maintained,
-not resource-friendly, hard or barely configurable, or they simply did not work
-reliably. So I built my own and made it available for everyone with the same
-problem: an action that stays out of your way for the simple case and still
-handles the complex ones.
+existing options really fit. None of them verified the host key, none of them
+guarded a delete, and the ones that could skip unchanged files could not also
+run on a Windows runner. So I built my own and made it available for everyone
+with the same problem: an action that stays out of your way for the simple case
+and still handles the complex ones.
 
 Here is how easySFTP compares to other open-source actions that tackle the same
 job:
@@ -79,16 +79,21 @@ job:
 | Delete safety guards | yes (root refusal, max_deletes) | no | no | no | no |
 | Multiple targets / modes | yes (config file) | multiple mappings | single directory | single directory | single directory |
 | Dry run | yes | yes | yes | no | no |
-| Actively maintained | yes | last release 2024 | yes | yes | yes |
 
-The matrix reflects each project's public documentation as of July 2026.
+The matrix reflects each project's public documentation as of August 2026.
 "Not documented" means the feature was not found in that action's README, not
 that it is impossible. SamKirkland's FTP-Deploy-Action is by far the most
 popular deploy action, but it speaks FTP/FTPS rather than SFTP, so it is listed
 for context rather than as a direct SFTP alternative.
 
-easySFTP is a clean, from-scratch implementation in Go, inspired by the
-no-longer-maintained [Dylan700/sftp-upload-action][dylan]:
+The matrix deliberately carries no "actively maintained" row. Feature rows age
+slowly and a maintenance row ages in weeks, so it is the one cell most likely
+to be wrong when you read it. Each project's releases page answers that
+question better than this table can: [Dylan700][dylan-rel], [SamKirkland][sam-rel],
+[wlixcc][wlixcc-rel], [wangyucode][wang-rel].
+
+easySFTP is a clean, from-scratch implementation in Go, inspired by
+[Dylan700/sftp-upload-action][dylan]:
 
 - compiled static binary instead of a Node.js runtime (fast startup, parallel transfers)
 - works on Linux, macOS **and** Windows runners, with no Docker required
@@ -104,6 +109,10 @@ shows a before/after workflow.
 [sam]: https://github.com/SamKirkland/FTP-Deploy-Action
 [wlixcc]: https://github.com/wlixcc/SFTP-Deploy-Action
 [wang]: https://github.com/wangyucode/sftp-upload-action
+[dylan-rel]: https://github.com/Dylan700/sftp-upload-action/releases
+[sam-rel]: https://github.com/SamKirkland/FTP-Deploy-Action/releases
+[wlixcc-rel]: https://github.com/wlixcc/SFTP-Deploy-Action/releases
+[wang-rel]: https://github.com/wangyucode/sftp-upload-action/releases
 
 ## Inputs & outputs
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,10 +1,11 @@
 # Migrating from Dylan700/sftp-upload-action
 
 easySFTP is a from-scratch Go implementation inspired by
-[Dylan700/sftp-upload-action][dylan], whose last release was in 2024. If you
-are coming from it, this page is the whole switch: an input-by-input mapping,
-a before/after workflow, and the handful of behavior differences that are
-worth knowing before the first run.
+[Dylan700/sftp-upload-action][dylan]. If you are coming from it, this page is
+the whole switch: an input-by-input mapping, a before/after workflow, and the
+handful of behavior differences that are worth knowing before the first run.
+Both projects are maintained, so this is a migration between two live actions,
+not a rescue from an abandoned one.
 
 Migrating from an older **easySFTP** version instead? See
 [Migrating from v2 to v3](migration-v3.md).


### PR DESCRIPTION
Closes #234.

## What was wrong

Checked against the GitHub API today:

```
$ gh api repos/Dylan700/sftp-upload-action/releases --jq '.[] | "\(.tag_name)\t\(.published_at)"'
v1.2.5  2026-08-25T11:34:23Z
v1.2.4  2026-07-27T22:48:20Z
v1.2.3  2024-03-27T00:22:37Z

$ gh api repos/Dylan700/sftp-upload-action/commits --jq '.[0] | "\(.commit.author.date)\t\(.commit.message)"'
2026-08-25T11:29:49Z    Bumping ssh2-sftp-client version to 12.1.1 (#42)
```

The README stated `last release 2024` in the comparison table and called the project "no-longer-maintained" in the prose. `docs/migration.md` carried the same claim in its opening sentence (the issue does not mention that third instance; a repo-wide grep found it).

## What changed

1. **The "Actively maintained" row is gone rather than refreshed.** Feature rows age slowly, maintenance rows age in weeks, and this one was wrong six weeks after it was written. A sentence under the table now points at each project's releases page, which answers the question without going stale.
2. **The prose no longer calls the project unmaintained**, in the README and in `docs/migration.md`.
3. **The opening paragraph now argues from capability.** "They were either no longer actively maintained, not resource-friendly, hard or barely configurable, or they simply did not work reliably" becomes three concrete differences that are visible in the table itself and that no competitor release can invalidate: none verified the host key, none guarded a delete, and nothing that skipped unchanged files also ran on a Windows runner.
4. The caveat line is re-dated to August 2026.

## Checked but deliberately not changed

The rest of the row-by-row comparison against that action still holds. Its documented inputs are `server`, `username`, `password`, `key`, `passphrase`, `port`, `uploads`, `ignore`, `ignore-from`, `dry-run`, `delete`: no host key verification, no sync or skip-unchanged, no concurrency, no retries, no proxy support. Only the maintenance claim was wrong, so only the maintenance claim moved.

I also dropped a draft phrase calling easySFTP "a superset of its inputs". That was true of v2 and is not true of v3, which removed most of those input names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)