### PR TITLE
perf(tuning): fit the throughput prior to the link that was measured

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,17 @@ planned as metadata only (`Workload.Unknown`), which is what keeps a redeploy
 that changed three files from paying for a pool, and stage 3 widens it if the
 observed ratio says most files really are being sent.
 
+`assumedStreamBytesPerSecond` is the one input the model cannot measure before
+it decides, and since issue #230 it is fitted like everything else here: 0.35
+MiB/s, just under the 0.36 to 0.39 MiB/s single-stream control the stored
+results record, replacing a 1 MiB/s guess that was 2.8x above it. `W` is divided
+by it, so a prior that is too high understates the work, understates
+`k = sqrt(W/H)` and opens too few connections. Replaying every stored sweep,
+worst-case regret falls from 24.4% to 14.4% and the whole 0.25 to 0.75 MiB/s
+range stays inside the 15% budget, so the number is not balanced on a knife
+edge. Carry the caveat with it: one host, one 13 ms path, `shaping.available`
+false in every stored result.
+
 `internal/autotune/regret_test.go` is the acceptance test issue #209 asks for:
 it replays the policy over every sweep committed under `benchmarks/matrix/`
 with at least three repeats and fails when the regret against the best measured
@@ -189,6 +200,20 @@ that from turning into stale configuration (issue #212):
 4. **A ceiling is let go.** A pool capped at a remembered limit never asks for
    more and so never finds out whether the limit is still there, so an
    untested ceiling is carried at most `MaxCeilingCarry` runs.
+
+What the cache is worth, measured. Replaying every stored sweep with a *perfect*
+cache (the sweep's own single-stream control handed to `Plan` as
+`SourceCached`) against no cache at all: on the old 1 MiB/s prior it moved mean
+regret 3.91% to 3.38% and worst 24.4% to 14.4%; on the refitted prior it moves
+mean 3.36% to 3.38% and worst 14.4% to 14.4%. In other words the throughput
+half of this package was earning its keep by compensating for a badly chosen
+default, and on the data this repository has it now adds nothing. That is not
+an argument to delete it: the measured corpus is one host on one unshaped
+13 ms path, a real server-specific measurement still beats any fixed prior on a
+link that differs from it, and the connection ceiling a record carries is
+information the cost model cannot derive at all (it assumes perfect scaling).
+It is an argument not to reach for the cache to fix a number the prior should
+be fixing. See issue #230.
 
 Two more things to know before changing anything here. `request_concurrency`
 is deliberately outside the cache's reach: it is baked into an SFTP client at

--- a/internal/autotune/autotune.go
+++ b/internal/autotune/autotune.go
@@ -158,12 +158,44 @@ const (
 	tailShare = 0.1
 
 	// assumedStreamBytesPerSecond is the per-connection throughput Plan
-	// assumes while nothing has been measured yet. It is deliberately low.
+	// assumes while nothing has been measured yet.
+	//
+	// Fitted, like every other constant here, rather than guessed: it was set
+	// to 1 MiB/s and called conservative, while the only link the project has
+	// ever measured reports a single-stream control of 0.36 to 0.39 MiB/s,
+	// stable across four releases (issue #230). W is divided by this number,
+	// so a prior 2.8x too high understates the work, understates
+	// k = sqrt(W/H), and opens fewer connections than the link would reward.
+	//
+	// Replaying the policy over every stored sweep, varying only this value:
+	//
+	//	assumed        mean regret   worst regret
+	//	1 MiB/s              3.91%         24.40%
+	//	0.75 MiB/s           3.62%         14.44%
+	//	0.5 MiB/s            3.38%         14.44%
+	//	0.375 MiB/s          3.36%         14.44%
+	//	0.35 MiB/s           3.36%         14.44%
+	//	0.25 MiB/s           3.42%         14.44%
+	//	0.1875 MiB/s         4.61%         22.12%
+	//	0.125 MiB/s          5.77%         32.08%
+	//
+	// The whole 0.25 to 0.75 MiB/s range holds the worst case inside the 15%
+	// budget, so the choice is not balanced on one number; the flat optimum is
+	// 0.35 to 0.45. This sits just under the lowest measured control, which is
+	// the conservative side to be on: under-estimating throughput errs toward
+	// one more connection, and the scaling data says that is the cheaper
+	// direction to be wrong in.
+	//
+	// Caveat worth carrying with the number: one host, one 13 ms path, and
+	// shaping.available is false in all 15 stored results. A prior fitted to a
+	// single measured link beats one fitted to nothing and is not a general
+	// answer.
+	//
 	// The number is only used to ask "is this run long enough to be worth
 	// another handshake", the answer is checked against the throughput the
 	// run really achieves as soon as it has one (see Controller), and the
 	// damage a wrong guess can do is bounded by MaxConnections handshakes.
-	assumedStreamBytesPerSecond = 1 << 20 // 1 MiB/s
+	assumedStreamBytesPerSecond = 360 << 10 // 0.35 MiB/s
 
 	// fallbackRTT and fallbackHandshake stand in when the probe could not
 	// measure the link at all (a server that refuses SSH_FXP_REALPATH, say).

--- a/internal/autotune/autotune_test.go
+++ b/internal/autotune/autotune_test.go
@@ -46,8 +46,11 @@ func TestPlanChoosesPerWorkload(t *testing.T) {
 		{
 			name: "many small files",
 			w:    autotune.Workload{Uploads: 300, UploadBytes: 300 * 4 * KiB, LargestUpload: 4 * KiB},
-			want: autotune.Settings{Connections: 4, Concurrency: 64, RequestConcurrency: 16},
-			why:  "the stored 'small' sweep is fastest at 4 connections and flat past 32 workers",
+			want: autotune.Settings{Connections: 5, Concurrency: 64, RequestConcurrency: 16},
+			why: "the stored 'small' sweep is fastest at 4 connections and flat past 32 workers; " +
+				"5 is between two swept columns (4 and 8) and the replay scores it at 4, " +
+				"the same 5.0/4.5/4.9 second medians, so refitting the throughput prior " +
+				"in #230 moved this by one connection into a gap the grid cannot separate",
 		},
 		{
 			name: "very many small files",
@@ -196,10 +199,19 @@ func TestAnUnmeasuredLinkFallsBackInsteadOfDividingByZero(t *testing.T) {
 // connections than the same files over the conservative prior are, and a link
 // measured as fast is worth fewer.
 func TestMeasuredThroughputMovesTheDecision(t *testing.T) {
-	w := autotune.Workload{Uploads: 60, UploadBytes: 12 * MiB, LargestUpload: 2 * MiB}
+	// Both fixtures moved when #230 refitted the throughput prior from 1 MiB/s
+	// to the measured 0.35 MiB/s, and both moved because the refit did what it
+	// was meant to do.
+	//
+	// The workload is smaller because 12 MiB now puts the *prior* at
+	// MaxConnections, where a slower measurement has nowhere left to go; this
+	// one leaves the prior at 6, off the ceiling, so the ordering can be read.
+	// And "slow" has to be genuinely below the prior: 300 KiB/s is no longer
+	// slower than what Plan already assumes.
+	w := autotune.Workload{Uploads: 60, UploadBytes: 4 * MiB, LargestUpload: 2 * MiB}
 
 	slow := house
-	slow.StreamBytesPerSecond = 300 * KiB
+	slow.StreamBytesPerSecond = 100 * KiB
 	fast := house
 	fast.StreamBytesPerSecond = 50 * MiB
 


### PR DESCRIPTION
Closes #230.

## Empirical evidence first, as the issue asks

`assumedStreamBytesPerSecond` was 1 MiB/s and called conservative. The only link this project has ever measured reports a single-stream control of **0.36 to 0.39 MiB/s**, stable across four releases, so the prior was 2.8x above it and was the one constant in `internal/autotune` never fitted to anything.

I replayed the policy over **every** stored sweep under `benchmarks/matrix/` (six sweeps, 61 scored scenario/profile groups), using the same workload reconstruction, link derivation and cell snapping as `regret_test.go`, varying only this constant. The replay reads the repeats-2 release sweeps too, which the acceptance test excludes (that exclusion is #228, filed separately and not touched here).

| assumed | mean regret | worst regret |
|---|---|---|
| **1 MiB/s (before)** | 3.91% | **24.40%** |
| 0.75 MiB/s | 3.62% | 14.44% |
| 0.5 MiB/s | 3.38% | 14.44% |
| 0.375 MiB/s | 3.36% | 14.44% |
| **0.35 MiB/s (this PR)** | **3.36%** | **14.44%** |
| 0.25 MiB/s | 3.42% | 14.44% |
| 0.1875 MiB/s | 4.61% | 22.12% |
| 0.125 MiB/s | 5.77% | 32.08% |

Two things this shows beyond "lower is better": the whole **0.25 to 0.75 MiB/s** range holds the worst case inside the documented 15% budget, so the fix is not balanced on one number and is not overfitted; and below 0.25 MiB/s it gets worse again, so there is a real optimum rather than a monotone trend.

Where the change actually lands, per scenario:

| sweep | scenario | before | after |
|---|---|---|---|
| v3.7.0 | **mixed** | chose 5 conns, **+24.4%** | chose 8 conns, **+6.7%** |
| v3.7.0 | calib-100x64k | +11.4% | +9.8% |
| 20260816 | calib-100x64k | +7.9% | +0.7% |
| 20260820 | calib-100x64k | +6.2% | +0.2% |
| 20260815 | calib-100x64k | +2.6% | +1.0% |
| v3.6.0 | calib-100x64k | +5.5% | +9.9% |

`mixed` at v3.7.0 is the single worst case in the whole corpus and is what the issue predicted: it chose 5 to 6 connections where the grid measured 8 as fastest. One row moves the wrong way (v3.6.0 `calib`, +5.5% to +9.9%), still comfortably inside budget.

## The acceptance test CLAUDE.md requires

`go test ./internal/autotune/` passes, and its `calib-100x64k` rows improve from `+7.9%` and `+6.2%` to `+0.7%` and `+0.2%`. The control test still fails the pre-adaptive fixed 1/4/16 (up to 375% behind), so the replay has not stopped discriminating.

## What the cache is still worth on top (issue point 4)

The issue asks this explicitly. Replaying with a **perfect** cache, the sweep's own single-stream control handed to `Plan` as `SourceCached`, against no cache at all:

| | mean | worst |
|---|---|---|
| old prior, no cache | 3.91% | 24.40% |
| old prior + perfect cache | 3.38% | 14.44% |
| **new prior, no cache** | **3.36%** | **14.44%** |
| new prior + perfect cache | 3.38% | 14.44% |

So on the data this repository has, the throughput half of `internal/autocache` was earning its keep by compensating for a badly chosen default, and now adds nothing. That is **not** an argument to delete it, and the PR does not: the corpus is one host on one unshaped 13 ms path, a real server-specific measurement still beats a fixed prior on a link that differs from it, and the connection ceiling a record carries is information the cost model cannot derive at all. It is written down in CLAUDE.md next to the four rules, as the issue asks, so nobody reaches for the cache to fix a number the prior should fix.

## Two test fixtures moved, and why

Both moved because the refit did what it was meant to do. Flagging them explicitly since "the test needed changing" deserves scrutiny in this package:

1. `TestPlanChoosesPerWorkload/many_small_files` expected 4 connections and now gets 5. The `small` grid sweeps 1/2/4/8, so 5 is between two columns; the replay scores it at 4 and measures the same 5.0/4.5/4.9 second medians. The grid cannot separate the two, and the evidence for the change comes from the scenarios where it can.
2. `TestMeasuredThroughputMovesTheDecision` asserts slow > prior > fast connections. Its "slow" link was 300 KiB/s, which is no longer slower than the prior, and its 12 MiB workload now puts the *prior* at `MaxConnections` where nothing slower has anywhere to go. Both fixtures moved (4 MiB, 100 KiB/s) so the ordering is readable again; the property under test is unchanged.

The acceptance test itself was **not** touched.

## Not changed

`PolicyVersion` is deliberately not bumped. CLAUDE.md's rule is that it moves when a change makes an older stored *measurement* mean something different, not merely when it changes what the policy decides. This is the latter, and bumping it would invalidate every cached record for no reason.

The caveat travels with the constant, in the comment and in CLAUDE.md: one host, one 13 ms path, `shaping.available` false in all 15 stored results. A prior fitted to a single measured link beats one fitted to nothing and is not a general answer, which is an argument for getting a second link profile measured (#240) rather than against refitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)