### PR TITLE
fix(benchmark): derive the stored settings sentence from the config

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -467,6 +467,44 @@ Results up to and including v3.3.1 predate this and name only the kernel and
 CPU count (`Linux 6.17.0-1020-azure, 4 cpu`); every one of them was measured on
 a GitHub-hosted runner. From v3.3.2 on the field starts with `self-hosted`.
 
+### Correction: what the v3.6.0 and v3.7.0 `settings` field says
+
+The `settings` string used to be a literal in the harness, written when the
+transport defaults really were fixed. #211 made `auto` the real default on
+2026-08-21, and the literal was not updated, so two stored release results
+describe settings their runs did not use:
+
+| stored release | released | `settings` correct |
+|---|---|---|
+| v3.3.2, v3.4.0, v3.5.0 | before #211 | yes |
+| **v3.6.0** | 2026-08-21 | **no** |
+| **v3.7.0** | 2026-08-25 | **no** |
+
+Both of those runs left `connections`, `concurrency` and `request_concurrency`
+to the auto policy, which resolved them per scenario. What each scenario
+actually ran at is recorded in the same documents and is not affected: read
+`results[].counters.config_*` (and, in the matching matrix sweep, the `auto[]`
+block). For v3.7.0 those counters read:
+
+| scenario | `config_connections` | `config_concurrency` | `config_request_concurrency` |
+|---|---|---|---|
+| large | 2 | 2 | 64 |
+| mixed | 6 | 56 | 64 |
+| small | 4 | 64 | 16 |
+
+against a `settings` field claiming `concurrency 4, request_concurrency 16` for
+all three. A stored result is never rewritten, which is why the correction
+lives here rather than in the files.
+
+Concretely, a reader comparing v3.5.0 against v3.7.0 should not conclude the
+two ran the same configuration: v3.5.0 genuinely ran at 4/16, v3.7.0 ran at
+whatever the policy chose, so the configuration is one of the things that
+changed between them.
+
+The sentence is derived from `config.Defaults()` from this release on, and
+`internal/benchmark/driver` has a test that fails if it names a fixed number
+while the defaults are adaptive (issue #229).
+
 ## Reading a delta
 
 Every repeat's individual value is kept, alongside the median, min, max and the

--- a/internal/benchmark/driver/driver_test.go
+++ b/internal/benchmark/driver/driver_test.go
@@ -1,6 +1,7 @@
 package driver_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/eiserv/easySFTP/internal/benchmark/driver"
 	"github.com/eiserv/easySFTP/internal/benchmark/runner"
 	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+	"github.com/eiserv/easySFTP/internal/config"
 )
 
 // These tests are the harness's own self-check, and since issue #190 step 6 the
@@ -607,4 +609,47 @@ func glob(t *testing.T, dir, pattern string) []string {
 		t.Fatalf("globbing %s: %v", pattern, err)
 	}
 	return matches
+}
+
+// TestStandardSettingsSentenceDescribesTheRun. The sentence is stored verbatim
+// in a permanent document and published as a release asset, so it has to
+// describe the run rather than a run that was true when the literal was
+// written. It stopped being true the day #211 made auto the real default, and
+// two stored releases (v3.6.0, v3.7.0) claim "concurrency 4,
+// request_concurrency 16" for runs that resolved all three transport settings
+// through the policy (issue #229).
+func TestStandardSettingsSentenceDescribesTheRun(t *testing.T) {
+	opts := options(t)
+	opts.Repeats = 1
+	if err := driver.Standard(opts); err != nil {
+		t.Fatalf("measuring: %v", err)
+	}
+	result := readJSON[schema.Standard](t, filepath.Join(opts.OutDir, "results.json"))
+
+	cfg := config.Defaults()
+	if !cfg.Auto.Connections || !cfg.Auto.Concurrency || !cfg.Auto.RequestConcurrency {
+		t.Fatal("the easySFTP defaults are no longer fully adaptive; revisit this test deliberately rather than deleting it")
+	}
+	for _, name := range []string{"connections", "concurrency", "request_concurrency"} {
+		if !strings.Contains(result.Settings, name+" auto") {
+			t.Errorf("stored settings do not say %s ran at auto: %q", name, result.Settings)
+		}
+	}
+	// The literal's numbers must not come back while the settings are
+	// adaptive: naming a fixed value the run did not use is what made the two
+	// stored documents wrong.
+	for _, stale := range []string{"concurrency 4", "request_concurrency 16"} {
+		if strings.Contains(result.Settings, stale) {
+			t.Errorf("stored settings name a fixed %q although the defaults are adaptive: %q", stale, result.Settings)
+		}
+	}
+	for _, want := range []string{
+		fmt.Sprintf("retries %d", cfg.Retries),
+		fmt.Sprintf("timeout %s", cfg.Timeout),
+		"mode overlay",
+	} {
+		if !strings.Contains(result.Settings, want) {
+			t.Errorf("stored settings are missing %q: %q", want, result.Settings)
+		}
+	}
 }

