### PR TITLE
fix(uploader): refuse a destructive target that climbs above the login directory

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -154,8 +154,13 @@ before any delete worker starts.
 
 Two safety nets apply before `sync` or `clean` delete anything:
 
-- **Remote root is always refused.** A target that resolves to `/` (or `.`)
-  is rejected outright. No mode will ever wipe a server root.
+- **Remote root is always refused.** A target that resolves to `/`, `.`, `~`
+  or the empty string is rejected outright. So is one that climbs above the
+  directory the session starts in, such as `..`, `../..` or `dist/../..`,
+  which is where a target built from a workflow expression tends to land when
+  the expression is empty or has a component too many. No mode will ever wipe
+  a server root or a login directory. A relative target that stays put, like
+  `www/public_html`, is unaffected.
 - **`max_deletes`** aborts a run that would delete more files than the limit,
   catching a misconfiguration before it does damage. `0` means unlimited. Set
   it via `safety.max_deletes` in the [config file](configuration.md#sections).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -246,9 +246,16 @@ never deleted by `sync` itself.
 
 ### `refusing a destructive mode on remote root`
 
-`sync` and `clean` refuse to operate on `/` (or `.`) as the remote target,
-always. Deploy into a specific subdirectory instead. This guard cannot be
-disabled; see [delete guards](strategies.md#delete-guards).
+`sync` and `clean` refuse a remote target that resolves to `/`, `.`, `~` or
+the empty string, and one that climbs above the directory the session starts
+in (`..`, `../..`, `dist/../..`). Deploy into a specific subdirectory instead.
+
+If you did not write `..` anywhere, check how the target is built: an
+expression such as `${{ inputs.dir }}/..` lands here when `inputs.dir` is
+empty, and so does a path whose last component was stripped by a shell.
+
+This guard cannot be disabled; see
+[delete guards](strategies.md#delete-guards).
 
 ### `refusing to delete N files: exceeds safety.max_deletes`
 

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -165,10 +165,25 @@ func remoteAbsent(client *sftp.Client, p string, watch *stallWatchdog) (bool, er
 
 // checkRemoteRoot refuses a destructive mode whose target resolves to the
 // filesystem root or an unspecific path: the one guard that is always on.
+//
+// It also refuses a relative target that escapes upward. path.Clean("..") is
+// "..", which is not the root and used to pass, so "mode: clean" with a target
+// of ".." resolved against the SFTP session's working directory (the login
+// user's home on nearly every server) and deleted what it found there. That is
+// reachable by accident rather than only by malice: a target built from an
+// expression, a variable that resolves to the empty string, or a shell that
+// stripped the last path component all land on exactly these values, which is
+// the class of mistake this guard exists to catch (issue #222).
+//
+// A relative target that stays put ("www/public_html") is still allowed. It is
+// the documented behaviour and a great many workflows use it.
 func checkRemoteRoot(remote string) error {
-	switch normalizeRemote(remote) {
-	case "/", ".", "", "~":
+	normalized := normalizeRemote(remote)
+	switch {
+	case normalized == "/", normalized == ".", normalized == "", normalized == "~":
 		return fmt.Errorf("refusing a destructive mode on remote root %q; target a specific subdirectory instead", remote)
+	case normalized == "..", strings.HasPrefix(normalized, "../"):
+		return fmt.Errorf("refusing a destructive mode on remote root %q: it resolves to %q, above the directory the session starts in; target a specific subdirectory instead", remote, normalized)
 	}
 	return nil
 }

--- a/internal/uploader/remoteroot_test.go
+++ b/internal/uploader/remoteroot_test.go
@@ -1,0 +1,93 @@
+package uploader
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// checkRemoteRoot is the one delete guard that is always on and cannot be
+// configured away, and until issue #222 nothing exercised it directly. The
+// table covers both directions: what it must refuse, and what it must keep
+// allowing, since a guard that grew too strict would break every workflow
+// deploying into a relative directory.
+func TestCheckRemoteRoot(t *testing.T) {
+	refused := []struct {
+		name   string
+		remote string
+	}{
+		{"filesystem root", "/"},
+		{"working directory", "."},
+		{"empty target", ""},
+		{"home shorthand", "~"},
+		{"absolute path that climbs back to the root", "/var/www/../.."},
+		{"home shorthand that climbs to itself", "~/.."},
+
+		// The rows below all passed before #222: path.Clean leaves ".." as
+		// "..", which is not the root, so the switch never matched it.
+		{"bare parent", ".."},
+		{"grandparent", "../.."},
+		{"parent reached through the current directory", "./.."},
+		{"parent reached by climbing out of a subdirectory", "dist/../.."},
+		{"escape below a deeper prefix", "../../etc"},
+		{"backslashes normalize to the same escape", `..\..`},
+	}
+	for _, tc := range refused {
+		t.Run("refused/"+tc.name, func(t *testing.T) {
+			err := checkRemoteRoot(tc.remote)
+			if err == nil {
+				t.Fatalf("checkRemoteRoot(%q) allowed a destructive mode on %q", tc.remote, normalizeRemote(tc.remote))
+			}
+			if !strings.Contains(err.Error(), "remote root") {
+				t.Errorf("checkRemoteRoot(%q) = %v, want an error naming the remote root", tc.remote, err)
+			}
+		})
+	}
+
+	allowed := []struct {
+		name   string
+		remote string
+	}{
+		{"absolute subdirectory", "/var/www/public_html"},
+		{"absolute subdirectory with a trailing slash", "/var/www/"},
+		{"relative subdirectory", "www/public_html"},
+		{"relative subdirectory below the current directory", "./dist"},
+		{"path that climbs and comes back down", "/var/www/../html"},
+		{"directory whose name merely starts with two dots", "..config"},
+		{"home subdirectory", "~/public_html"},
+	}
+	for _, tc := range allowed {
+		t.Run("allowed/"+tc.name, func(t *testing.T) {
+			if err := checkRemoteRoot(tc.remote); err != nil {
+				t.Errorf("checkRemoteRoot(%q) refused a legitimate target: %v", tc.remote, err)
+			}
+		})
+	}
+}
+
+// The guard has to stop the run, not merely return an error to a caller that
+// ignores it. This is the shape a workflow lands in when an expression leaves
+// a trailing "/.." on the target.
+func TestCleanRefusesTargetAboveTheLoginDirectory(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"a.txt": "a"})
+
+	client := srv.verifyClient(t)
+	if err := client.MkdirAll("/www/keep"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "dist/../..", Strategy: config.StrategyClean}}
+
+	_, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "remote root") {
+		t.Fatalf("expected the remote-root guard to stop the run, got %v", err)
+	}
+	if !remoteExists(t, srv, "/www/keep") {
+		t.Error("the run deleted remote content before the guard refused it")
+	}
+}


### PR DESCRIPTION
Closes #222.

## The gap

`checkRemoteRoot` normalized with `path.Clean` and compared against a literal set of four strings. `path.Clean("..")` is `".."`, which was not in that set, so every relative target that escapes upward passed the one delete guard that cannot be turned off:

| `target` | normalized | blocked before | blocked now |
|---|---|---|---|
| `/` | `/` | yes | yes |
| `.` | `.` | yes | yes |
| `~` | `~` | yes | yes |
| `/var/www/../..` | `/` | yes | yes |
| `..` | `..` | **no** | yes |
| `../..` | `../..` | **no** | yes |
| `./..` | `..` | **no** | yes |
| `dist/../..` | `..` | **no** | yes |

With `mode: clean` that resolves against the SFTP session's working directory, which is the login user's home on nearly every server, and the run then lists it and deletes what it finds. `safety.max_deletes` defaults to unlimited, so nothing downstream stops it either.

## The fix

One extra case: refuse a normalized target equal to `..` or beginning with `../`. Backslash spellings are covered because `normalizeRemote` already folds them.

## What is deliberately still allowed

The issue offers "reject a target that is not absolute at all when the mode is destructive" as an option. I did not take it. A relative target such as `www/public_html` is documented behaviour and widely used, and CLAUDE.md's principle is to default to today's behaviour. Refusing an escape closes the reachable-by-accident hole; refusing every relative target would break working deploys to close nothing extra. `..config` (a directory whose name merely starts with two dots) also still works, and there is a test row for it.

## Tests

The issue reports the guard has no test anywhere. That is right about the *function*: there was one end-to-end case in `sync_test.go` pinning the `/` spelling, and nothing else, and nothing at all for the escape.

New `internal/uploader/remoteroot_test.go`:

- `TestCheckRemoteRoot`: 12 refused rows (including all four from the table above and the backslash spelling) and 7 allowed rows, so a future tightening that breaks relative deploys fails here.
- `TestCleanRefusesTargetAboveTheLoginDirectory`: a real `clean` run against the in-process server with `target: dist/../..`, asserting the run is stopped **and** that pre-existing remote content is still there afterwards.

Both fail without the fix, verified by reverting just the new `case`:

```
--- FAIL: TestCheckRemoteRoot/refused/bare_parent
    checkRemoteRoot("..") allowed a destructive mode on ".."
--- FAIL: TestCheckRemoteRoot/refused/parent_reached_by_climbing_out_of_a_subdirectory
    checkRemoteRoot("dist/../..") allowed a destructive mode on ".."
--- FAIL: TestCleanRefusesTargetAboveTheLoginDirectory
    expected the remote-root guard to stop the run, got <nil>
```

## Docs

`docs/strategies.md` (delete guards) and `docs/troubleshooting.md` now describe what is refused, and troubleshooting gains the pointer that matters when this fires on someone who never typed `..`: check how the target is built, because `${{ inputs.dir }}/..` lands here whenever `inputs.dir` is empty.

## Not addressed here

The issue's closing note, whether `clean` should ask the server for its real path and refuse a target that resolves above the login directory at run time, is a separate change: `path.Clean` alone cannot know where a relative target lands. Left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)