### PR TITLE
fix(autocache): anchor a record that never held a throughput like any other

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,15 @@ that from turning into stale configuration (issue #212):
    forever for a dataset that grows a per cent at a time, which is the failure
    mode this whole package is shaped around.
    `internal/autocache/drift_test.go` replays both readings over the same
-   sequence of deploys and is the acceptance test for it.
+   sequence of deploys and is the acceptance test for it. The rule holds for
+   every record, including one whose measurement produced no throughput; that
+   used to be an exemption and it defeated the rule for exactly the small
+   deploys the cache is most often pointed at (issue #225). The one thing an
+   anchor is not protected from is being spent: past `MaxAge`, `MaxReuse` or a
+   policy generation, `Lookup` refuses the record anyway, so `Store.Update`
+   lets the next run replace it (`Record.stillTrusted`). Freezing a record no
+   run can be given would leave a deploy too small to ever measure anything
+   with a permanently dead entry.
 3. **The RTT measured now is the validation.** `Candidate.Validate` compares
    the probe's answer against the record's. It costs nothing (the probe runs
    anyway) and it is the only gate backed by a measurement taken today.

--- a/internal/autocache/autocache.go
+++ b/internal/autocache/autocache.go
@@ -431,15 +431,35 @@ type Observation struct {
 // The rule is one sentence: a stored measurement is replaced only by a new
 // measurement, and never merely by a newer run.
 //
-//   - This run measured the link, or there was no measurement stored to
-//     protect: the record is written from this run, anchor and all. New
+//   - This run measured the link, or there is no record Lookup would still
+//     consider: the record is written from this run, anchor and all. New
 //     evidence, new anchor, reuse count back to zero.
-//   - This run did not measure, and a stored measurement is still standing:
-//     the anchor, the whole stored link and MeasuredAt are left exactly as
-//     they were. Only the provenance, the recorded settings and the ceiling
-//     move. This is the case that would otherwise let a dataset (or a
+//   - This run did not measure, and a record Lookup would still consider is
+//     standing: the anchor, the whole stored link and MeasuredAt are left
+//     exactly as they were. Only the provenance, the recorded settings and the
+//     ceiling move. This is the case that would otherwise let a dataset (or a
 //     round-trip time) drift a per cent at a time until the record described
 //     nothing that was ever measured.
+//
+// The second bullet used to require the stored record to carry a throughput,
+// which quietly exempted every record written by a run that had nothing to
+// measure (issue #225). Those records are legitimate: they still carry the
+// round-trip time the next run is validated against and the connection
+// ceiling, which is why Record documents them. Exempting them meant they
+// re-anchored on every run, compared each run against the one before it, and
+// so hit forever on a dataset that grows a per cent at a time, which is the
+// one failure mode this package is shaped around. Reused was carried in the
+// same skipped branch, so MaxReuse could never evict them either, and
+// MeasuredAt kept moving, so MaxAge never could. A record has one life,
+// whichever of its fields happen to be populated.
+//
+// What the throughput test was reaching for is in stillTrusted instead, and
+// stated as the thing it actually is: an anchor is worth protecting only while
+// it is one a run could still be given. A spent record (too old, reused too
+// often, written by another policy generation) restores nothing, and only a
+// measuring run rewrites an anchor, so freezing a spent one would leave a
+// deploy that is too small to ever measure anything with a permanently dead
+// cache entry.
 //
 // The link is kept whole rather than field by field on purpose. The stored
 // round-trip time is what the next run validates against, so letting today's
@@ -461,7 +481,7 @@ func (s *Store) Update(obs Observation, at time.Time) bool {
 		Link:          obs.Link,
 		Settings:      obs.Settings,
 	}
-	if existed && !obs.Measured && old.Link.StreamBytesPerSecond > 0 {
+	if existed && !obs.Measured && old.stillTrusted(at) {
 		rec.MeasuredAt = old.MeasuredAt
 		rec.Workload = old.Workload
 		rec.Link = old.Link
@@ -488,6 +508,18 @@ func (s *Store) Update(obs Observation, at time.Time) bool {
 	}
 	s.put(rec)
 	return true
+}
+
+// stillTrusted reports whether Lookup would still consider this record at time
+// at, on the gates that do not depend on the run being planned. It is
+// deliberately the same three constants Lookup checks (MaxAge, MaxReuse and
+// the policy generation); the workload band is not one of them, because a
+// deploy that walked out of the band is exactly the case where the stored
+// anchor still has to be protected.
+func (r Record) stillTrusted(at time.Time) bool {
+	return r.PolicyVersion == autotune.PolicyVersion &&
+		at.Sub(r.MeasuredAt) <= MaxAge &&
+		r.Reused < MaxReuse
 }
 
 // equal reports whether two records say the same thing. LastUsed is ignored:

--- a/internal/autocache/autocache_test.go
+++ b/internal/autocache/autocache_test.go
@@ -274,11 +274,15 @@ func TestUpdateReanchorsOnlyOnAMeasurement(t *testing.T) {
 	}
 }
 
-// TestUpdateWritesARecordWithNoMeasurementToProtect: a record that never held
-// a throughput has no anchor worth freezing, so a later run may replace it
-// outright. This is what keeps a first run's round-trip time from ageing out
-// while the deploys keep coming.
-func TestUpdateWritesARecordWithNoMeasurementToProtect(t *testing.T) {
+// TestUpdateAnchorsARecordThatNeverHeldAThroughput: a record written by a run
+// with nothing to measure is still a record. It carries the round-trip time
+// the next run is validated against and the connection ceiling, and it is
+// anchored like any other: a later run that measured nothing may not move the
+// workload it describes, its stored link, or when it was taken.
+//
+// This used to be the one exemption in the rule, and it defeated the rule for
+// exactly the deploys the cache is most often pointed at (issue #225).
+func TestUpdateAnchorsARecordThatNeverHeldAThroughput(t *testing.T) {
 	s := stored(mediumTree(), Link{RTTMillis: 13, HandshakeMillis: 380})
 	later := now.Add(48 * time.Hour)
 
@@ -293,8 +297,80 @@ func TestUpdateWritesARecordWithNoMeasurementToProtect(t *testing.T) {
 	}, later)
 
 	rec, _ := s.find(target)
-	if rec.Workload != grown || !rec.MeasuredAt.Equal(later) {
-		t.Errorf("a record with nothing measured in it was preserved anyway: %+v", rec)
+	switch {
+	case rec.Workload != mediumTree():
+		t.Errorf("a run that measured nothing moved the anchor to %+v", rec.Workload)
+	case rec.Link.RTTMillis != 13:
+		t.Errorf("the stored round-trip time moved to %.1f ms without a measurement", rec.Link.RTTMillis)
+	case !rec.MeasuredAt.Equal(now):
+		t.Errorf("measured_at is %v, want the time the record was taken", rec.MeasuredAt)
+	case rec.Reused != 1:
+		t.Errorf("reuse count is %d, want the run that leaned on the record counted", rec.Reused)
+	}
+}
+
+// TestUpdateReplacesASpentRecord: the other half of the same rule. An anchor is
+// worth protecting only while it is one a run could still be given. Past
+// MaxAge, Lookup refuses the record, and since only a measuring run may rewrite
+// an anchor, a deploy too small to ever measure a throughput would otherwise
+// keep a dead entry for the life of the cache file.
+func TestUpdateReplacesASpentRecord(t *testing.T) {
+	s := stored(mediumTree(), Link{RTTMillis: 13, HandshakeMillis: 380})
+	stale := now.Add(MaxAge + time.Hour)
+
+	if _, dec := s.Lookup(target, mediumTree(), stale); dec.Reason == "" {
+		t.Fatal("the record was still accepted at this age, so this test proves nothing")
+	}
+
+	grown := mediumTree()
+	grown.Files = 1400
+	s.Update(Observation{
+		Target:   target,
+		Workload: grown,
+		Link:     Link{RTTMillis: 14, HandshakeMillis: 400},
+	}, stale)
+
+	rec, _ := s.find(target)
+	switch {
+	case rec.Workload != grown:
+		t.Errorf("a spent record kept its anchor at %+v", rec.Workload)
+	case !rec.MeasuredAt.Equal(stale):
+		t.Errorf("measured_at is %v, want the spent record replaced by this run", rec.MeasuredAt)
+	}
+}
+
+// stillTrusted decides whether Update protects an anchor, and it must not
+// drift from the gates Lookup applies for the same reasons. Anything Lookup
+// refuses on age, reuse or policy generation is spent; anything it accepts is
+// not.
+func TestStillTrustedAgreesWithLookup(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Record)
+		at     time.Time
+		want   bool
+	}{
+		{"fresh", func(*Record) {}, now, true},
+		{"one day short of the age limit", func(*Record) {}, now.Add(MaxAge - 24*time.Hour), true},
+		{"past the age limit", func(*Record) {}, now.Add(MaxAge + time.Hour), false},
+		{"one reuse short of the limit", func(r *Record) { r.Reused = MaxReuse - 1 }, now, true},
+		{"at the reuse limit", func(r *Record) { r.Reused = MaxReuse }, now, false},
+		{"another policy generation", func(r *Record) { r.PolicyVersion = autotune.PolicyVersion + 1 }, now, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := stored(mediumTree(), measuredLink(), tc.mutate)
+			rec, _ := s.find(target)
+
+			if got := rec.stillTrusted(tc.at); got != tc.want {
+				t.Errorf("stillTrusted = %v, want %v", got, tc.want)
+			}
+			_, dec := s.Lookup(target, mediumTree(), tc.at)
+			if accepted := dec.Reason == ""; accepted != tc.want {
+				t.Errorf("Lookup accepted = %v (%s), want %v; stillTrusted has drifted from it", accepted, dec.Reason, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/autocache/drift_test.go
+++ b/internal/autocache/drift_test.go
@@ -3,6 +3,8 @@ package autocache
 import (
 	"testing"
 	"time"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
 )
 
 // The failure mode this file exists for.
@@ -189,5 +191,117 @@ func TestAMeasuringRunIsAllowedToMoveTheAnchor(t *testing.T) {
 	}
 	if rec, _ := s.find(target); rec.Workload.Files != files {
 		t.Errorf("the anchor is %d files, want the %d the last measurement was taken on", rec.Workload.Files, files)
+	}
+}
+
+// TestDriftWithNoStoredThroughput is the same trap through the one door that
+// used to be left open (issue #225).
+//
+// A record whose measurement produced no per-connection throughput is written
+// by any deploy that never fills a stream, which is most small deploys, and is
+// exactly what the cache is most often pointed at. Update used to require a
+// stored throughput before it would protect an anchor, so those records fell
+// through to being rebuilt from the current run: they compared each run against
+// the one before it, hit forever, and dragged the anchor along. Reused was
+// carried in the same skipped branch, so the reuse budget never bit either.
+//
+// The record still has to work: it carries the round-trip time and the
+// connection ceiling, so it must keep hitting for a deploy that has not really
+// changed. What it must not do is keep hitting for one that has.
+func TestDriftWithNoStoredThroughput(t *testing.T) {
+	const (
+		runs       = 120
+		growth     = 1.03
+		firstFiles = 400
+	)
+
+	growingTree := func(n int) Workload {
+		files := firstFiles
+		for i := 0; i < n; i++ {
+			files = int(float64(files) * growth)
+		}
+		return Workload{
+			Files:   files,
+			Bytes:   int64(files) * 256 * 1024,
+			P50:     256 * 1024,
+			P90:     256 * 1024,
+			Largest: 4 << 20,
+		}
+	}
+
+	// No throughput, but a ceiling: this is a record worth keeping, which is
+	// why the answer to #225 could not simply be to throw such records away.
+	// How long the ceiling itself survives is a separate rule with its own
+	// lifetime (MaxCeilingCarry); what is under test here is the anchor.
+	noThroughput := Link{RTTMillis: 13, HandshakeMillis: 380}
+	anchored := stored(growingTree(0), noThroughput, func(r *Record) { r.ConnectionCeiling = 4 })
+
+	lastHit, reuses := -1, 0
+	for n := 1; n < runs; n++ {
+		at := now.Add(time.Duration(n) * time.Hour)
+		w := growingTree(n)
+
+		cand, dec := anchored.Lookup(target, w, at)
+		if dec.Reason == "" {
+			dec = cand.Validate(13 * time.Millisecond)
+		}
+		if dec.Hit {
+			lastHit = n
+			reuses++
+		}
+		anchored.Update(Observation{
+			Target:   target,
+			Workload: w,
+			Link:     noThroughput,
+			Reused:   dec.Hit,
+		}, at)
+
+		rec, _ := anchored.find(target)
+		if rec.Workload != growingTree(0) {
+			t.Fatalf("run %d moved the anchor to %+v without measuring anything", n, rec.Workload)
+		}
+		if !rec.MeasuredAt.Equal(now) {
+			t.Fatalf("run %d moved measured_at to %v without measuring anything", n, rec.MeasuredAt)
+		}
+		if rec.Reused != reuses {
+			t.Fatalf("run %d left the reuse count at %d after %d reuses, so MaxReuse can never bite", n, rec.Reused, reuses)
+		}
+	}
+
+	switch {
+	case lastHit < 0:
+		t.Fatal("the cache never hit at all, so this test proves nothing about drift")
+	case lastHit >= runs-1:
+		t.Fatalf("the cache still hit on the last run, with the deploy %.1fx its original size",
+			float64(growingTree(runs-1).Files)/firstFiles)
+	}
+	grown := float64(growingTree(lastHit).Files) / firstFiles
+	if grown > 2.1 {
+		t.Errorf("the cache kept hitting until the deploy was %.1fx its original size", grown)
+	}
+	t.Logf("a throughput-less record stopped hitting at run %d, with the deploy %.2fx its original size", lastHit+1, grown)
+
+	// The pre-#225 reading, reproduced: with no stored throughput the guarded
+	// branch was skipped, so the record was rebuilt from the current run every
+	// time. It never stops hitting, however far the deploy has travelled.
+	naive := stored(growingTree(0), noThroughput, func(r *Record) { r.ConnectionCeiling = 4 })
+	for n := 1; n < runs; n++ {
+		at := now.Add(time.Duration(n) * time.Hour)
+		w := growingTree(n)
+		if _, dec := naive.Lookup(target, w, at); dec.Reason != "" {
+			t.Fatalf("the pre-fix reading missed at run %d (%s), which it did not do", n, dec.Reason)
+		}
+		naive.put(Record{
+			Target:            target,
+			PolicyVersion:     autotune.PolicyVersion,
+			MeasuredAt:        at,
+			LastUsed:          at,
+			Workload:          w,
+			Link:              noThroughput,
+			ConnectionCeiling: 4,
+		})
+	}
+	if float64(growingTree(runs-1).Files)/firstFiles < 10 {
+		t.Fatal("the deploy did not grow far enough for the contrast to mean anything")
 	}
 }


### PR DESCRIPTION
Closes #225.

## The bug

`Store.Update`'s anchoring guard had three conjuncts:

```go
if existed && !obs.Measured && old.Link.StreamBytesPerSecond > 0 {
```

The third one exempted every record whose measurement produced no per-connection throughput. Those records are not exotic: `Record`'s own doc comment describes them ("zero for a record written by a run that had nothing to measure ... such a record still carries the round-trip time and the ceiling"), and they are what any deploy that never fills a stream leaves behind, which is most small deploys and therefore most of what the cache is pointed at.

For those records the branch was skipped and the fields fell through to values built from the *current* run. Three consequences, all in the same direction:

- the workload anchor and the stored link re-anchored on every run, so the record compared each run against the one before it and hit forever on a dataset that grows a per cent at a time,
- `Reused` was carried inside the same skipped branch, so it stayed pinned at `0` and `MaxReuse` could never evict the record,
- `MeasuredAt` kept moving, so `MaxAge` could not either.

## The fix

The third conjunct is replaced by the thing it was reaching for, stated as what it actually is:

```go
if existed && !obs.Measured && old.stillTrusted(at) {
```

`Record.stillTrusted` checks the same three gates `Lookup` applies that do not depend on the run being planned: policy generation, `MaxAge`, `MaxReuse`.

**Why not just delete the conjunct**, which is what the issue's preferred reading says. Because only a measuring run may rewrite an anchor, and a deploy too small to ever measure a throughput never produces one. A bare deletion would mean that 30 days after such a record is written, `Lookup` refuses it on age, `Update` refuses to replace it, and the entry is permanently dead: the cache gives that user nothing, forever. The old code accidentally avoided that by refreshing `MeasuredAt` every run, which is exactly the drift. `stillTrusted` keeps the anti-drift property and keeps the record replaceable once it is spent, which is what `MaxAge` and `MaxReuse` already mean.

The workload band is deliberately *not* one of the gates: a deploy that walked out of the band is precisely when the stored anchor still has to be protected.

## Tests

`internal/autocache/drift_test.go` gains `TestDriftWithNoStoredThroughput`: the same 120-deploy 3%-growth replay as the existing acceptance test, seeded with a throughput-less record, asserting on every run that the anchor, `MeasuredAt` and the reuse count all behave, and that hits stop at roughly 2x growth. It carries the same contrast half the existing test has, replaying the pre-fix reading and showing it never misses.

`TestUpdateWritesARecordWithNoMeasurementToProtect` **pinned the bug** and is replaced by two tests that pin the rule instead:

- `TestUpdateAnchorsARecordThatNeverHeldAThroughput`: a non-measuring run may not move the anchor, the stored link or `MeasuredAt`, and must count the reuse.
- `TestUpdateReplacesASpentRecord`: past `MaxAge`, where `Lookup` already refuses, the next run does replace it.
- `TestStillTrustedAgreesWithLookup`: a table asserting `stillTrusted` and `Lookup` accept and refuse the same six cases, so the two cannot drift apart.

Verified the new tests fail against the old condition:

```
--- FAIL: TestUpdateAnchorsARecordThatNeverHeldAThroughput
    a run that measured nothing moved the anchor to {Files:1400 ...}
--- FAIL: TestDriftWithNoStoredThroughput
    run 1 moved the anchor to {Files:412 ...} without measuring anything
```

`go test ./internal/autocache/ ./internal/uploader/ ./internal/autotune/` is green.

## Docs

CLAUDE.md's rule 2 now says the anchoring rule holds for every record and records the one thing an anchor is not protected from, being spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)