--- a/internal/benchmark/driver/standard.go
+++ b/internal/benchmark/driver/standard.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"github.com/eiserv/easySFTP/internal/benchmark"
 	"github.com/eiserv/easySFTP/internal/benchmark/link"
@@ -10,6 +11,7 @@ import (
 	"github.com/eiserv/easySFTP/internal/benchmark/scenario"
 	"github.com/eiserv/easySFTP/internal/benchmark/schema"
 	"github.com/eiserv/easySFTP/internal/benchmark/stats"
+	"github.com/eiserv/easySFTP/internal/config"
 )
 
 // StandardScenarios is the standard benchmark's scenario set, and it is fixed:
@@ -174,13 +176,50 @@ func (r *run) measure(build int, name string, repeat int) error {
 	return nil
 }
 
+// defaultsSentence describes what a run at the defaults is actually configured
+// with, read from internal/config rather than restated.
+//
+// It used to be a literal, and it went stale the day #211 made auto the real
+// default: two permanent documents (v3.6.0 and v3.7.0) say "concurrency 4,
+// request_concurrency 16" for runs that in fact resolved all three transport
+// settings through the auto policy, per scenario (issue #229). The three store
+// invariants mean those documents stay as they are; benchmarks/README.md
+// carries the correction.
+//
+// The resolved numbers deliberately stay out of this sentence. They are not
+// run-wide any more, so the honest run-wide statement is that the run left them
+// to easySFTP; what the policy then chose is per scenario and already lives in
+// the auto[] block, read back from the run's own config_* counters.
+//
+// One caveat worth naming: this reads the defaults of the tree the harness was
+// built from, which for a release sweep is the tree of the build being
+// measured. A comparison run against an older baseline ref describes the
+// candidate's defaults, which is the run the sentence is about.
+func defaultsSentence() string {
+	cfg := config.Defaults()
+	autoOr := func(isAuto bool, n int) string {
+		if isAuto {
+			return "auto"
+		}
+		return strconv.Itoa(n)
+	}
+	return fmt.Sprintf(
+		"easySFTP defaults (no advanced.* overrides): connections %s, concurrency %s, request_concurrency %s, retries %d, timeout %s, mode overlay",
+		autoOr(cfg.Auto.Connections, cfg.Connections),
+		autoOr(cfg.Auto.Concurrency, cfg.Concurrency),
+		autoOr(cfg.Auto.RequestConcurrency, cfg.SftpRequestConcurrency),
+		cfg.Retries,
+		cfg.Timeout,
+	)
+}
+
 // aggregateStandard hands the run over to the aggregation half.
 //
 // The display strings travel verbatim rather than being rebuilt on the other
 // side. This half already has them, and a summary table that reformats itself
 // during a rewrite is a change to a stored document made by accident.
 func (r *run) aggregateStandard() error {
-	settings := "easySFTP defaults (no advanced.* overrides): concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay"
+	settings := defaultsSentence()
 	if r.opts.Connections > 0 {
 		settings += fmt.Sprintf("; the pool%d build is the same binary with advanced.connections: %d",
 			r.opts.Connections, r.opts.Connections)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -274,6 +274,29 @@ const (
 	defaultTimeoutSec         = 30
 )
 
+// Defaults returns the configuration a run starts from before a single input
+// or config-file field is read.
+//
+// It exists so that anything needing to describe "the easySFTP defaults" reads
+// them instead of restating them. The benchmark harness names them in every
+// stored result, and because it restated them, two permanent documents claim a
+// run at "concurrency 4, request_concurrency 16" that in fact resolved all
+// three through the auto policy (issue #229).
+func Defaults() *Config {
+	return &Config{
+		Concurrency:            defaultConcurrency,
+		SftpRequestConcurrency: defaultRequestConcurrency,
+		Connections:            defaultConnections,
+		// Adaptive unless the config file pins a number. Inline mode has no
+		// input for any of the three (every non-secret setting has exactly
+		// one home in v3), so an inline run is always fully adaptive.
+		Auto:         AutoSettings{Connections: true, Concurrency: true, RequestConcurrency: true},
+		Retries:      defaultRetries,
+		Timeout:      defaultTimeoutSec * time.Second,
+		ManifestName: DefaultManifestName,
+	}
+}
+
 // removedInput maps a v2 input's environment variable to its migration hint.
 // The inputs stay declared in action.yml (without defaults) so a workflow
 // still passing them fails loudly here instead of being silently ignored by
@@ -345,21 +368,10 @@ func Load() (*Config, error) {
 		return strings.TrimSpace(os.Getenv(envPrefix + name))
 	}
 
-	cfg := &Config{
-		Password:               os.Getenv(envPrefix + "PASSWORD"),
-		PrivateKey:             os.Getenv(envPrefix + "PRIVATE_KEY"),
-		Passphrase:             os.Getenv(envPrefix + "PASSPHRASE"),
-		Concurrency:            defaultConcurrency,
-		SftpRequestConcurrency: defaultRequestConcurrency,
-		Connections:            defaultConnections,
-		// Adaptive unless the config file pins a number. Inline mode has no
-		// input for any of the three (every non-secret setting has exactly
-		// one home in v3), so an inline run is always fully adaptive.
-		Auto:         AutoSettings{Connections: true, Concurrency: true, RequestConcurrency: true},
-		Retries:      defaultRetries,
-		Timeout:      defaultTimeoutSec * time.Second,
-		ManifestName: DefaultManifestName,
-	}
+	cfg := Defaults()
+	cfg.Password = os.Getenv(envPrefix + "PASSWORD")
+	cfg.PrivateKey = os.Getenv(envPrefix + "PRIVATE_KEY")
+	cfg.Passphrase = os.Getenv(envPrefix + "PASSPHRASE")
 
 	var err error
 	if cfg.DryRun, err = parseBool(get("DRY_RUN"), false); err != nil {


### PR DESCRIPTION
Closes #229.

## The defect, shown from the stored document

`internal/benchmark/driver/standard.go` hard-coded the sentence every stored release result carries as its `settings` field. It was accurate when it was written in #190 on 2026-08-03, and stopped being accurate on 2026-08-21 when #211 made `auto` the real default.

Read straight out of `benchmarks/releases/release-v3.7.0.json`:

```
settings: easySFTP defaults (no advanced.* overrides): concurrency 4, request_concurrency 16, retries 2, timeout 30s, mode overlay

  candidate large   config_connections=2  config_concurrency=2   config_request_concurrency=64
  candidate mixed   config_connections=6  config_concurrency=56  config_request_concurrency=64
  candidate small   config_connections=4  config_concurrency=64  config_request_concurrency=16
```

The same document states the settings and records that they were not used.

## What changed

**`config.Defaults()` is now exported**, and `Load()` builds on it rather than restating the values, so the two cannot disagree. Behaviour is unchanged; `internal/config`'s tests are green.

**The sentence is derived from it:**

```
easySFTP defaults (no advanced.* overrides): connections auto, concurrency auto, request_concurrency auto, retries 2, timeout 30s, mode overlay
```

Two properties the issue asks for are kept:

- The string is still **built once at the start of the run and stored verbatim**, never rebuilt on the aggregation side. A summary table that reformats itself during a rewrite is a change to a stored document made by accident.
- The **resolved numbers stay out of it**. They are not run-wide any more, so the honest run-wide statement is that the run left the three settings to easySFTP; what the policy then chose per scenario already lives in `results[].counters.config_*` and in the matrix sweep's `auto[]` block, read back from the run's own counters.

## Test

`TestStandardSettingsSentenceDescribesTheRun` drives the real `driver.Standard` against the stub build and asserts on the stored `results.json`: the settings say `auto` for all three, do **not** name `concurrency 4` or `request_concurrency 16` while the defaults are adaptive, and still name the retries, timeout and mode. If the defaults ever stop being adaptive it fails loudly with a message saying to revisit it deliberately, rather than passing vacuously.

## The two documents already on disk

The three store invariants say a stored result is never rewritten, so v3.6.0 and v3.7.0 stay as they are. `benchmarks/README.md` gains a **Correction** section under "Where the numbers were measured": which releases are affected, the per-scenario counters that say what those runs really ran at, and the specific misreading to avoid (comparing v3.5.0, genuinely 4/16, against v3.7.0 and concluding the configuration was held constant).

I did not add the note to `index.json` as the issue also suggests. `KIND=reindex go run ./cmd/easysftp-bench store` rebuilds that file from what is on disk, so a hand-added note would disappear at the next reindex, and making it survive means a schema field plus store support: a larger change than the correction warrants, and one that would need its own decision about what else belongs in the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)