### PR TITLE
fix(uploader): stop the non-atomic publish from losing the file it replaces

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -125,8 +125,11 @@ behind; delete the old file manually.
 ## Temporary upload files in web roots
 
 Uploads stream into a temporary sibling file (`<name>.easysftp-tmp.<n>`) that
-is renamed over the target on success. A run killed hard (cancelled workflow,
-job timeout, reclaimed runner) can leave such files behind, and until the
+is renamed over the target on success. On a server without
+`posix-rename@openssh.com` the live file is briefly parked under
+`<name>.easysftp-tmp.bak` while that rename happens, so it can be put back if
+the rename fails. A run killed hard (cancelled workflow, job timeout,
+reclaimed runner) can leave either kind of file behind, and until the
 next deploy sweeps them (see
 [troubleshooting.md](troubleshooting.md#replacing-path--or-leftover-easysftp-tmp-files))
 a partially written copy of the file sits in the target, served over HTTP
@@ -135,13 +138,13 @@ MIME handling. Deny the pattern in the web server, next to the manifest rule
 above. nginx:
 
 ```nginx
-location ~ \.easysftp-tmp(\.\d+)?$ { deny all; }
+location ~ \.easysftp-tmp(\.\d+|\.bak)?$ { deny all; }
 ```
 
 Apache (vhost or `.htaccess`):
 
 ```apache
-<FilesMatch "\.easysftp-tmp(\.[0-9]+)?$">
+<FilesMatch "\.easysftp-tmp(\.[0-9]+|\.bak)?$">
     Require all denied
 </FilesMatch>
 ```

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -31,7 +31,10 @@ Uploads are **atomic per file**: content is streamed to a temporary sibling
 file (`<name>.easysftp-tmp.<n>`, `<n>` being the file's position in the plan so
 two planned transfers never share a temp name) and renamed over the target
 only once the transfer fully succeeded. A broken connection never leaves a
-half-written file where the live one was.
+half-written file where the live one was. Servers without
+`posix-rename@openssh.com` cannot do that swap in one step, so easySFTP parks
+the live file under `<name>.easysftp-tmp.bak` first and puts it back if the
+rename fails: the target is briefly missing there, but never lost.
 
 ### `advanced.skip_unchanged`: skip same-size files
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -174,16 +174,19 @@ appears to work.
 ### `replacing "<path>": ...` or leftover `.easysftp-tmp` files
 
 easySFTP uploads to a temporary sibling file (named `<path>.easysftp-tmp.<n>`)
-and renames it over the target (atomic on servers supporting the
-`posix-rename@openssh.com` extension, with a remove+rename fallback
-otherwise). A hard kill mid-upload (a cancelled workflow past its grace
-period, a job timeout, a reclaimed runner) can leave such a file behind; it
-is safe to delete manually.
+and renames it over the target. On a server supporting the
+`posix-rename@openssh.com` extension that rename is atomic. Without it, the
+live file is first moved aside to `<path>.easysftp-tmp.bak`, the upload is
+renamed into place, and the backup is removed; if the rename fails, the backup
+is put back, so a failed publish never costs you the file it was replacing.
+A hard kill mid-upload (a cancelled workflow past its grace period, a job
+timeout, a reclaimed runner) can leave either file behind; both are safe to
+delete manually.
 
 If **every** overwrite fails this way while new files upload fine, the server
 is refusing the rename rather than lacking the extension: easySFTP only falls
-back to remove+rename on a server that does not offer atomic rename, and never
-removes a live file to retry a rename the server has already declined. Check
+back to the move-aside path on a server that does not offer atomic rename, and
+never removes a live file to retry a rename the server has already declined. Check
 write permissions on the existing target files and any policy on the server
 that forbids replacing them. See
 [what easySFTP needs from a server](providers.md#what-easysftp-needs-from-a-server).
@@ -196,8 +199,8 @@ is ever listed or touched. The age margin keeps the sweep from deleting a
 concurrently running deploy's in-progress upload. The sweep intentionally
 runs in every mode, `overlay` included, and is on by default: even though
 overlay never deletes your files, the sweep only ever removes the action's
-own `*.easysftp-tmp` / `*.easysftp-tmp.<n>` debris, never a file it did not
-name itself. A real file of yours that happens to carry such a name is part
+own `*.easysftp-tmp` / `*.easysftp-tmp.<n>` / `*.easysftp-tmp.bak` debris,
+never a file it did not name itself. A real file of yours that happens to carry such a name is part
 of the deployment and is therefore never swept, in `sync` too, where it is
 protected even on runs that leave it unchanged. An orphan in a directory
 that no later deploy uploads into

--- a/internal/uploader/atomic_test.go
+++ b/internal/uploader/atomic_test.go
@@ -331,3 +331,86 @@ func TestIsRetryable(t *testing.T) {
 		}
 	}
 }
+
+// TestNonAtomicPublishKeepsTheLiveFileWhenTheRenameFails is the guarantee the
+// atomic-upload feature exists for, arriving through the fallback that servers
+// without posix-rename@openssh.com take.
+//
+// The old spelling was remove(final) then rename(tmp, final). If the remove
+// succeeded and the rename then failed, the live file was gone and nothing had
+// replaced it, which is precisely the outcome the feature promises cannot
+// happen. The causes are ordinary on the appliance and managed-hosting servers
+// this path exists for: a full filesystem, a quota, a permission change, a
+// dropped connection, another process taking the name (issue #242).
+func TestNonAtomicPublishKeepsTheLiveFileWhenTheRenameFails(t *testing.T) {
+	srv := startTestServer(t,
+		withFailPosixRename(sftp.ErrSSHFxOpUnsupported),
+		withFailPublishRename("/www/index.html"))
+	seedRemoteFile(t, srv, "/www", "index.html", "original")
+
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "replacement"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err == nil {
+		t.Fatal("expected the failed publish to fail the run")
+	}
+	if got := readRemote(t, srv, "/www/index.html"); got != "original" {
+		t.Errorf("the live file reads %q; a failed publish must not cost the file it was replacing", got)
+	}
+	if remoteHasTmpFile(t, srv, "/www", "index.html") {
+		t.Error("a temporary or backup file was left behind after the rollback")
+	}
+}
+
+// TestNonAtomicPublishOfANewFile covers the branch where there is nothing to
+// park, on both kinds of server: one that reports a missing file specifically,
+// and one that answers every absence with a generic status, where the tie-break
+// from issue #152 is the only thing that can tell "nothing there" from "the
+// server refused to move it".
+func TestNonAtomicPublishOfANewFile(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []serverOption
+	}{
+		{"server reports a missing file", []serverOption{withFailPosixRename(sftp.ErrSSHFxOpUnsupported)}},
+		{"server answers absence generically", []serverOption{withCoarseStatus(sftp.ErrSSHFxFailure), withFailPosixRename(sftp.ErrSSHFxOpUnsupported)}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := startTestServer(t, tc.opts...)
+			local := t.TempDir()
+			writeTree(t, local, map[string]string{"index.html": "fresh"})
+
+			cfg := baseConfig(srv)
+			cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+
+			if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+				t.Fatalf("first upload without posix-rename failed: %v", err)
+			}
+			if got := readRemote(t, srv, "/www/index.html"); got != "fresh" {
+				t.Errorf("unexpected content: %q", got)
+			}
+			if remoteHasTmpFile(t, srv, "/www", "index.html") {
+				t.Error("a temporary or backup file was left behind")
+			}
+		})
+	}
+}
+
+// The backup has to be swept if a run is killed between parking the live file
+// and putting it back, which is why it lives inside the tmpSuffix family
+// rather than under a name of its own.
+func TestBackupNameIsSweptAsATempFile(t *testing.T) {
+	if !isTempFileName("index.html" + bakSuffix) {
+		t.Errorf("%q is not recognised as a temp file, so an interrupted publish would leave it behind forever", "index.html"+bakSuffix)
+	}
+	for _, name := range []string{".easysftp-tmp.bak", "index.html.bak", "index.html.easysftp-tmp.baked"} {
+		if isTempFileName(name) {
+			t.Errorf("%q is swept but is not a file this action writes", name)
+		}
+	}
+}

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -434,6 +434,40 @@ func (f *faultyRename) PosixRename(r *sftp.Request) error {
 	return errors.New("injected rename failure")
 }
 
