### PR TITLE
fix(uploader): confine remote-supplied names to the deployment before deleting

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -82,13 +82,29 @@ update the secret with the new keys.
 ## The sync manifest in web roots
 
 The `sync` strategy keeps its manifest (default `.easysftp-manifest.json`)
-inside each deploy target. When the target is a public web root, the manifest
-is served like any other file and discloses the deployment's complete relative
-file list plus a SHA-256 hash of each file's content. That is information
-disclosure, not compromise, but it maps out paths that are not linked anywhere
-(admin bundles, backups, generated files) and lets anyone confirm exact file
-contents by hash. Being a dotfile is not protection: Apache's default `.ht*`
-rules do not cover it, and nginx setups vary.
+inside each deploy target. The file is both **read by anyone who can reach the
+target over HTTP** and **parsed by the next run**, so it matters twice.
+
+**Read.** When the target is a public web root, the manifest is served like any
+other file and discloses the deployment's complete relative file list plus a
+SHA-256 hash of each file's content. That is information disclosure, not
+compromise, but it maps out paths that are not linked anywhere (admin bundles,
+backups, generated files) and lets anyone confirm exact file contents by hash.
+Being a dotfile is not protection: Apache's default `.ht*` rules do not cover
+it, and nginx setups vary.
+
+**Parsed.** The next `sync` run reads the manifest and deletes every entry that
+is no longer present locally, so its keys are delete targets. Anything else
+able to write that one file (a CMS upload directory, a second workflow, a
+compromised script, a shared-hosting neighbour) would otherwise be choosing
+where the deploy account deletes. easySFTP confines them: a key that is
+absolute or climbs out of the deployment is ignored with a warning and nothing
+is removed for it, and the same confinement applies to the entry names a server
+returns from a directory listing during a `clean` scan or the stale-temp sweep.
+The manifest is also read under a size cap and an over-size one is treated as a
+first sync (upload everything, delete nothing). Write access to the manifest
+still lets someone suppress deletions or force re-uploads inside the
+deployment, so the guidance below is worth following either way.
 
 Pick one (or both):
 

