### PR TITLE
fix(uploader): make safety.max_deletes count directories and cover the run

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Inline mode uses a small, self-explanatory set of inputs:
 | `dry-run` | `false` | Log what would happen, change nothing. |
 | `log-level` | `normal` | `normal`, `verbose` (per-file lines) or `debug` (exclude decisions). |
 
-Outputs: `files-uploaded`, `files-deleted`, `files-skipped`, `bytes-uploaded`,
-`duration-ms`, plus a summary table in the job summary. If a transfer fails
+Outputs: `files-uploaded`, `files-deleted`, `dirs-deleted`, `files-skipped`,
+`bytes-uploaded`, `duration-ms`, plus a summary table in the job summary. If a transfer fails
 partway, the outputs contain the progress completed before the failure and the
 summary is marked as failed.
 
@@ -149,8 +149,8 @@ summary is marked as failed.
 `sync` is manifest-based: it only ever deletes files it uploaded itself, skips
 unchanged files by content hash, and only transfers what changed on re-deploys.
 Destructive modes are protected by [delete guards](docs/strategies.md#delete-guards):
-the remote root is always refused, and `max_deletes` caps how much a single run
-may delete. Preview anything with `dry-run: true`.
+the remote root is always refused, and `max_deletes` caps how many remote
+entries (files and directories) the whole run may delete. Preview anything with `dry-run: true`.
 
 ➡ Details, manifest semantics and guard rules: [docs/strategies.md](docs/strategies.md)
 

--- a/action.yml
+++ b/action.yml
@@ -241,6 +241,12 @@ outputs:
   files-deleted:
     description: Number of remote files deleted by the clean/sync mode.
     value: ${{ steps.easysftp.outputs.files-deleted }}
+  dirs-deleted:
+    description: >-
+      Number of remote directories removed by the clean mode's sweep or the
+      sync mode's prune. Counted against safety.max_deletes together with
+      files-deleted.
+    value: ${{ steps.easysftp.outputs.dirs-deleted }}
   files-skipped:
     description: >-
       Number of unchanged files skipped (by the sync mode, or by overlay

--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -66,6 +66,7 @@ func run() error {
 	stats, runErr := uploader.Run(ctx, cfg, ghaLogger{})
 	metrics.Set("files_uploaded", int64(stats.FilesUploaded))
 	metrics.Set("files_deleted", int64(stats.FilesDeleted))
+	metrics.Set("dirs_deleted", int64(stats.DirsDeleted))
 	metrics.Set("files_skipped", int64(stats.FilesSkipped))
 	metrics.Set("bytes_uploaded", stats.BytesUploaded)
 	if runErr != nil {
@@ -76,8 +77,8 @@ func run() error {
 		mode = "would upload (dry-run)"
 	}
 	if runErr == nil {
-		gha.Infof("done: %s %d file(s), %s, deleted %d file(s), skipped %d unchanged, took %s",
-			mode, stats.FilesUploaded, humanBytes(stats.BytesUploaded), stats.FilesDeleted, stats.FilesSkipped, stats.Duration.Round(time.Millisecond))
+		gha.Infof("done: %s %d file(s), %s, deleted %d file(s) and %d director(y/ies), skipped %d unchanged, took %s",
+			mode, stats.FilesUploaded, humanBytes(stats.BytesUploaded), stats.FilesDeleted, stats.DirsDeleted, stats.FilesSkipped, stats.Duration.Round(time.Millisecond))
 	}
 
 	reportStats(cfg, stats, mode, runErr)
@@ -169,6 +170,7 @@ func reportStats(cfg *config.Config, stats *uploader.Stats, mode string, runErr 
 
 	gha.SetOutput("files-uploaded", fmt.Sprintf("%d", stats.FilesUploaded))
 	gha.SetOutput("files-deleted", fmt.Sprintf("%d", stats.FilesDeleted))
+	gha.SetOutput("dirs-deleted", fmt.Sprintf("%d", stats.DirsDeleted))
 	gha.SetOutput("files-skipped", fmt.Sprintf("%d", stats.FilesSkipped))
 	gha.SetOutput("bytes-uploaded", fmt.Sprintf("%d", stats.BytesUploaded))
 	gha.SetOutput("duration-ms", fmt.Sprintf("%d", stats.Duration.Milliseconds()))
@@ -178,8 +180,8 @@ func reportStats(cfg *config.Config, stats *uploader.Stats, mode string, runErr 
 		configSource = fmt.Sprintf("`%s` (version 3)", cfg.ConfigPath)
 	}
 	summary := fmt.Sprintf(
-		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Host key | %s |\n| Configuration | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %s |\n| Duration | %s |\n",
-		status, hostKeyStatus(cfg), configSource, mode, stats.FilesUploaded, stats.FilesDeleted, stats.FilesSkipped, humanBytes(stats.BytesUploaded), stats.Duration.Round(time.Millisecond))
+		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Host key | %s |\n| Configuration | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Directories removed | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %s |\n| Duration | %s |\n",
+		status, hostKeyStatus(cfg), configSource, mode, stats.FilesUploaded, stats.FilesDeleted, stats.DirsDeleted, stats.FilesSkipped, humanBytes(stats.BytesUploaded), stats.Duration.Round(time.Millisecond))
 	summary += deploymentBreakdown(stats.Deployments)
 	gha.AppendSummary(summary)
 }

--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -121,6 +121,7 @@ func TestReportStatsOnFailure(t *testing.T) {
 	stats := &uploader.Stats{
 		FilesUploaded: 3,
 		FilesDeleted:  1,
+		DirsDeleted:   2,
 		FilesSkipped:  4,
 		BytesUploaded: 2048,
 		Duration:      1500 * time.Millisecond,
@@ -136,6 +137,7 @@ func TestReportStatsOnFailure(t *testing.T) {
 	for name, want := range map[string]string{
 		"files-uploaded": "3",
 		"files-deleted":  "1",
+		"dirs-deleted":   "2",
 		"files-skipped":  "4",
 		"bytes-uploaded": "2048",
 		"duration-ms":    "1500",
@@ -155,6 +157,7 @@ func TestReportStatsOnFailure(t *testing.T) {
 		"| Configuration | inline inputs |",
 		"| Files uploaded | 3 |",
 		"| Files deleted | 1 |",
+		"| Directories removed | 2 |",
 		"| Files skipped (unchanged) | 4 |",
 		"| Bytes transferred | 2.0 KiB (2,048 bytes) |",
 	} {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,7 +156,7 @@ deployments:                   # at least one named deployment
     mode: clean
 
 safety:
-  max_deletes: 500             # 0 = unlimited
+  max_deletes: 500             # files + directories, whole run; 0 = unlimited
 
 advanced:
   retries: 2
@@ -186,7 +186,7 @@ sync:
 | `connection` | ✅ | Where and as whom to connect. Credentials are **not** here; they stay inputs. |
 | `defaults` | | `mode` and `exclude` defaults applied to every deployment. |
 | `deployments` | ✅ | A **map** of named deployments (at least one). The name appears in logs and the job summary. |
-| `safety` | | `max_deletes` (0 = unlimited); see [delete guards](strategies.md#delete-guards). |
+| `safety` | | `max_deletes`: the most remote entries, **files and directories together**, the **whole run** may remove (0 = unlimited, the default); see [delete guards](strategies.md#delete-guards). |
 | `advanced` | | Transfer tuning; the defaults suit most deploys. |
 | `permissions` | | Remote file/dir modes and `preserve_times` (all best-effort). |
 | `sync` | | The sync mode's manifest name and fast-path. |
@@ -393,6 +393,7 @@ exclude: |
 |---|---|
 | `files-uploaded` | Number of uploaded files (planned files in dry-run mode). |
 | `files-deleted` | Number of remote files removed by the `clean`/`sync` mode. |
+| `dirs-deleted` | Number of remote directories removed by the `clean` mode's sweep or the `sync` mode's prune. Counted against `safety.max_deletes` together with `files-deleted`. |
 | `files-skipped` | Number of unchanged files skipped (by `sync`, or by `overlay` with `advanced.skip_unchanged`). |
 | `bytes-uploaded` | Total bytes transferred (planned bytes in dry-run mode). |
 | `duration-ms` | Total runtime in milliseconds. |

--- a/docs/easysftp.example.yml
+++ b/docs/easysftp.example.yml
@@ -63,7 +63,8 @@ deployments:
     # single files only support the overlay mode
 
 safety:
-  # Abort if a run would delete more than this many files (0 = unlimited).
+  # Abort if the whole run would remove more than this many remote entries,
+  # files and directories together (0 = unlimited, the default).
   # Deleting the remote root ("/") is always refused, independent of this.
   max_deletes: 200
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -164,9 +164,26 @@ Two safety nets apply before `sync` or `clean` delete anything:
   the expression is empty or has a component too many. No mode will ever wipe
   a server root or a login directory. A relative target that stays put, like
   `www/public_html`, is unaffected.
-- **`max_deletes`** aborts a run that would delete more files than the limit,
-  catching a misconfiguration before it does damage. `0` means unlimited. Set
-  it via `safety.max_deletes` in the [config file](configuration.md#sections).
+- **`max_deletes`** aborts a run that would remove more remote entries than
+  the limit, catching a misconfiguration before it does damage. `0` means
+  unlimited, and is the default. Set it via `safety.max_deletes` in the
+  [config file](configuration.md#sections).
+
+  Three details, because they are easy to guess wrong:
+
+  - **It counts directories too**, not just files. A `clean` run against a
+    tree of 10,000 empty directories is 10,000 removals as far as the guard is
+    concerned. The run reports the two apart, as the `files-deleted` and
+    `dirs-deleted` outputs, but they share one budget.
+  - **It is for the whole run**, not per deployment. A config file with eight
+    deployments and `max_deletes: 100` allows 100 removals in total, and the
+    deployment that would take the run past the limit is the one that is
+    refused.
+  - **A run that would go over is refused before it removes anything.** The
+    one exception is the `sync` mode's pruning of directories it has just
+    emptied: those are only known after the deletions they follow, so an
+    exhausted budget stops the pruning instead of failing a run whose real
+    work already succeeded.
 
 ## Dry runs
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -260,11 +260,17 @@ empty, and so does a path whose last component was stripped by a shell.
 This guard cannot be disabled; see
 [delete guards](strategies.md#delete-guards).
 
-### `refusing to delete N files: exceeds safety.max_deletes`
+### `refusing to delete N remote entries: exceeds safety.max_deletes`
 
-Your run would delete more files than `safety.max_deletes` allows. Inspect the
-plan with `dry-run: true`; if the deletions are intended, raise (or remove)
-the limit in the config file.
+Your run would remove more remote entries than `safety.max_deletes` allows.
+Inspect the plan with `dry-run: true`; if the deletions are intended, raise
+(or remove) the limit in the config file.
+
+Two things count towards the limit that its name does not spell out:
+**directories** as well as files, and **every deployment of the run**, not
+each one on its own. A variant of the message that says "N more remote
+entries: M were already deleted earlier in this run" is the second case: an
+earlier deployment used part of the budget.
 
 ## Configuration errors
 

--- a/internal/uploader/delete.go
+++ b/internal/uploader/delete.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/pkg/sftp"
 
@@ -81,11 +82,24 @@ func countDeleted(deleted []bool) int {
 // removeRemoteDirs removes independent directories at the same depth in
 // parallel, while keeping the real child-before-parent dependency between
 // depths. Directory removal is best effort, matching the previous behavior:
-// a non-empty or unreadable directory is left in place.
-func removeRemoteDirs(ctx context.Context, cfg *config.Config, sess *session, watch *stallWatchdog, dirs []string) {
-	if cfg.DryRun || len(dirs) == 0 {
-		return
+// a non-empty or unreadable directory is left in place. It returns how many
+// directories it actually removed, which is what the run reports as
+// dirs-deleted.
+//
+// budget is non-nil only where the count could not be reserved in advance
+// (the sync mode's prune of directories it just emptied): removals are then
+// charged one at a time and pruning stops once the budget is spent. The clean
+// mode reserves its whole listing up front and passes nil; see deleteBudget
+// and issue #237.
+func removeRemoteDirs(ctx context.Context, cfg *config.Config, sess *session, watch *stallWatchdog, dirs []string, budget *deleteBudget) int {
+	if len(dirs) == 0 {
+		return 0
 	}
+	if cfg.DryRun {
+		// The planned count, like every other dry-run number.
+		return len(dirs)
+	}
+	var removed atomic.Int64
 	byDepth := make(map[int][]string)
 	var depths []int
 	for _, dir := range dirs {
@@ -100,14 +114,24 @@ func removeRemoteDirs(ctx context.Context, cfg *config.Config, sess *session, wa
 		level := byDepth[depth]
 		_ = runBounded(ctx, sess.workers(len(level)), len(level), func(groupCtx context.Context, i int) error {
 			dir := level[i]
-			_ = sess.do(groupCtx, watch, func(client *sftp.Client) error {
+			if budget != nil && !budget.take() {
+				return nil
+			}
+			err := sess.do(groupCtx, watch, func(client *sftp.Client) error {
 				done := metrics.Op("sftp_rmdir")
 				err := client.RemoveDirectory(dir)
 				done(err)
 				watch.tick()
 				return err
 			})
+			switch {
+			case err == nil:
+				removed.Add(1)
+			case budget != nil:
+				budget.refund()
+			}
 			return nil
 		})
 	}
+	return int(removed.Load())
 }

--- a/internal/uploader/maxdeletes_test.go
+++ b/internal/uploader/maxdeletes_test.go
@@ -1,0 +1,132 @@
+package uploader
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+// TestMaxDeletesCountsDirectories: safety.max_deletes used to be handed only
+// the file count, so a clean run against a tree of empty directories walked
+// straight past the limit (issue #237).
+func TestMaxDeletesCountsDirectories(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "new"})
+
+	// One file and four directories on the server: five removals in total.
+	seedRemoteFile(t, srv, "/www", "old.txt", "old")
+	for _, dir := range []string{"/www/a", "/www/b", "/www/c", "/www/d"} {
+		if err := srv.verifyClient(t).MkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategyClean}}
+	cfg.Safety.MaxDeletes = 3
+
+	_, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "safety.max_deletes") {
+		t.Fatalf("expected the guard to refuse 5 removals against a limit of 3, got %v", err)
+	}
+	// Refused before it removed anything, which is what "guard" has to mean.
+	if !remoteExists(t, srv, "/www/old.txt") || !remoteExists(t, srv, "/www/a") {
+		t.Error("the run removed entries before refusing")
+	}
+}
+
+// TestMaxDeletesReportsDirectoriesRemoved is the reporting half of the same
+// issue: directory removals were absent from the run's statistics, so the job
+// summary and the outputs under-reported what the run did.
+func TestMaxDeletesReportsDirectoriesRemoved(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "new"})
+
+	seedRemoteFile(t, srv, "/www", "old.txt", "old")
+	seedRemoteFile(t, srv, "/www/gone", "stale.txt", "stale")
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www", Strategy: config.StrategyClean}}
+
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesDeleted != 2 {
+		t.Errorf("FilesDeleted = %d, want 2", stats.FilesDeleted)
+	}
+	if stats.DirsDeleted != 1 {
+		t.Errorf("DirsDeleted = %d, want 1 (/www/gone)", stats.DirsDeleted)
+	}
+}
+
+// TestMaxDeletesIsRunWide: the check used to sit inside the per-deployment
+// execute functions, so a config file with N deployments allowed N times the
+// limit. The key lives under a run-wide safety: section.
+func TestMaxDeletesIsRunWide(t *testing.T) {
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "new"})
+
+	seedRemoteFile(t, srv, "/one", "a.txt", "a")
+	seedRemoteFile(t, srv, "/one", "b.txt", "b")
+	seedRemoteFile(t, srv, "/two", "c.txt", "c")
+	seedRemoteFile(t, srv, "/two", "d.txt", "d")
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{
+		{Name: "one", Local: local, Remote: "/one", Strategy: config.StrategyClean},
+		{Name: "two", Local: local, Remote: "/two", Strategy: config.StrategyClean},
+	}
+	// Each deployment deletes two files: within the limit on its own, over it
+	// for the run.
+	cfg.Safety.MaxDeletes = 3
+
+	_, err := Run(context.Background(), cfg, testLogger{t})
+	if err == nil || !strings.Contains(err.Error(), "safety.max_deletes") {
+		t.Fatalf("expected the second deployment to exhaust the run-wide budget, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "already deleted earlier in this run") {
+		t.Errorf("the error should say the budget was already partly spent, got %q", err)
+	}
+	// The first deployment ran; the second was refused before deleting.
+	if remoteExists(t, srv, "/one/a.txt") {
+		t.Error("the first deployment did not run")
+	}
+	if !remoteExists(t, srv, "/two/c.txt") {
+		t.Error("the second deployment deleted before the guard refused it")
+	}
+}
+
+// TestDeleteBudgetUnlimitedByDefault pins the documented default: 0 is
+// unlimited, and that is still what a config that says nothing gets.
+func TestDeleteBudgetUnlimitedByDefault(t *testing.T) {
+	b := newDeleteBudget(&config.Config{})
+	if err := b.reserve(1_000_000); err != nil {
+		t.Fatalf("an unset limit must not refuse anything, got %v", err)
+	}
+	if !b.take() {
+		t.Fatal("an unset limit must not run out")
+	}
+}
+
+// TestDeleteBudgetTakeAndRefund covers the sync prune's accounting: a
+// directory that could not be removed must not spend budget, or a prune over a
+// deep tree would stop far short of the limit the user set.
+func TestDeleteBudgetTakeAndRefund(t *testing.T) {
+	b := newDeleteBudget(&config.Config{Safety: config.Safety{MaxDeletes: 2}})
+	if !b.take() {
+		t.Fatal("first take must succeed")
+	}
+	b.refund()
+	if !b.take() || !b.take() {
+		t.Fatal("a refunded charge must be available again")
+	}
+	if b.take() {
+		t.Fatal("the budget must run out after its limit")
+	}
+}

--- a/internal/uploader/remote.go
+++ b/internal/uploader/remote.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/pkg/sftp"
@@ -188,12 +189,75 @@ func checkRemoteRoot(remote string) error {
 	return nil
 }
 
-// checkMaxDeletes enforces the guards.max_deletes limit (0 means unlimited).
-func checkMaxDeletes(n int, cfg *config.Config) error {
-	if cfg.Safety.MaxDeletes > 0 && n > cfg.Safety.MaxDeletes {
-		return fmt.Errorf("refusing to delete %d files: exceeds safety.max_deletes=%d (raise the limit in the config file, or run with dry-run to inspect the plan)", n, cfg.Safety.MaxDeletes)
+// deleteBudget enforces safety.max_deletes. Three things about it are worth
+// stating, because the code used to disagree with what the setting's name
+// promises (issue #237):
+//
+//   - It counts **every remote entry a run removes**, directories included.
+//     Directory removals used to be free, so a clean run against a tree of
+//     10,000 empty directories with max_deletes: 10 proceeded.
+//   - It is **run-wide**. The check used to sit inside the per-deployment
+//     execute functions, so a config file with eight deployments and
+//     max_deletes: 100 permitted 800 removals. The key lives under a run-wide
+//     safety: section and now behaves like it.
+//   - 0 still means unlimited, which is the default. Making the guard finite
+//     by default is a product decision, not this one; what changed is that
+//     the guard a user does set is the guard they get.
+//
+// A limit is checked against a batch before that batch runs, so a run that
+// would go over is refused rather than stopped halfway. The one exception is
+// the sync mode's pruning of directories it just emptied, where the number is
+// not knowable in advance; see reserve and take.
+type deleteBudget struct {
+	mu    sync.Mutex
+	limit int // 0 means unlimited
+	spent int
+}
+
+func newDeleteBudget(cfg *config.Config) *deleteBudget {
+	return &deleteBudget{limit: cfg.Safety.MaxDeletes}
+}
+
+// reserve charges n removals whose count is known before any of them runs, and
+// refuses the run when they would take it past the limit.
+func (b *deleteBudget) reserve(n int) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limit > 0 && b.spent+n > b.limit {
+		if b.spent > 0 {
+			return fmt.Errorf("refusing to delete %d more remote entries (files and directories): %d were already deleted earlier in this run, which would take it past safety.max_deletes=%d (raise the limit in the config file, or run with dry-run to inspect the plan)", n, b.spent, b.limit)
+		}
+		return fmt.Errorf("refusing to delete %d remote entries (files and directories): exceeds safety.max_deletes=%d (raise the limit in the config file, or run with dry-run to inspect the plan)", n, b.limit)
 	}
+	b.spent += n
 	return nil
+}
+
+// take charges one removal that could not be counted in advance, reporting
+// whether the budget had room for it. It exists for the sync mode's prune of
+// directories the run itself emptied: those are discovered after the file
+// deletions they follow, so the honest answer to an exhausted budget is to
+// stop pruning, not to fail a run whose real work already succeeded.
+func (b *deleteBudget) take() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limit > 0 && b.spent >= b.limit {
+		return false
+	}
+	b.spent++
+	return true
+}
+
+// refund gives back a charge from take whose removal did not happen. Most
+// prune candidates are directories that are still in use, and a budget spent
+// on directories that were never removed would quietly stop the prune far
+// short of the limit the user set.
+func (b *deleteBudget) refund() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.spent > 0 {
+		b.spent--
+	}
 }
 
 // listRemoteContents returns every regular file and directory under root

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -62,7 +62,7 @@ type manifest struct {
 // manifest: it uploads new/changed files, deletes files that the previous sync
 // wrote but are now gone locally, prunes empty directories and rewrites the
 // manifest. Unchanged files are skipped.
-func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, watch *stallWatchdog, log Logger) error {
+func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, budget *deleteBudget, watch *stallWatchdog, log Logger) error {
 	verb := planVerb(cfg)
 	base := normalizeRemote(p.pair.Remote)
 
@@ -138,7 +138,7 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 		if err := checkRemoteRoot(p.pair.Remote); err != nil {
 			return err
 		}
-		if err := checkMaxDeletes(len(toDelete), cfg); err != nil {
+		if err := budget.reserve(len(toDelete)); err != nil {
 			return err
 		}
 	}
@@ -193,7 +193,10 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 		// deleted is a subset of toDelete, so this cannot fail either.
 		deletedFull[i], _ = safeJoin(base, rel)
 	}
-	pruneEmptyDirs(ctx, cfg, sess, watch, base, deletedFull)
+	// The prune's directories are only known once the file deletions have
+	// happened, so they are charged one at a time and pruning stops (rather
+	// than the run failing) if the budget runs out; see deleteBudget.
+	stats.DirsDeleted += pruneEmptyDirs(ctx, cfg, sess, watch, base, deletedFull, budget)
 	endWrite := metrics.Phase("manifest_write")
 	err = sess.do(ctx, watch, func(client *sftp.Client) error {
 		return writeManifest(client, base, cfg.SyncManifestName(), manifest{Version: manifestVersion, Files: local})
@@ -391,7 +394,7 @@ func writeManifest(client *sftp.Client, dir, name string, m manifest) error {
 // deepest first, walking up to (but not including) base. Each removal runs
 // through sess.do: the outcome stays best-effort, but a dropped connection is
 // redialed rather than silently failing every remaining removal.
-func pruneEmptyDirs(ctx context.Context, cfg *config.Config, sess *session, watch *stallWatchdog, base string, deleted []string) {
+func pruneEmptyDirs(ctx context.Context, cfg *config.Config, sess *session, watch *stallWatchdog, base string, deleted []string, budget *deleteBudget) int {
 	seen := map[string]struct{}{}
 	var candidates []string
 	for _, f := range deleted {
@@ -404,7 +407,7 @@ func pruneEmptyDirs(ctx context.Context, cfg *config.Config, sess *session, watc
 		}
 	}
 	defer metrics.Phase("prune_dirs")()
-	removeRemoteDirs(ctx, cfg, sess, watch, candidates)
+	return removeRemoteDirs(ctx, cfg, sess, watch, candidates, budget)
 }
 
 // hashFile returns the sha256 hex digest of a local file's contents.

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -35,6 +35,11 @@ type Logger interface {
 type Stats struct {
 	FilesUploaded int
 	FilesDeleted  int
+	// DirsDeleted counts remote directories removed by the clean mode's sweep
+	// and the sync mode's prune. They are reported apart from FilesDeleted so
+	// the existing files-deleted output keeps meaning files, but they are
+	// charged to the same safety.max_deletes budget; see deleteBudget.
+	DirsDeleted   int
 	FilesSkipped  int // unchanged files skipped (sync, or overlay with skip-unchanged)
 	BytesUploaded int64
 	Duration      time.Duration
@@ -62,6 +67,10 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	start := time.Now()
 	stats := &Stats{}
 	defer func() { stats.Duration = time.Since(start) }()
+
+	// One budget for the whole run: safety.max_deletes lives under a run-wide
+	// safety: section and is enforced like one (issue #237).
+	budget := newDeleteBudget(cfg)
 
 	// Everything the configuration left at "auto" is this value's to decide;
 	// see internal/autotune and docs/tuning.md. The benchmark reads the
@@ -161,7 +170,7 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 		}
 		before := *stats
 		planStart := time.Now()
-		err := executePlan(ctx, cfg, sess, p, stats, watch, log)
+		err := executePlan(ctx, cfg, sess, p, stats, budget, watch, log)
 		// Recorded from the before/after delta (not threaded through
 		// executePlan) so a deployment's partial progress on failure is
 		// still captured, matching the totals' own partial-progress
@@ -206,7 +215,7 @@ func logDeploymentSummary(cfg *config.Config, pair config.UploadPair, ds Deploym
 }
 
 // executePlan performs (or previews) one plan according to its strategy.
-func executePlan(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, watch *stallWatchdog, log Logger) error {
+func executePlan(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, budget *deleteBudget, watch *stallWatchdog, log Logger) error {
 	header := fmt.Sprintf("%s => %s [%s] (%d local files)", p.pair.Local, p.pair.Remote, p.strategy, len(p.files))
 	if p.pair.Name != "" {
 		header = fmt.Sprintf("%s: %s", p.pair.Name, header)
@@ -219,14 +228,14 @@ func executePlan(ctx context.Context, cfg *config.Config, sess *session, p plan,
 	}
 
 	if p.strategy == config.StrategySync {
-		return executeSync(ctx, cfg, sess, p, stats, watch, log)
+		return executeSync(ctx, cfg, sess, p, stats, budget, watch, log)
 	}
-	return executeOverlayOrClean(ctx, cfg, sess, p, stats, watch, log)
+	return executeOverlayOrClean(ctx, cfg, sess, p, stats, budget, watch, log)
 }
 
 // executeOverlayOrClean uploads the plan, first wiping the remote target when
 // the strategy is clean.
-func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, watch *stallWatchdog, log Logger) error {
+func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *session, p plan, stats *Stats, budget *deleteBudget, watch *stallWatchdog, log Logger) error {
 	verb := planVerb(cfg)
 	base := normalizeRemote(p.pair.Remote)
 
@@ -241,7 +250,10 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 		if err != nil {
 			return fmt.Errorf("scanning remote directory %q: %w", p.pair.Remote, err)
 		}
-		if err := checkMaxDeletes(len(files), cfg); err != nil {
+		// Files and directories together: everything this sweep is about to
+		// remove is known now, so a run that would go over the limit is refused
+		// before it removes anything (issue #237).
+		if err := budget.reserve(len(files) + len(dirs)); err != nil {
 			return err
 		}
 		endSweep := metrics.Phase("delete_sweep")
@@ -253,7 +265,7 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 		}
 		// Best effort, but parallel within a depth: siblings are independent;
 		// parents still wait for every child level to finish.
-		removeRemoteDirs(ctx, cfg, sess, watch, dirs)
+		stats.DirsDeleted += removeRemoteDirs(ctx, cfg, sess, watch, dirs, nil)
 		endSweep()
 	}
 

--- a/schema/easysftp.schema.json
+++ b/schema/easysftp.schema.json
@@ -126,7 +126,7 @@
       "additionalProperties": false,
       "properties": {
         "max_deletes": {
-          "description": "Refuse a run that would delete more than this many files. 0 means unlimited. Deleting the remote root is always refused, regardless of this value.",
+          "description": "Refuse a run that would remove more than this many remote entries, files and directories together, across all of its deployments. 0 means unlimited. Deleting the remote root is always refused, regardless of this value.",
           "type": "integer",
           "minimum": 0
         }


### PR DESCRIPTION
Closes #237.

## The problem

`safety.max_deletes` is the guard the README sells as a differentiator ("Delete safety guards | yes (root refusal, max_deletes)" against four competitors with none). It had three limits its documentation did not state:

1. **It ignored directories.** `checkMaxDeletes` was called with the file count only. A `clean` run against a tree of 10,000 empty directories with `max_deletes: 10` proceeded. Those removals were also missing from `stats.FilesDeleted`, so the job summary and the outputs under-reported the run.
2. **It was per deployment.** The check sat inside `executeSync` and `executeOverlayOrClean`, both of which run once per deployment, so a config file with eight deployments and `max_deletes: 100` permitted 800 removals — from a key that lives under a run-wide `safety:` section.
3. **It defaults to unlimited.** That one is a product decision and is left alone; see below.

## Semantics chosen

`checkMaxDeletes` becomes a run-wide `deleteBudget`:

- **Files and directories share one budget.** Where the count is known before the removals start (both destructive sweeps), a run that would go over is refused *before it removes anything* — that is what "guard" has to mean.
- **The `sync` mode's prune is the one exception**, and the shape forces it: directories the run has just emptied are only discovered *after* the file deletions they follow. Failing there would abort a run whose real work already succeeded, so an exhausted budget stops the pruning instead. A candidate that could not be removed (most of them, since prune candidates are usually still in use) refunds its charge, or a prune over a deep tree would quietly stop far short of the limit the user set.
- **One budget for the run**, created in `Run` and threaded through both execute functions.

## Reporting

Directory removals are now visible: a new `dirs-deleted` output, a `Directories removed` row in the job summary, a `dirs_deleted` metrics counter and `Stats.DirsDeleted`.

They are kept **apart** from `files-deleted` rather than folded into it: silently changing what an existing output counts is worse than adding one. The docs say explicitly that the guard counts both together.

## Default left alone

`0` still means unlimited and is still the default. The issue calls this a product decision rather than a bug, and CLAUDE.md's stated principle is to default to today's behaviour. What changed is that the guard a user *does* set is the guard they get.

## Docs

`docs/strategies.md` (delete guards), `docs/configuration.md` (sections table, outputs table, example), `docs/troubleshooting.md` (the error heading changed, and both variants of the message are explained), `docs/easysftp.example.yml`, `README.md`, `action.yml` and the JSON Schema description.

## Tests

- `TestMaxDeletesCountsDirectories` — one file, four directories, `max_deletes: 3`; refused, and nothing removed first.
- `TestMaxDeletesReportsDirectoriesRemoved` — `FilesDeleted` and `DirsDeleted` are separate and both right.
- `TestMaxDeletesIsRunWide` — two deployments of two deletions each against a limit of 3; the first runs, the second is refused, and the message says the budget was already partly spent.
- `TestDeleteBudgetUnlimitedByDefault`, `TestDeleteBudgetTakeAndRefund`.

Plus `dirs-deleted` assertions in the existing `cmd/easysftp` output and summary tests.

`go test ./...` passes. `-race` needs cgo and was not available on this machine; CI runs that pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)