### PR TITLE
fix(action): bound the release fetch so a stall fails instead of hanging

### DIFF
--- a/scripts/action-lib.sh
+++ b/scripts/action-lib.sh
@@ -70,7 +70,17 @@ resolve_release_commit() {
       "refs/tags/$version") direct=$sha ;;
       "refs/tags/$version^{}") peeled=$sha ;;
     esac
-  done < <(git ls-remote --exit-code \
+  # Bounded on purpose (issue #236). This runs on every SHA-pinned job, and
+  # an unbounded git talking to github.com is the same hang as an unbounded
+  # curl: the step never fails, it just runs until the workflow timeout,
+  # which defaults to six hours. The low-speed pair aborts a connection that
+  # stops delivering, and GIT_TERMINAL_PROMPT stops a credential prompt from
+  # waiting on a stdin nobody is attached to. Resolution here is best
+  # effort, so an abort just falls back to a source build.
+  done < <(GIT_TERMINAL_PROMPT=0 \
+    GIT_HTTP_LOW_SPEED_LIMIT=1000 \
+    GIT_HTTP_LOW_SPEED_TIME=30 \
+    git ls-remote --exit-code \
     'https://github.com/eiserv/easySFTP.git' \
     "refs/tags/$version" \
     "refs/tags/$version^{}")
@@ -155,6 +165,17 @@ download_release_file() {
   local max_size=$4
   local url="https://github.com/eiserv/easySFTP/releases/download/${version}/${asset}"
 
+  # The three timeouts are load-bearing (issue #236). curl supplies none of
+  # them by default, so a transfer that stalls after connecting waits
+  # forever, and --retry only fires on a failure that completed. Without
+  # them the job does not fail, it hangs until the workflow timeout, which
+  # defaults to six hours on GitHub-hosted runners and is usually left
+  # there. --max-time bounds one attempt (180s is well over what a 6 MB
+  # binary needs at any plausible runner speed) and --retry-max-time
+  # bounds when a new attempt may still start, so the call as a whole is
+  # bounded rather than three full budgets deep. --max-filesize stays a
+  # sanity check rather than a bound: curl only enforces it once a
+  # Content-Length declares the size or the limit is already exceeded.
   curl \
     --proto '=https' \
     --proto-redir '=https' \
@@ -163,8 +184,11 @@ download_release_file() {
     --fail \
     --silent \
     --show-error \
+    --connect-timeout 15 \
+    --max-time 180 \
     --retry 3 \
     --retry-all-errors \
+    --retry-max-time 300 \
     --max-filesize "$max_size" \
     --output "$output" \
     "$url"

--- a/scripts/test-action.sh
+++ b/scripts/test-action.sh
@@ -67,6 +67,9 @@ cat > "$tmp/bin/curl" <<'MOCK_CURL'
 set -euo pipefail
 output=''
 url=''
+saw_connect_timeout=0
+saw_max_time=0
+saw_retry_max_time=0
 while (( $# )); do
   case "$1" in
     --output)
@@ -74,6 +77,18 @@ while (( $# )); do
       shift 2
       ;;
     --max-redirs | --retry | --max-filesize)
+      shift 2
+      ;;
+    --connect-timeout)
+      saw_connect_timeout=1
+      shift 2
+      ;;
+    --max-time)
+      saw_max_time=1
+      shift 2
+      ;;
+    --retry-max-time)
+      saw_retry_max_time=1
       shift 2
       ;;
     --proto | --proto-redir)
@@ -88,6 +103,15 @@ while (( $# )); do
       ;;
   esac
 done
+# Issue #236: curl has no default timeouts, so a release fetch that stalls
+# after connecting hangs the step instead of failing it, and the job then
+# runs to the workflow timeout (six hours by default). A stalling stub
+# server is more machinery than the fix is worth; what can regress is
+# someone deleting a flag, and that is what this asserts.
+if (( ! saw_connect_timeout || ! saw_max_time || ! saw_retry_max_time )); then
+  printf 'mock curl: download_release_file must pass --connect-timeout, --max-time and --retry-max-time (issue #236)\n' >&2
+  exit 1
+fi
 cp "$MOCK_ASSET_DIR/${url##*/}" "$output"
 MOCK_CURL
 chmod +x "$tmp/bin/curl"
@@ -97,6 +121,14 @@ cat > "$tmp/bin/git" <<'MOCK_GIT'
 set -euo pipefail
 if [[ "${1:-}" != 'ls-remote' ]]; then
   exit 2
+fi
+# Issue #236: the same hang through git. resolve_release_commit runs on
+# every SHA-pinned job and talks to github.com with no bound of its own.
+if [[ "${GIT_TERMINAL_PROMPT:-}" != '0' ]] ||
+  [[ -z "${GIT_HTTP_LOW_SPEED_LIMIT:-}" ]] ||
+  [[ -z "${GIT_HTTP_LOW_SPEED_TIME:-}" ]]; then
+  printf 'mock git: resolve_release_commit must bound ls-remote with GIT_TERMINAL_PROMPT and the low-speed pair (issue #236)\n' >&2
+  exit 1
 fi
 printf '%s\t%s\n' \
   '1111111111111111111111111111111111111111' 'refs/tags/v1.2.3' \


### PR DESCRIPTION
Closes #236.

## What changed

Two unbounded network calls on the hottest path in the project, the one every `uses: eiserv/easySFTP@v3` job runs before anything else happens.

**`download_release_file`** gains the three bounds curl does not supply by default:

```
--connect-timeout 15
--max-time 180
--retry-max-time 300
```

`--max-time` bounds one attempt (180s is well over what a 6 MB binary needs at any plausible runner speed) and `--retry-max-time` bounds when a new attempt may still start, so the call as a whole is bounded rather than three full budgets deep. The comment now also records that `--max-filesize` is a sanity check and not a bound, since curl only enforces it once a `Content-Length` declares the size or the limit is already exceeded.

**`resolve_release_commit`** gains a bound on `git ls-remote`:

```
GIT_TERMINAL_PROMPT=0 GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=30 git ls-remote ...
```

The issue suggests `timeout 30` as an alternative. I used the git environment variables instead because `timeout` is GNU coreutils and **macOS runners do not have it**, and macOS is a released, mapped platform in `resolve_release_asset`. The low-speed pair is portable to every platform the action supports and needs no external binary. `GIT_TERMINAL_PROMPT=0` closes a second hang in the same function: a credential prompt waiting on a stdin nobody is attached to.

That path is already best effort (failure falls back to a source build), so a bound simply makes the documented fallback reachable instead of theoretical.

## Tests

The issue notes that testing the stall itself needs a stub server that accepts and never finishes, which is more machinery than the fix warrants. What *can* regress is someone deleting a flag, so both mocks in `scripts/test-action.sh` now assert the bounds are passed. Verified they bite:

```
$ # remove '--max-time 180' from action-lib.sh
$ bash scripts/test-action.sh; echo $?
mock curl: download_release_file must pass --connect-timeout, --max-time and --retry-max-time (issue #236)
1

$ # remove 'GIT_HTTP_LOW_SPEED_TIME=30' from action-lib.sh
$ bash scripts/test-action.sh
FAIL: annotated release commit resolution: expected 'aaaa...', got ''
1 action test(s) failed

$ # restored
$ bash scripts/test-action.sh; echo $?
All action launcher tests passed.
0
```

`shellcheck scripts/*.sh` is clean.

## Worst case after this change

A blackholed download now fails the step in at most roughly `--retry-max-time` plus one final `--max-time`, about 8 minutes, with curl's own error in the log, rather than occupying the runner until the workflow timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)