### PR TITLE
feat(action): mask credentials the runner does not mask for us

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -256,6 +256,24 @@ outputs:
 runs:
   using: composite
   steps:
+    # First, before anything else has a chance to log. The runner masks
+    # values it read from secrets.* by itself; this covers the cases it does
+    # not, such as a credential produced by an earlier step's output, a
+    # matrix entry, a plain environment variable or a vault action. Private
+    # keys are deliberately left out; see mask_credentials in
+    # scripts/action-lib.sh for why (issue #149).
+    - name: Mask credentials
+      shell: bash
+      run: |
+        action_path="${ACTION_PATH//\\//}"
+        bash "$action_path/scripts/mask-credentials.sh"
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        EASYSFTP_PASSWORD: ${{ inputs.password }}
+        EASYSFTP_PASSPHRASE: ${{ inputs.passphrase }}
+        EASYSFTP_PROXY_PASSWORD: ${{ inputs.proxy-password }}
+        EASYSFTP_PROXY_PASSPHRASE: ${{ inputs.proxy-passphrase }}
+
     - name: Prepare easySFTP
       id: prepare
       shell: bash

--- a/docs/security.md
+++ b/docs/security.md
@@ -56,6 +56,19 @@ update the secret with the new keys.
   [encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
   and never hardcode them in a workflow file.
 - easySFTP receives credentials via environment variables and never prints them.
+- The action's first step registers the passwords and passphrases it was
+  given with the runner's log masker (`::add-mask::`), before anything else
+  in the action runs, so any later line that happened to contain one would
+  print as `***`. The runner already does this for values read from
+  `secrets.*`; this covers the cases it does not, such as a credential
+  produced by an earlier step's output, a matrix entry, a plain environment
+  variable or a vault action. It is defence in depth, not a licence to
+  inline a credential: a masked value is still sitting in the workflow file
+  and in the job's environment.
+- Private keys are deliberately not masked. `::add-mask::` works line by line,
+  so masking a PEM block would mean masking its short base64 lines, which
+  garbles unrelated log output. Key material is never printed, and the
+  passphrase protecting it is masked.
 - **Prefer key-based authentication** over passwords. Generate a dedicated
   deploy key and restrict what its account can do on the server:
 

--- a/internal/actionmeta/actionmeta_test.go
+++ b/internal/actionmeta/actionmeta_test.go
@@ -119,6 +119,40 @@ func TestActionMetadata(t *testing.T) {
 			t.Errorf("env %s is wired but input %q is missing from wantInputs", envName, inputName)
 		}
 	}