--- a/internal/uploader/pathconfine_test.go
+++ b/internal/uploader/pathconfine_test.go
@@ -1,0 +1,190 @@
+package uploader
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// TestSafeJoinConfinesRemoteSuppliedPaths pins the helper every remote-derived
+// delete path goes through. The escaping cases are the ones that matter: they
+// are what a poisoned manifest key or a lying directory listing looks like.
+func TestSafeJoinConfinesRemoteSuppliedPaths(t *testing.T) {
+	const base = "/var/www/html"
+	ok := []struct{ rel, want string }{
+		{"index.html", "/var/www/html/index.html"},
+		{"assets/app.css", "/var/www/html/assets/app.css"},
+		{"a/../b.txt", "/var/www/html/b.txt"},
+		{"./nested/x", "/var/www/html/nested/x"},
+		{"..hidden", "/var/www/html/..hidden"},
+		{"dir/..b", "/var/www/html/dir/..b"},
+		// A backslash is an ordinary character in a POSIX file name and is
+		// not a separator here, so it must not be treated as an escape.
+		{`weird\..\name`, `/var/www/html/weird\..\name`},
+	}
+	for _, tc := range ok {
+		got, err := safeJoin(base, tc.rel)
+		if err != nil {
+			t.Errorf("safeJoin(%q, %q) returned error %v, want %q", base, tc.rel, err, tc.want)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("safeJoin(%q, %q) = %q, want %q", base, tc.rel, got, tc.want)
+		}
+	}
+
+	bad := []string{
+		"../etc/passwd",
+		"../../../../home/other/public_html/index.php",
+		"a/../../escape",
+		"/etc/nginx/nginx.conf",
+		"/",
+		"..",
+		".",
+		"",
+	}
+	for _, rel := range bad {
+		if got, err := safeJoin(base, rel); err == nil {
+			t.Errorf("safeJoin(%q, %q) = %q, want an error", base, rel, got)
+		}
+	}
+
+	// A relative base is resolved against the session's working directory; a
+	// climb out of it is just as much an escape.
+	if got, err := safeJoin("www", "../secrets"); err == nil {
+		t.Errorf(`safeJoin("www", "../secrets") = %q, want an error`, got)
+	}
+	if got, err := safeJoin("www", "a.txt"); err != nil || got != "www/a.txt" {
+		t.Errorf(`safeJoin("www", "a.txt") = %q, %v; want "www/a.txt", nil`, got, err)
+	}
+
+	// safeChild additionally refuses a separator: ReadDir returns names, so a
+	// server answering with a path is not describing its own directory.
+	if got, err := safeChild("/www", "sub/file.txt"); err == nil {
+		t.Errorf(`safeChild("/www", "sub/file.txt") = %q, want an error`, got)
+	}
+	if got, err := safeChild("/www", "file.txt"); err != nil || got != "/www/file.txt" {
+		t.Errorf(`safeChild("/www", "file.txt") = %q, %v; want "/www/file.txt", nil`, got, err)
+	}
+}
+
+// TestSyncIgnoresManifestEntriesOutsideTheDeployment is the end-to-end case
+// issue #223 describes: the manifest lives in the deploy target, so anything
+// able to write that one file could name a delete target anywhere the deploy
+// account can reach. The run must upload as normal and leave the named file
+// alone.
+func TestSyncIgnoresManifestEntriesOutsideTheDeployment(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "hello"})
+
+	seedRemoteFile(t, srv, "/home/other/public_html", "index.php", "victim")
+	seedRemoteFile(t, srv, "/www", manifestName, `{
+	  "version": 3,
+	  "files": {
+	    "gone.txt": {"hash": "abc", "size": 1, "mtime": 1},
+	    "../../home/other/public_html/index.php": {"hash": "def", "size": 1, "mtime": 1},
+	    "/etc/nginx/nginx.conf": {"hash": "ghi", "size": 1, "mtime": 1}
+	  }
+	}`)
+	seedRemoteFile(t, srv, "/www", "gone.txt", "stale")
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	stats, err := Run(context.Background(), syncConfig(srv, local), log)
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	if !remoteExists(t, srv, "/home/other/public_html/index.php") {
+		t.Fatal("a manifest key that climbs out of the deployment was followed and the file was deleted")
+	}
+	// The in-deployment entry is still handled normally: the guard must not
+	// turn a poisoned manifest into a manifest that does nothing.
+	if remoteExists(t, srv, "/www/gone.txt") {
+		t.Error("the legitimate manifest entry was not deleted")
+	}
+	if stats.FilesDeleted != 1 {
+		t.Errorf("FilesDeleted = %d, want 1 (only the in-deployment entry)", stats.FilesDeleted)
+	}
+	if !hasWarning(log, "point outside the deployment") {
+		t.Errorf("expected a warning naming the out-of-deployment entries, got %v", log.warnings)
+	}
+}
+
+// TestCleanIgnoresListingEntriesOutsideTheDirectory covers the same helper on
+// the other kind of remote-supplied name: what a server answers a directory
+// listing with during the clean-mode scan.
+func TestCleanIgnoresListingEntriesOutsideTheDirectory(t *testing.T) {
+	srv := startTestServer(t, withLyingList("/www", "sub/..", true))
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "new"})
+
+	seedRemoteFile(t, srv, "/", "victim.txt", "do not delete me")
+	seedRemoteFile(t, srv, "/www", "old.txt", "old")
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategyClean}}
+	log := &recordingLogger{testLogger: testLogger{t}}
+
+	if _, err := Run(context.Background(), cfg, log); err != nil {
+		t.Fatalf("clean deploy failed: %v", err)
+	}
+
+	if !remoteExists(t, srv, "/victim.txt") {
+		t.Fatal("the clean scan followed a listing entry that pointed out of the directory it listed")
+	}
+	if remoteExists(t, srv, "/www/old.txt") {
+		t.Error("clean did not remove the real remote file")
+	}
+	if !hasWarning(log, "skipping remote entry while scanning") {
+		t.Errorf("expected a warning about the skipped entry, got %v", log.warnings)
+	}
+}
+
+// TestReadManifestRefusesOversizeManifest: the manifest is a remote file, so
+// its size is not this run's to trust. Over the cap it degrades to a first
+// sync, exactly like an unreadable one.
+func TestReadManifestRefusesOversizeManifest(t *testing.T) {
+	srv := startTestServer(t)
+	prev := maxManifestBytes
+	maxManifestBytes = 512
+	t.Cleanup(func() { maxManifestBytes = prev })
+
+	var b strings.Builder
+	b.WriteString(`{"version":3,"files":{`)
+	for i := 0; i < 50; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `"file%02d.txt":{"hash":"h","size":1,"mtime":1}`, i)
+	}
+	b.WriteString(`}}`)
+	seedRemoteFile(t, srv, "/www", manifestName, b.String())
+
+	log := &recordingLogger{testLogger: testLogger{t}}
+	got, err := readManifest(srv.verifyClient(t), "/www", manifestName, log)
+	if err != nil {
+		t.Fatalf("readManifest returned error %v, want nil", err)
+	}
+	if len(got.Files) != 0 {
+		t.Fatalf("readManifest returned %d entries from an over-size manifest, want 0", len(got.Files))
+	}
+	if !hasWarning(log, "is larger than") {
+		t.Errorf("expected an over-size warning, got %v", log.warnings)
+	}
+}
+
+// hasWarning reports whether the logger recorded a warning containing sub.
+func hasWarning(log *recordingLogger, sub string) bool {
+	log.mu.Lock()
+	defer log.mu.Unlock()
+	for _, w := range log.warnings {
+		if strings.Contains(w, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -206,7 +206,7 @@ func checkMaxDeletes(n int, cfg *config.Config) error {
 // The worker count is asked for per level rather than fixed for the scan: with
 // advanced.concurrency at auto it is the width of the level being listed, and a
 // tree whose levels are one directory wide never opens a worker it cannot use.
-func listRemoteContents(ctx context.Context, sess *session, root string, watch *stallWatchdog) (files, dirs []string, err error) {
+func listRemoteContents(ctx context.Context, sess *session, root string, watch *stallWatchdog, log Logger) (files, dirs []string, err error) {
 	level := []string{root}
 	for len(level) > 0 {
 		entries := make([][]fs.FileInfo, len(level))
@@ -250,7 +250,15 @@ func listRemoteContents(ctx context.Context, sess *session, root string, watch *
 		var next []string
 		for i, dir := range level {
 			for _, entry := range entries[i] {
-				full := path.Join(dir, entry.Name())
+				// The name comes from the server. Everything collected here
+				// is deleted a moment later, so an entry that does not name
+				// something inside the directory it was listed from is
+				// dropped rather than followed; see safeJoin and issue #223.
+				full, err := safeChild(dir, entry.Name())
+				if err != nil {
+					log.Warningf("skipping remote entry while scanning %s: %v", dir, err)
+					continue
+				}
 				if entry.IsDir() {
 					dirs = append(dirs, full)
 					next = append(next, full)
@@ -279,4 +287,69 @@ func parentDirs(remotePath string) []string {
 	}
 	sort.Strings(dirs)
 	return dirs
+}
+
+// safeJoin joins a remote-supplied relative path onto base and refuses
+// anything whose result would not stay strictly under it.
+//
+// path.Join cleans, it does not confine: path.Join("/var/www", "../../etc")
+// is "/etc". Three inputs reach this package from the server rather than from
+// the configuration, and all three end up as arguments to Remove or
+// RemoveDirectory: the keys of the sync manifest (a file that lives in the
+// deploy target, so anything else able to write there can choose them), and
+// the entry names a server returns from ReadDir during the clean-mode scan and
+// the stale-temp sweep. Whoever controls one of those should not thereby
+// control where this run deletes; see issue #223.
+//
+// The three are not equally exposed. The manifest is the one an attacker needs
+// no server access for, and its keys arrive exactly as written. Listing names
+// pass through pkg/sftp's client first, which drops a literal "." or ".." and
+// reduces everything else to its last component, so the only escape left on
+// that path is a name whose base climbs ("sub/.." arrives as ".."). That is
+// still an escape, and the guard is the same one, so both go through it.
+//
+// Rejecting a leading ".." after path.Clean is enough on its own (Clean
+// resolves every interior "..", so a cleaned relative path that does not start
+// with ".." cannot escape), but the containment check is kept as the property
+// the caller actually cares about, stated where a reader can see it.
+func safeJoin(base, rel string) (string, error) {
+	if rel == "" || rel == "." {
+		return "", fmt.Errorf("refusing remote-supplied path %q: it names no file under %q", rel, base)
+	}
+	if strings.HasPrefix(rel, "/") {
+		return "", fmt.Errorf("refusing remote-supplied path %q: it is absolute, not relative to %q", rel, base)
+	}
+	cleaned := path.Clean(rel)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("refusing remote-supplied path %q: it resolves to %q, outside %q", rel, path.Join(base, cleaned), base)
+	}
+	full := path.Join(base, cleaned)
+	if !within(base, full) {
+		return "", fmt.Errorf("refusing remote-supplied path %q: it resolves to %q, outside %q", rel, full, base)
+	}
+	return full, nil
+}
+
+// safeChild is safeJoin for a single entry name from a directory listing,
+// where a path separator is already wrong: ReadDir returns names, not paths,
+// so a server that answers with one is not describing its own directory.
+func safeChild(dir, name string) (string, error) {
+	if strings.Contains(name, "/") {
+		return "", fmt.Errorf("refusing remote-supplied directory entry %q in %q: an entry name cannot contain %q", name, dir, "/")
+	}
+	return safeJoin(dir, name)
+}
+
+// within reports whether full is strictly below base, both as slash paths.
+func within(base, full string) bool {
+	b := path.Clean(base)
+	if b == "." {
+		// A relative base resolved against the session's working directory.
+		// Everything that is itself relative and does not climb is under it.
+		return !strings.HasPrefix(full, "/") && full != ".." && !strings.HasPrefix(full, "../")
+	}
+	if full == b {
+		return false
+	}
+	return strings.HasPrefix(full, strings.TrimSuffix(b, "/")+"/")
 }

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -24,6 +24,19 @@ import (
 // and v2 (mtime in whole seconds); see readManifest.
 const manifestVersion = 3
 
+// maxManifestBytes caps what readManifest will pull into memory. The manifest
+// is a remote file, so its size is not this run's to trust: without a cap, a
+// server (or anything that can write the deploy target) turns a sync into an
+// unbounded allocation. At roughly 120 bytes per entry this still admits about
+// half a million files, far past any plausible deployment, and an over-size
+// manifest degrades to a first sync exactly like an unreadable one. See
+// issue #223.
+//
+// A var rather than a const only so the size test can lower it instead of
+// seeding 64 MiB through the in-process server; no test in this package runs
+// in parallel.
+var maxManifestBytes int64 = 64 << 20
+
 // manifestEntry records what is known about one file from the last sync.
 // Size and MTime enable the size+mtime fast path in hashPlanFiles: an entry
 // with MTime 0 never matches and always falls back to a full re-hash.
@@ -99,9 +112,20 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 
 	var toDelete []string // paths relative to base, ascending
 	for rel := range old.Files {
-		if _, ok := local[rel]; !ok {
-			toDelete = append(toDelete, rel)
+		if _, ok := local[rel]; ok {
+			continue
 		}
+		// The manifest lives in the deploy target, so its keys are data the
+		// server (or anything else that can write that one file) supplies,
+		// and every key that survives here becomes an argument to Remove.
+		// readManifest already drops keys that would leave the deployment;
+		// this re-checks at the point the key becomes a delete target, which
+		// is where the property is worth stating. See safeJoin and issue #223.
+		if _, err := safeJoin(base, rel); err != nil {
+			log.Warningf("ignoring sync manifest entry in %s: %v", base, err)
+			continue
+		}
+		toDelete = append(toDelete, rel)
 	}
 	sort.Strings(toDelete)
 
@@ -141,7 +165,8 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 
 	deletePaths := make([]string, len(toDelete))
 	for i, rel := range toDelete {
-		deletePaths[i] = path.Join(base, rel)
+		// Cannot fail: every entry of toDelete passed safeJoin above.
+		deletePaths[i], _ = safeJoin(base, rel)
 	}
 	endSweep := metrics.Phase("delete_sweep")
 	deleteResults, deleteErr := deleteRemoteFiles(ctx, cfg, sess, deletePaths, watch, log)
@@ -165,7 +190,8 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 
 	deletedFull := make([]string, len(deleted))
 	for i, rel := range deleted {
-		deletedFull[i] = path.Join(base, rel)
+		// deleted is a subset of toDelete, so this cannot fail either.
+		deletedFull[i], _ = safeJoin(base, rel)
 	}
 	pruneEmptyDirs(ctx, cfg, sess, watch, base, deletedFull)
 	endWrite := metrics.Phase("manifest_write")
@@ -270,12 +296,16 @@ func readManifest(client *sftp.Client, dir, name string, log Logger) (manifest, 
 	}
 	defer f.Close()
 
-	data, err := io.ReadAll(f)
+	data, err := io.ReadAll(io.LimitReader(f, maxManifestBytes+1))
 	if err != nil {
 		if isConnError(err) {
 			return empty, err
 		}
 		log.Warningf("could not read sync manifest in %s (%v); treating as first sync", dir, err)
+		return empty, nil
+	}
+	if int64(len(data)) > maxManifestBytes {
+		log.Warningf("sync manifest in %s is larger than %s; treating as first sync (nothing will be deleted this run)", dir, HumanSize(maxManifestBytes))
 		return empty, nil
 	}
 
@@ -291,7 +321,7 @@ func readManifest(client *sftp.Client, dir, name string, log Logger) (manifest, 
 				m.Files[rel] = e
 			}
 		}
-		return m, nil
+		return confineManifest(m, dir, log), nil
 	}
 
 	var v1 struct {
@@ -303,11 +333,36 @@ func readManifest(client *sftp.Client, dir, name string, log Logger) (manifest, 
 		for rel, hash := range v1.Files {
 			files[rel] = manifestEntry{Hash: hash}
 		}
-		return manifest{Version: v1.Version, Files: files}, nil
+		return confineManifest(manifest{Version: v1.Version, Files: files}, dir, log), nil
 	}
 
 	log.Warningf("sync manifest in %s is unreadable; treating as first sync", dir)
 	return empty, nil
+}
+
+// confineManifest drops every entry whose key would not stay under dir. The
+// keys easySFTP writes are always plain relative slash paths, so a key that is
+// absolute or climbs out was not written by a run of this action; deleting
+// what it points at would hand whoever put it there the deploy account's whole
+// reach. Dropping is the right degradation: the file it named is simply not
+// deleted, and the next successful sync rewrites the manifest from the local
+// tree without it. See issue #223.
+func confineManifest(m manifest, dir string, log Logger) manifest {
+	var dropped []string
+	for rel := range m.Files {
+		if _, err := safeJoin(dir, rel); err != nil {
+			dropped = append(dropped, rel)
+		}
+	}
+	if len(dropped) == 0 {
+		return m
+	}
+	sort.Strings(dropped)
+	for _, rel := range dropped {
+		delete(m.Files, rel)
+	}
+	log.Warningf("sync manifest in %s has %d entry/entries that point outside the deployment (first: %q); ignoring them", dir, len(dropped), dropped[0])
+	return m
 }
 
 // writeManifest atomically writes the manifest into dir under name.

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -948,3 +948,94 @@ func (l *recordingLogger) Warningf(format string, args ...any) {
 	defer l.mu.Unlock()
 	l.warnings = append(l.warnings, fmt.Sprintf(format, args...))
 }
+
+// lyingList adds one synthetic entry, once, to the listing of one exact
+// directory, so a test can play a server that answers a listing with a name
+// that points out of the directory it listed. No real server does this; the
+// point is that easySFTP must not join it into a delete path (issue #223).
+//
+// The name to inject is ".." rather than "../victim.txt", because pkg/sftp's
+// client reduces every listed name to its last component (path.Base, see
+// client.go's ReadDir) and drops the two entries a server sends literally
+// ("." and ".."). What survives that is a name whose *base* climbs, e.g.
+// "sub/..", which reaches the caller as "..". That is the whole remaining
+// escape on this path, and it is enough: joined onto the target it is the
+// target's parent, which the clean scan would then walk and empty.
+//
+// Injecting only once keeps an unfixed run terminating: the parent's listing
+// contains the target again, so a permanent injection would loop forever
+// instead of failing.
+type lyingList struct {
+	inner sftp.FileLister
+	dir   string
+	name  string
+	isDir bool
+	once  sync.Once
+}
+
+func (l *lyingList) Filelist(r *sftp.Request) (sftp.ListerAt, error) {
+	lister, err := l.inner.Filelist(r)
+	if err != nil || r.Method != "List" || r.Filepath != l.dir {
+		return lister, err
+	}
+	injected := false
+	l.once.Do(func() { injected = true })
+	if !injected {
+		return lister, nil
+	}
+	return sliceLister(append(drainLister(lister), fakeFileInfo{name: l.name, dir: l.isDir})), nil
+}
+
+func withLyingList(dir, name string, isDir bool) serverOption {
+	return func(s *testServer) {
+		s.handlers.FileList = &lyingList{inner: s.handlers.FileList, dir: dir, name: name, isDir: isDir}
+	}
+}
+
+// drainLister reads a ListerAt fully into a slice.
+func drainLister(l sftp.ListerAt) []os.FileInfo {
+	var all []os.FileInfo
+	buf := make([]os.FileInfo, 16)
+	for off := int64(0); ; {
+		n, err := l.ListAt(buf, off)
+		all = append(all, buf[:n]...)
+		off += int64(n)
+		if err != nil {
+			return all
+		}
+	}
+}
+
+// sliceLister serves a fixed slice of entries as a sftp.ListerAt.
+type sliceLister []os.FileInfo
+
+func (l sliceLister) ListAt(f []os.FileInfo, off int64) (int, error) {
+	if off >= int64(len(l)) {
+		return 0, io.EOF
+	}
+	n := copy(f, l[off:])
+	if off+int64(n) >= int64(len(l)) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// fakeFileInfo is a minimal os.FileInfo for an entry the server invents. Its
+// ModTime is the epoch, so the stale-temp sweep considers it old enough to
+// remove and the name is the only thing standing between it and a Remove.
+type fakeFileInfo struct {
+	name string
+	dir  bool
+}
+
+func (f fakeFileInfo) Name() string { return f.name }
+func (f fakeFileInfo) Size() int64  { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode {
+	if f.dir {
+		return os.ModeDir | 0o755
+	}
+	return 0o644
+}
+func (f fakeFileInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (f fakeFileInfo) IsDir() bool        { return f.dir }
+func (f fakeFileInfo) Sys() any           { return nil }

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -550,12 +550,18 @@ func sweepDirStaleTemps(client *sftp.Client, dir string, keep map[string]struct{
 		if time.Since(e.ModTime()) < staleTempMaxAge {
 			continue
 		}
-		full := path.Join(dir, e.Name())
+		// Names come from the server; a temp-looking one that points out of
+		// the directory it was listed from is not swept (issue #223).
+		full, err := safeChild(dir, e.Name())
+		if err != nil {
+			log.Warningf("skipping remote entry while sweeping %s: %v", dir, err)
+			continue
+		}
 		if _, ok := keep[full]; ok {
 			continue
 		}
 		done := metrics.Op("sftp_remove")
-		err := client.Remove(full)
+		err = client.Remove(full)
 		done(err)
 		if err != nil {
 			if isConnError(err) {

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -236,7 +236,7 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 		}
 		var files, dirs []string
 		endRemoteScan := metrics.Phase("remote_scan")
-		files, dirs, err := listRemoteContents(ctx, sess, base, watch)
+		files, dirs, err := listRemoteContents(ctx, sess, base, watch, log)
 		endRemoteScan()
 		if err != nil {
 			return fmt.Errorf("scanning remote directory %q: %w", p.pair.Remote, err)


### PR DESCRIPTION
Closes #223.

## The problem

Three code paths joined a string that came from the remote server into a path that is then deleted, with nothing checking that the result stays inside the deployment target:

- `internal/uploader/sync.go` — sync manifest keys become delete paths
- `internal/uploader/remote.go` — `ReadDir` entry names during the clean-mode scan
- `internal/uploader/transfer.go` — the same names in the stale-temp sweep

`path.Join` cleans, it does not confine: `path.Join("/var/www", "../../etc/nginx/nginx.conf")` is `/etc/nginx/nginx.conf`.

The manifest is the one that needs no server compromise at all. It lives in the deploy target, which for a web-root deploy is writable by anything else that can write there (a CMS upload directory, a second workflow, a compromised script, a shared-hosting neighbour). A key of `../../../../home/otherhost/public_html/index.php` was deleted on the next `mode: sync` run, turning write access to one file into delete access over everything the deploy account can reach.

## What this changes

- **One helper, three call sites.** `safeJoin(base, rel)` refuses anything absolute or climbing, and confirms the result is strictly under `base`. `safeChild(dir, name)` adds the rule that a listing entry is a name, not a path.
- **Sanitised at the parse point too.** `readManifest` drops out-of-deployment keys with a warning, so no downstream code can ever see one. The join sites re-check anyway; the property is worth stating where the path becomes a delete target.
- **Degradation, not failure.** A poisoned entry is skipped with a warning and the rest of the run proceeds normally. A bad manifest must not be able to abort a deploy either.
- **Manifest size cap.** `io.LimitReader` at 64 MiB (~500k entries). Over it, the run degrades to a first sync, exactly as an unreadable manifest already did.
- **`docs/security.md`** framed the manifest as information disclosure. It is also a parsed input that drives deletions; the section now says both.

## On the listing paths

Worth recording, because it changes how the tests are written: `pkg/sftp`'s client already reduces every listed name to its last component (`path.Base` in `ReadDir`) and drops a literal `.` or `..`. So the escape that survives on that path is a name whose *base* climbs — `sub/..` reaches the caller as `..`, which joined onto `/www` is `/`, and the clean scan would then walk and empty the parent. The new `withLyingList` server option injects exactly that, once (a permanent injection loops forever on an unfixed run instead of failing).

## Tests

- `TestSafeJoinConfinesRemoteSuppliedPaths` — the helper, including the cases that must keep working: `a/../b.txt`, `..hidden`, and a backslash, which is an ordinary character in a POSIX file name and not a separator here.
- `TestSyncIgnoresManifestEntriesOutsideTheDeployment` — end to end with a poisoned manifest; the named file survives, the legitimate entry is still deleted.
- `TestCleanIgnoresListingEntriesOutsideTheDirectory` — the lying server.
- `TestReadManifestRefusesOversizeManifest`.

Both end-to-end tests were confirmed to fail without the guard (deletes 2 instead of 1, and 3 instead of 2, with the out-of-scope file gone).

`go test ./...` passes. `-race` needs cgo and was not available on this machine; CI runs that pass.

## Not in scope

Issue #223 also asks whether `safety.max_deletes` should default to something finite. That is a product decision and is tracked with the rest of the `max_deletes` gaps in #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)