### PR TITLE
ci: add pinned govulncheck scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Vulnerability scan
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+          govulncheck ./...
+
       - name: Test
         run: go test -race ./...
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eiserv/easySFTP
 
-go 1.25.5
+go 1.25.13
 
 require (
 	github.com/pkg/sftp v1.13.11


### PR DESCRIPTION
## What & why

Closes #147.

- Raise the Go patch baseline from 1.25.5 to 1.25.13.
- Run `govulncheck@v1.7.0` in the existing Linux and Windows unit-test matrix.

The exact Go 1.25.5 baseline scan exited 3 with reachable standard-library findings. The same pinned scanner on Go 1.25.13 exited 0 with no reachable vulnerabilities.

## Checklist

- [x] `go test ./...`, `go vet ./...` and `gofmt -l .` are clean
- [x] Behavior changes have a test (not applicable, CI-only change)
- [x] Docs updated where affected: `README.md`, `docs/`, `action.yml` input descriptions, `schema/easysftp.schema.json` (not applicable)
- [x] New external dependency in CI is pinned by full commit SHA / `@sha256:` digest (`govulncheck` is pinned to the exact Go module release `@v1.7.0` requested by #147)
- [x] `CHANGELOG.md` **not** hand-edited (release-please generates it)

## Notes for the reviewer

Validation: `govulncheck ./...`, `gofmt -l .`, `go mod tidy -diff`, `go vet ./...`, `go test ./...`, `go build ./cmd/easysftp`, YAML parsing and diff checks.

`go test -race ./...` could not start locally because this Windows environment has CGO disabled and no C compiler; the existing CI matrix will run it.

Not included: staticcheck, CodeQL, actionlint or golangci-lint.