+	// Every password and passphrase the upload step is handed must also reach
+	// the masking step, or the runner never learns to redact it (issue #149).
+	// Keyed off the input name rather than a fixed list so a future credential
+	// input cannot be wired into one step and forgotten in the other.
+	var maskStep *actionStep
+	for i, step := range action.Runs.Steps {
+		if step.Name == "Mask credentials" {
+			maskStep = &action.Runs.Steps[i]
+		}
+	}
+	if maskStep == nil {
+		t.Fatal("step \"Mask credentials\" is missing")
+	}
+	if action.Runs.Steps[0].Name != "Mask credentials" {
+		t.Errorf("first step is %q; masking has to run before anything else can log", action.Runs.Steps[0].Name)
+	}
+	for envName := range uploadStep.Env {
+		inputName := strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(envName, "EASYSFTP_")), "_", "-")
+		if !strings.HasSuffix(inputName, "password") && !strings.HasSuffix(inputName, "passphrase") {
+			continue
+		}
+		if _, ok := maskStep.Env[envName]; !ok {
+			t.Errorf("env %s is passed to the upload step but not to the masking step", envName)
+		}
+	}
+	// The private keys stay out on purpose: add-mask is line oriented and
+	// masking a PEM block's short base64 lines garbles the log. If that ever
+	// changes, change this assertion deliberately rather than by accident.
+	for _, envName := range []string{"EASYSFTP_PRIVATE_KEY", "EASYSFTP_PROXY_PRIVATE_KEY"} {
+		if _, ok := maskStep.Env[envName]; ok {
+			t.Errorf("env %s is wired into the masking step; masking key material line by line garbles the log (issue #149)", envName)
+		}
+	}
+
 	for _, name := range []string{"files-uploaded", "files-deleted", "files-skipped", "bytes-uploaded", "duration-ms"} {
 		if _, ok := action.Outputs[name]; !ok {
 			t.Errorf("output %q is missing", name)

--- a/scripts/action-lib.sh
+++ b/scripts/action-lib.sh
@@ -10,6 +10,48 @@ easysftp_error() {
   return 1
 }
 
+# easysftp_add_mask registers one value with the runner's log masker, so any
+# later line that happens to contain it prints as *** instead.
+#
+# The runner already does this for anything read from secrets.*, which covers
+# the documented path. It does not cover a credential produced by an earlier
+# step's output, read from a matrix entry or a plain environment variable, or
+# returned by a vault action, and it cannot cover a literal somebody inlined
+# against advice. See issue #149.
+#
+# The value is percent-encoded the way the workflow-command protocol expects,
+# which matters twice here: a newline inside a credential would otherwise end
+# the command and print the remainder as an ordinary log line, in clear text,
+# and a literal % would be read back as the start of an escape.
+#
+# An empty or whitespace-only value is skipped on purpose: asking the runner to
+# mask it would redact large parts of the log.
+easysftp_add_mask() {
+  local value=$1
+  if [[ -z "${value//[[:space:]]/}" ]]; then
+    return 0
+  fi
+  value=${value//%/%25}
+  value=${value//$'\r'/%0D}
+  value=${value//$'\n'/%0A}
+  printf '::add-mask::%s\n' "$value"
+}
+
+# mask_credentials masks every password and passphrase the action was given,
+# direct and proxy, from the environment the caller set up.
+#
+# The private keys are deliberately not masked. ::add-mask:: is line oriented,
+# so a PEM block would have to be masked line by line, and masking the short
+# base64 lines of a key garbles unrelated log output for the rest of the job.
+# Key material is never printed anywhere, and the passphrase that protects it
+# is masked, so the cost would buy nothing.
+mask_credentials() {
+  easysftp_add_mask "${EASYSFTP_PASSWORD:-}"
+  easysftp_add_mask "${EASYSFTP_PASSPHRASE:-}"
+  easysftp_add_mask "${EASYSFTP_PROXY_PASSWORD:-}"
+  easysftp_add_mask "${EASYSFTP_PROXY_PASSPHRASE:-}"
+}
+
 # detect_build_mode picks how to obtain the easySFTP binary from the action
 # ref alone (the build-mode input was removed in v3): a ref matching the
 # checkout's release version (tag or exact release commit) uses the verified

--- a/scripts/mask-credentials.sh
+++ b/scripts/mask-credentials.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Runs as the action's first step, before anything else has a chance to log.
+# Everything after this point is covered: the prepare step, the Go build, the
+# upload itself, and any error text from any of them that quotes a value.
+# See mask_credentials in action-lib.sh and issue #149.
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+# shellcheck source=scripts/action-lib.sh
+source "$script_dir/action-lib.sh"
+
+mask_credentials

--- a/scripts/test-action.sh
+++ b/scripts/test-action.sh
@@ -49,6 +49,34 @@ expect_equal 'Windows arm64 mapping' 'easysftp_windows_arm64.exe' "$(resolve_rel
 expect_failure 'unsupported OS' resolve_release_asset FreeBSD X64
 expect_failure 'unsupported architecture' resolve_release_asset Linux RISCV64
 
+# Credential masking (issue #149). The runner masks secrets.* by itself; these
+# cover the values it does not, and the encoding that keeps a multi-line
+# credential from ending the workflow command and printing itself in clear.
+expect_equal 'masks a plain value' '::add-mask::hunter2' "$(easysftp_add_mask hunter2)"
+expect_equal 'escapes a percent sign' '::add-mask::p%25ss' "$(easysftp_add_mask 'p%ss')"
+multiline_value=$'two\nlines'
+crlf_value=$'two\r\nlines'
+expect_equal 'escapes a newline instead of ending the command' '::add-mask::two%0Alines' "$(easysftp_add_mask "$multiline_value")"
+expect_equal 'escapes a carriage return' '::add-mask::two%0D%0Alines' "$(easysftp_add_mask "$crlf_value")"
+expect_equal 'skips an empty value' '' "$(easysftp_add_mask '')"
+expect_equal 'skips a whitespace-only value' '' "$(easysftp_add_mask '  ')"
+
+masked=$(
+  EASYSFTP_PASSWORD=direct-pass \
+  EASYSFTP_PASSPHRASE=key-pass \
+  EASYSFTP_PROXY_PASSWORD=jump-pass \
+  EASYSFTP_PROXY_PASSPHRASE=jump-key-pass \
+  EASYSFTP_PRIVATE_KEY='-----BEGIN OPENSSH PRIVATE KEY-----' \
+    mask_credentials
+)
+expect_equal 'masks every password and passphrase' \
+  '::add-mask::direct-pass
+::add-mask::key-pass
+::add-mask::jump-pass
+::add-mask::jump-key-pass' "$masked"
+expect_equal 'leaves private key material unmasked' '' "$(EASYSFTP_PRIVATE_KEY=secret-key mask_credentials)"
+expect_equal 'masks nothing when no credential is set' '' "$(mask_credentials)"
+
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 


### PR DESCRIPTION
Closes #149.

## What changed

The action's **first** composite step now registers every password and passphrase it was given with the runner's log masker, before anything else in the action runs.

```yaml
- name: Mask credentials
  shell: bash
  run: |
    action_path="${ACTION_PATH//\//}"
    bash "$action_path/scripts/mask-credentials.sh"
  env:
    EASYSFTP_PASSWORD: ${{ inputs.password }}
    EASYSFTP_PASSPHRASE: ${{ inputs.passphrase }}
    EASYSFTP_PROXY_PASSWORD: ${{ inputs.proxy-password }}
    EASYSFTP_PROXY_PASSPHRASE: ${{ inputs.proxy-passphrase }}
```

`easysftp_add_mask` and `mask_credentials` live in `scripts/action-lib.sh`, so they are shellchecked and directly testable from `scripts/test-action.sh`, like everything else there.

## Deviation from the issue, and why

The issue asks for `gha.AddMask` called from `run()` in `cmd/easysftp/main.go`. I built it in the launcher instead. Three reasons, in order of weight:

1. **It covers more.** Masking in `run()` can only cover what happens after `config.Load()` returns. The prepare step, the Go build, and every failure path inside `config.Load()` itself come earlier. All credentials arrive as action inputs (credentials are category 3, valid in both inline and config mode), so the launcher sees all of them and sees them first.
2. **It does not print credentials outside Actions.** `::add-mask::hunter2` on stdout is only safe because the runner intercepts the line. Run the binary on a laptop and the Go version would print the password to the terminal. The rest of `internal/gha` already no-ops outside Actions for this reason.
3. A first attempt at the Go version tripped CodeQL's `go/clear-text-logging` at high severity (`Sensitive data returned by an access to Password flows to a logging call`), which is a fair reading of what it does. Moving the masking to where the credential already lives, rather than dismissing the alert, seemed better than arguing with the analyzer.

## Decisions the issue asked to make explicit

**Private keys are not masked.** `::add-mask::` is line oriented, so a PEM block would have to be masked line by line, and masking the short base64 lines of a key garbles unrelated log output for the rest of the job. Key material is never printed anywhere, and the passphrase that protects it *is* masked. Recorded in the function comment, in `docs/security.md`, and pinned by an assertion in `actionmeta` that `EASYSFTP_PRIVATE_KEY` is **not** wired into the mask step, so removing that exclusion has to be deliberate.

**Empty and whitespace-only values are skipped**, or the runner redacts large parts of the log.

One case the issue does not mention: a **multi-line** credential. `printf '::add-mask::%s\n' "$value"` on a value containing a newline ends the workflow command and prints the remainder as an ordinary log line, in clear text. The value is percent-encoded (`%` → `%25`, `\r` → `%0D`, `\n` → `%0A`) the way the protocol expects, which the runner decodes back into a single multi-line secret.

## Tests

`scripts/test-action.sh` gains nine cases: plain value, `%` escaped, newline escaped, CRLF escaped, empty skipped, whitespace-only skipped, all four credentials masked in order, a private key producing no output, and nothing set producing no output.

`internal/actionmeta` gains a drift check in the family CLAUDE.md describes: every env var reaching the upload step whose input name ends in `password` or `passphrase` must also reach the mask step, keyed off the name rather than a fixed list so a future credential input cannot be wired into one and forgotten in the other. It also asserts the mask step is first.

Both guards verified to bite:

```
$ # drop EASYSFTP_PROXY_PASSPHRASE from mask_credentials
$ bash scripts/test-action.sh; echo $?
1

$ # drop EASYSFTP_PROXY_PASSPHRASE from the action.yml mask step
$ go test ./internal/actionmeta/
--- FAIL: TestActionMetadata
    env EASYSFTP_PROXY_PASSPHRASE is passed to the upload step but not to the masking step
```

`shellcheck scripts/*.sh` is clean and `go test ./...` is green. The CI self-test drives `action.yml` end to end against a real OpenSSH server with a non-secret password, so the new step runs there on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)