+// faultyPublishRename fails the rename that publishes an upload over target,
+// while letting the rename that puts a backup back succeed. That is what makes
+// the non-atomic publish path testable: it parks the live file under
+// "<final>.easysftp-tmp.bak", renames the upload onto the final name, and
+// rolls the backup back if that fails, so a test has to fail the middle step
+// only (issue #242).
+//
+// Every attempt is failed rather than just the first, so a retry cannot
+// quietly turn the test green.
+type faultyPublishRename struct {
+	inner  sftp.FileCmder
+	target string
+}
+
+// withFailPublishRename makes every plain rename onto target fail, except one
+// coming from the backup name. Give it after withFailPosixRename so the server
+// reaches the fallback in the first place.
+func withFailPublishRename(target string) serverOption {
+	return func(s *testServer) {
+		s.handlers.FileCmd = &faultyPublishRename{inner: s.handlers.FileCmd, target: target}
+	}
+}
+
+func (f *faultyPublishRename) Filecmd(r *sftp.Request) error {
+	if r.Method == "Rename" && r.Target == f.target && !strings.HasSuffix(r.Filepath, bakSuffix) {
+		return errors.New("injected publish rename failure")
+	}
+	return f.inner.Filecmd(r)
+}
+
+func (f *faultyPublishRename) PosixRename(r *sftp.Request) error {
+	return posixRenamePassthrough(f.inner, r)
+}
+
 // faultyPosixRename wraps a FileCmder and answers every posix-rename request
 // with one fixed error while leaving plain "Rename" working, simulating a
 // server that does not implement posix-rename@openssh.com. The request server

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -25,6 +25,13 @@ import (
 // rename stays on one filesystem and is atomic.
 const tmpSuffix = ".easysftp-tmp"
 
+// bakSuffix names the short-lived copy of the live file that the non-atomic
+// publish path parks the target under while it renames the upload into place.
+// It sits inside the tmpSuffix family on purpose, so isTempFileName recognises
+// it and the stale-temp sweep collects one that an interrupted run left
+// behind. See renameReplaceViaBackup.
+const bakSuffix = tmpSuffix + ".bak"
+
 // transferEnv carries the invariants that every level of the upload call chain
 // re-threads to the next (the session, the stall watchdog, the logger and the
 // two warn-once flags). It is built once in uploadFiles and passed down, so
@@ -294,7 +301,7 @@ const posixRenameExt = "posix-rename@openssh.com"
 
 // renameReplace atomically moves tmp onto final. It prefers the
 // posix-rename@openssh.com extension (a true atomic overwrite) and falls back
-// to a plain remove+rename for servers that do not support it.
+// to renameReplaceViaBackup for servers that do not support it.
 func renameReplace(client *sftp.Client, tmp, final string) error {
 	err := client.PosixRename(tmp, final)
 	if err == nil {
@@ -304,10 +311,71 @@ func renameReplace(client *sftp.Client, tmp, final string) error {
 	if !posixRenameUnsupported(err, announced) {
 		return err
 	}
-	// note: non-atomic fallback, a brief window where final is missing.
-	// Only reached on servers lacking posix-rename; unavoidable there.
-	_ = client.Remove(final)
-	return client.Rename(tmp, final)
+	return renameReplaceViaBackup(client, tmp, final)
+}
+
+// renameReplaceViaBackup publishes tmp over final on a server that does not
+// implement posix-rename, without ever being in a state where the live file is
+// gone and nothing has replaced it.
+//
+// The obvious spelling, remove(final) then rename(tmp, final), has a window
+// that is not the one the comment here used to claim was unavoidable. A window
+// where final is briefly *missing* is unavoidable without the extension. A
+// window where final is *lost* is not: if the remove succeeds and the rename
+// then fails, the live file is gone, the replacement is not there, and the
+// error returned is the rename's. The causes of that second failure are
+// ordinary rather than exotic (the filesystem filled up between the two calls,
+// a quota was hit, the directory's permissions changed, the connection
+// dropped, another process took the name), and they are most likely on exactly
+// the appliance, embedded and managed-hosting servers this path exists for.
+//
+// So: park the live file under a backup name, move the upload into place, drop
+// the backup. The window where final is missing shrinks to a single rename,
+// and a failure at any step leaves the original content reachable. See
+// issue #242.
+func renameReplaceViaBackup(client *sftp.Client, tmp, final string) error {
+	backup := final + bakSuffix
+
+	// A backup an interrupted run left behind would make the park below fail
+	// on a server whose rename refuses an existing target, which is the same
+	// class of server that brought us here. Removing it is best effort: if it
+	// is still there afterwards the park fails and nothing has been touched.
+	_ = client.Remove(backup)
+
+	parked := false
+	switch err := client.Rename(final, backup); {
+	case err == nil:
+		parked = true
+	case errors.Is(err, os.ErrNotExist):
+		// Nothing live to protect: this is the first upload of this path.
+	default:
+		// A server answering "not there" with a generic status code looks the
+		// same as one refusing the rename, so ask it directly (issue #152).
+		// Anything that is not absence is a refusal, and a refusal must not
+		// cost the live file.
+		absent, aerr := remoteAbsent(client, final, nil)
+		if aerr != nil {
+			return aerr
+		}
+		if !absent {
+			return fmt.Errorf("could not move the existing file aside: %w", err)
+		}
+	}
+
+	if err := client.Rename(tmp, final); err != nil {
+		if !parked {
+			return err
+		}
+		if rerr := client.Rename(backup, final); rerr != nil {
+			return fmt.Errorf("%w; restoring the previous file from %s also failed: %v", err, backup, rerr)
+		}
+		return err
+	}
+
+	// Best effort. A leftover backup is swept by sweepStaleTemps once it is
+	// old enough, which is why bakSuffix lives in the tmpSuffix family.
+	_ = client.Remove(backup)
+	return nil
 }
 
 // posixRenameUnsupported reports whether a failed posix-rename@openssh.com
@@ -363,16 +431,18 @@ var staleTempMaxAge = time.Hour
 
 // isTempFileName reports whether name looks like a temporary upload file this
 // action writes: "<name>.easysftp-tmp.<n>" for a file upload (n being the
-// plan index, see uploadFile) or "<name>.easysftp-tmp" for a manifest write
-// (see writeManifest). The suffix is always appended to an existing name, so
-// a file named exactly ".easysftp-tmp" (i == 0) is not one of ours.
+// plan index, see uploadFile), "<name>.easysftp-tmp" for a manifest write
+// (see writeManifest), or "<name>.easysftp-tmp.bak" for the copy the
+// non-atomic publish path parks a live file under (see
+// renameReplaceViaBackup). The suffix is always appended to an existing name,
+// so a file named exactly ".easysftp-tmp" (i == 0) is not one of ours.
 func isTempFileName(name string) bool {
 	i := strings.LastIndex(name, tmpSuffix)
 	if i <= 0 {
 		return false
 	}
 	rest := name[i+len(tmpSuffix):]
-	if rest == "" {
+	if rest == "" || rest == ".bak" {
 		return true
 	}
 	if rest[0] != '.' || len(rest) < 2 {


### PR DESCRIPTION
Closes #242.

## The gap

`renameReplace`'s fallback for servers without `posix-rename@openssh.com` was:

```go
// note: non-atomic fallback, a brief window where final is missing.
// Only reached on servers lacking posix-rename; unavoidable there.
_ = client.Remove(final)
return client.Rename(tmp, final)
```

The comment is half right. A window where `final` is briefly **missing** is unavoidable without the extension. A window where `final` is **lost** is not: if the remove succeeds and the rename then fails, the live file is gone, the replacement is not in place, and the error returned is the rename's.

The classification in front of this is careful and stays untouched: `posixRenameUnsupported` (#152) already makes sure a *refusal* never reaches the fallback. The gap was only what happens after the remove.

## The fix

`renameReplaceViaBackup` does the three-step dance:

1. `Rename(final, backup)` where `backup` is `<final>.easysftp-tmp.bak`. Not-there is fine (first upload of this path). Anything else is a refusal, and it returns **before** touching anything.
2. `Rename(tmp, final)`. On failure, the backup is renamed back and the original error is returned; if the rollback also fails, the error names the backup path so the file can be recovered by hand.
3. `Remove(backup)`, best effort.

Two details worth calling out:

- **Absence has to be asked about, not assumed.** Step 1 on a missing `final` returns `SSH_FX_FAILURE` on a server that answers every absence generically, which is indistinguishable from a refusal. The `remoteAbsent` tie-break from #152 settles it, and a refusal must not cost the live file.
- **The backup name is in the `tmpSuffix` family** (`<final>.easysftp-tmp.bak`), so `isTempFileName` recognises it and the existing stale-temp sweep collects one that a killed run left behind, exactly as the issue asks. A stale backup is also removed before step 1, since a server whose plain rename refuses an existing target is the same class of server that brought us here.

## Tests

New fault injector `withFailPublishRename(target)` in `testserver_test.go`, following the pattern CLAUDE.md prescribes: it fails every plain rename **onto** `target` except one coming from the backup name, so it fails the middle step only and a retry cannot quietly turn the test green.

- `TestNonAtomicPublishKeepsTheLiveFileWhenTheRenameFails`: the run fails, the live file still reads `original`, and no temp or backup debris is left. **Fails against the old implementation**, verified by restoring `remove`+`rename`:
  ```
  --- FAIL: TestNonAtomicPublishKeepsTheLiveFileWhenTheRenameFails (0.04s)
  ```
- `TestNonAtomicPublishOfANewFile`: the nothing-to-park branch, on both a server that reports a missing file specifically and one that answers absence with a generic status (the `remoteAbsent` path).
- `TestBackupNameIsSweptAsATempFile`: the backup name is swept, and three near-misses (`.easysftp-tmp.bak` with no basename, `index.html.bak`, `index.html.easysftp-tmp.baked`) are not.

The existing `TestPosixRenameUnsupportedFallsBack` already asserts no `<base>.easysftp-tmp*` file survives a successful fallback, so it covers step 3 for free. `go test ./...` is green.

## Docs

`docs/security.md` describes the backup and **widens the nginx and Apache deny rules** to match it (`\.easysftp-tmp(\.\d+|\.bak)?$`). Without that, a backup orphaned in a public web root would be served, which is the exact hazard that section exists for. `docs/strategies.md` and `docs/troubleshooting.md` describe the new fallback, and the "unavoidable there" comment is gone, since it was the reason nobody revisited this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)