### PR TITLE
feat(security): verify release binaries against build provenance

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -185,6 +185,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # For the build provenance attestation (issue #146). id-token signs with
+      # this workflow's OIDC identity; attestations stores the result.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -221,6 +225,19 @@ jobs:
             cd release
             sha256sum "${expected[@]}" > checksums.txt
           )
+
+      # The checksum file travels in the same mutable release as the binaries
+      # it describes, so on its own it proves transport integrity and nothing
+      # more: whoever can replace one asset can replace both. The attestation
+      # is not an asset. It is signed with this workflow's OIDC identity and
+      # stored by GitHub, so it binds each digest to this repository, this
+      # workflow and this release commit, and a replaced binary has no
+      # attestation matching its digest. scripts/action-lib.sh verifies it at
+      # run time; see docs/security.md and issue #146.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: release/easysftp_*
 
       - name: Upload or replace release assets
         shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,6 +33,10 @@ jobs:
       needs.release-please.outputs.release_created == 'true'
     permissions:
       contents: write
+      # Passed through to the upload job's attestation step (issue #146); a
+      # called workflow cannot grant itself more than its caller has.
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release-binaries.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/repair-release.yml
+++ b/.github/workflows/repair-release.yml
@@ -16,6 +16,9 @@ jobs:
     name: Rebuild an existing exact release
     permissions:
       contents: write
+      # See release-please.yml: the attestation needs both (issue #146).
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release-binaries.yml
     with:
       tag: ${{ inputs.tag }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,5 +11,5 @@ or contact the maintainer directly. You will receive a response as soon as possi
 - Always set the `host-key` input (or `known-hosts`) so the server's identity is verified. In v3 a run without a pinned key fails unless you explicitly opt out with `allow-any-host-key: true`, which is not recommended
 - Store all credentials (`password`, `private-key`, `passphrase`) as encrypted GitHub Actions secrets
 - Prefer key-based authentication over passwords
-- Release refs download only this repository's platform binary and verify it against the release's `checksums.txt`
+- Release refs download only this repository's platform binary. It is checked against the release's `checksums.txt` (transport integrity: both files come from the same mutable release) and, decisively, against a build provenance attestation that binds the binary's digest to this repository and to `.github/workflows/release-binaries.yml`. A failed attestation check fails the run; see [docs/security.md](docs/security.md#supply-chain-safety)
 - The build mode is selected automatically from the action ref: release tags and the exact release commit SHA use the verified prebuilt binary; every other ref builds from source, so a stale release binary is never substituted for newer source

--- a/action.yml
+++ b/action.yml
@@ -284,6 +284,10 @@ runs:
         INPUT_BUILD_MODE: ${{ inputs.build-mode }}
         ACTION_PATH: ${{ github.action_path }}
         ACTION_REF: ${{ github.action_ref }}
+        # Read-only use: the attestation API of a public repository. A job
+        # that restricts or removes the token only loses the provenance
+        # check, which then warns instead of failing the deploy.
+        GH_TOKEN: ${{ github.token }}
 
     - name: Set up Go
       if: steps.prepare.outputs.build-mode == 'source'

--- a/docs/security.md
+++ b/docs/security.md
@@ -174,16 +174,47 @@ Apache (vhost or `.htaccess`):
 - Release refs download a verified prebuilt binary automatically. The launcher
   validates `.easysftp-version`, maps only the supported OS/architecture pairs,
   downloads only the matching binary and `checksums.txt` from
-  `eiserv/easySFTP`'s exact GitHub Release, and verifies SHA-256 before
+  `eiserv/easySFTP`'s exact GitHub Release, and checks SHA-256 before
   execution. Release downloads may follow GitHub's HTTPS redirect to its own
   release-asset CDN; no third-party download source is configured.
+- **The SHA-256 check is not what makes the binary trustworthy.**
+  `checksums.txt` is downloaded from the same GitHub Release as the binary, and
+  release assets are mutable: the release workflow uploads with `--clobber`,
+  and a repair workflow exists to re-run that upload for a tag that is already
+  published. Anyone able to write release assets could replace both files
+  together. On its own the checksum proves the download was not corrupted in
+  transit, and nothing more.
+- **Build provenance is what makes it trustworthy.** Every release binary
+  carries a [build provenance
+  attestation](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+  signed with the release workflow's OIDC identity and stored by GitHub, not as
+  a release asset. It binds the binary's exact digest to this repository, to
+  `.github/workflows/release-binaries.yml` and to the release commit. The
+  launcher verifies it with `gh attestation verify` before running the binary,
+  pinning both `--repo` and `--signer-workflow`, and **fails the run** if the
+  check runs and does not pass. You can run the same check yourself:
+
+  ```bash
+  gh attestation verify easysftp_linux_x64 --repo eiserv/easySFTP \
+    --signer-workflow eiserv/easySFTP/.github/workflows/release-binaries.yml
+  ```
+
+  If the check cannot run at all (no `gh` on the runner, no token, or a `gh`
+  older than the `attestation` command) the run warns and continues on the
+  checksum alone, so a runner without the tooling is not broken by it. The
+  warning names the escape hatch below.
 - Pin the action to a major tag for convenience (`eiserv/easySFTP@v3`) or to
   the full commit SHA of an exact release; both use the verified prebuilt
   binary. Any development ref (`@main`, a non-release commit SHA, or local
   `uses: ./`) builds the checked-out source from scratch instead, so a stale
-  release binary can never be substituted. The build mode is selected
+  release binary can never be substituted, and the executed artifact is
+  covered entirely by the ref you pinned. That source build is the escape
+  hatch for a policy that will not accept a run-time download at all; it costs
+  a Go build, roughly 30 to 60 seconds. The build mode is selected
   automatically from the ref; there is no `build-mode` input to get wrong.
-- Exact version tags (`v3.0.0`) are immutable once published; `v3` and `v3.0`
-  are rolling tags, see [RELEASING.md](RELEASING.md#tag-policy).
+- Exact version **tags** (`v3.0.0`) are immutable once published; `v3` and
+  `v3.0` are rolling tags, see [RELEASING.md](RELEASING.md#tag-policy). The
+  release **assets** behind an exact tag are a separate thing and are mutable,
+  which is why the attestation above exists.
 - Grant the deploy job only the permissions it needs
   (`permissions: contents: read` is enough for easySFTP itself).

--- a/scripts/action-lib.sh
+++ b/scripts/action-lib.sh
@@ -200,6 +200,70 @@ verify_release_checksum() {
   fi
 }
 
+# provenance_repo / provenance_workflow name what a release asset must have
+# been built by. They are constants rather than parameters so that a caller
+# cannot be talked into accepting an attestation from somewhere else.
+provenance_repo='eiserv/easySFTP'
+provenance_workflow='eiserv/easySFTP/.github/workflows/release-binaries.yml'
+
+# verify_release_provenance checks a downloaded release binary against the
+# build provenance attestation that release-binaries.yml recorded for it.
+#
+# It exists because the SHA-256 check on its own proves very little (issue
+# #146). checksums.txt is downloaded from the same GitHub release as the
+# binary, and release assets are mutable by design here: release-binaries.yml
+# uploads with --clobber and repair-release.yml exists to re-run that upload
+# for an already published tag. Anyone able to write release assets could
+# replace both files together and the checksum would still match. The
+# attestation is not an asset: it is signed with the workflow's OIDC identity
+# and stored by GitHub, so it says which repository, which workflow and which
+# commit produced this exact digest, and a replaced asset has no attestation
+# that matches it.
+#
+# A verification that runs and fails is fatal. A verification that cannot run
+# at all (no gh, no token, a gh too old for the command) warns and lets the
+# run continue on the checksum alone, which is what it had before this
+# existed. That asymmetry is deliberate: tampering fails closed, while a
+# runner without the tooling keeps working, and the warning names the escape
+# hatch that gives a hard guarantee (pin to a non-release commit and the
+# action builds from source, which is fully covered by the pin).
+verify_release_provenance() {
+  local binary=$1
+  local asset=$2
+  local version=$3
+  local token=${GH_TOKEN:-${GITHUB_TOKEN:-}}
+  local output=''
+
+  if ! command -v gh >/dev/null 2>&1; then
+    provenance_unavailable 'the GitHub CLI (gh) is not installed on this runner'
+    return 0
+  fi
+  if [[ -z "$token" ]]; then
+    provenance_unavailable 'no GitHub token was available to read the attestation'
+    return 0
+  fi
+  if ! gh attestation verify --help >/dev/null 2>&1; then
+    provenance_unavailable "this runner's gh is too old for 'gh attestation verify'"
+    return 0
+  fi
+
+  if ! output=$(GH_TOKEN="$token" gh attestation verify "$binary" \
+    --repo "$provenance_repo" \
+    --signer-workflow "$provenance_workflow" 2>&1); then
+    printf '%s\n' "$output" >&2
+    easysftp_error "build provenance verification failed for the $version release asset '$asset'; it was not built by $provenance_workflow. Do not use this run's result. Pin the action to a non-release commit to build from source instead."
+    return 1
+  fi
+  printf 'Verified build provenance for %s (%s, built by %s)\n' "$asset" "$version" "$provenance_workflow"
+}
+
+# provenance_unavailable reports that the provenance check could not run, and
+# says what the run is left with. A warning rather than an error; see
+# verify_release_provenance.
+provenance_unavailable() {
+  printf '::warning::easySFTP action: could not verify the build provenance of the release binary (%s). The SHA-256 check against checksums.txt still ran, but both files come from the same mutable release, so it proves transport integrity only. Pin the action to a non-release commit for a source build that is fully covered by the pin; see docs/security.md.\n' "$1"
+}
+
 download_release_file() {
   local version=$1
   local asset=$2

--- a/scripts/prepare-action.sh
+++ b/scripts/prepare-action.sh
@@ -46,6 +46,10 @@ if [[ "$mode" == 'prebuilt' ]]; then
   download_release_file "$version" 'checksums.txt' "$checksums" 1048576
   download_release_file "$version" "$asset" "$binary" 104857600
   verify_release_checksum "$binary" "$checksums" "$asset"
+  # The checksum proves the download was not corrupted in transit; the
+  # attestation is what proves the asset is the one this repository's release
+  # workflow built. See verify_release_provenance and issue #146.
+  verify_release_provenance "$binary" "$asset" "$version"
   chmod +x "$binary"
   echo "Using verified easySFTP $version release asset $asset"
 else

--- a/scripts/test-action.sh
+++ b/scripts/test-action.sh
@@ -255,34 +255,44 @@ exit "${MOCK_GH_EXIT:-0}"
 MOCK_GH
 chmod +x "$tmp/ghbin/gh"
 
-# Each case runs in a subshell so its PATH and token stay local to it.
-check_provenance() (
-  PATH=$1
-  export GH_TOKEN=$2 GITHUB_TOKEN=$2 MOCK_GH_EXIT=${3:-0}
-  verify_release_provenance "$tmp/assets/easysftp_linux_x64" easysftp_linux_x64 v1.2.3
-)
+# The three cases differ only in the environment the check runs in. The
+# failing one is a function because expect_failure takes a command, and its
+# body is a subshell so the environment it sets does not leak into the rest of
+# this script.
+provenance_asset="$tmp/assets/easysftp_linux_x64"
 
-provenance_ok=$(check_provenance "$tmp/ghbin:$PATH" mock-token)
+provenance_ok=$(PATH="$tmp/ghbin:$PATH" GH_TOKEN=mock-token \
+  verify_release_provenance "$provenance_asset" easysftp_linux_x64 v1.2.3)
 expect_equal 'verified provenance is reported' \
   'Verified build provenance for easysftp_linux_x64 (v1.2.3, built by eiserv/easySFTP/.github/workflows/release-binaries.yml)' \
   "$provenance_ok"
 
-expect_failure 'a failed provenance check fails the run' \
-  check_provenance "$tmp/ghbin:$PATH" mock-token 1
+failing_provenance() (
+  PATH="$tmp/ghbin:$PATH" GH_TOKEN=mock-token MOCK_GH_EXIT=1 \
+    verify_release_provenance "$provenance_asset" easysftp_linux_x64 v1.2.3
+)
+expect_failure 'a failed provenance check fails the run' failing_provenance
 
 # A runner without the tooling keeps working on the checksum alone and says so.
-# Tampering fails closed; a missing prerequisite does not break a deploy.
+# Tampering fails closed; a missing prerequisite does not break a deploy. Both
+# ways of missing it are covered: no gh on PATH, and no token to read the
+# attestation with.
 mkdir -p "$tmp/nogh"
-no_gh_warning=$(check_provenance "$tmp/nogh" '')
-case "$no_gh_warning" in
-  '::warning::easySFTP action: could not verify the build provenance'*)
-    echo 'PASS: an unavailable provenance check warns instead of failing'
-    ;;
-  *)
-    echo "FAIL: an unavailable provenance check should warn, got '$no_gh_warning'" >&2
-    failures=$((failures + 1))
-    ;;
-esac
+no_gh_warning=$(PATH="$tmp/nogh" \
+  verify_release_provenance "$provenance_asset" easysftp_linux_x64 v1.2.3)
+no_token_warning=$(PATH="$tmp/ghbin:$PATH" GH_TOKEN='' GITHUB_TOKEN='' \
+  verify_release_provenance "$provenance_asset" easysftp_linux_x64 v1.2.3)
+for warning in "$no_gh_warning" "$no_token_warning"; do
+  case "$warning" in
+    '::warning::easySFTP action: could not verify the build provenance'*)
+      echo 'PASS: an unavailable provenance check warns instead of failing'
+      ;;
+    *)
+      echo "FAIL: an unavailable provenance check should warn, got '$warning'" >&2
+      failures=$((failures + 1))
+      ;;
+  esac
+done
 
 if (( failures != 0 )); then
   echo "$failures action test(s) failed" >&2

--- a/scripts/test-action.sh
+++ b/scripts/test-action.sh
@@ -255,17 +255,25 @@ exit "${MOCK_GH_EXIT:-0}"
 MOCK_GH
 chmod +x "$tmp/ghbin/gh"
 
-provenance_ok=$(
-  PATH="$tmp/ghbin:$PATH" GH_TOKEN=mock-token     verify_release_provenance "$tmp/assets/easysftp_linux_x64" easysftp_linux_x64 v1.2.3
+# Each case runs in a subshell so its PATH and token stay local to it.
+check_provenance() (
+  PATH=$1
+  export GH_TOKEN=$2 GITHUB_TOKEN=$2 MOCK_GH_EXIT=${3:-0}
+  verify_release_provenance "$tmp/assets/easysftp_linux_x64" easysftp_linux_x64 v1.2.3
 )
-expect_equal 'verified provenance is reported'   'Verified build provenance for easysftp_linux_x64 (v1.2.3, built by eiserv/easySFTP/.github/workflows/release-binaries.yml)'   "$provenance_ok"
 
-expect_failure 'a failed provenance check fails the run' env   PATH="$tmp/ghbin:$PATH" GH_TOKEN=mock-token MOCK_GH_EXIT=1   bash -c 'source "$0"; verify_release_provenance "$1" easysftp_linux_x64 v1.2.3'   "$repo_root/scripts/action-lib.sh" "$tmp/assets/easysftp_linux_x64"
+provenance_ok=$(check_provenance "$tmp/ghbin:$PATH" mock-token)
+expect_equal 'verified provenance is reported' \
+  'Verified build provenance for easysftp_linux_x64 (v1.2.3, built by eiserv/easySFTP/.github/workflows/release-binaries.yml)' \
+  "$provenance_ok"
+
+expect_failure 'a failed provenance check fails the run' \
+  check_provenance "$tmp/ghbin:$PATH" mock-token 1
 
 # A runner without the tooling keeps working on the checksum alone and says so.
 # Tampering fails closed; a missing prerequisite does not break a deploy.
 mkdir -p "$tmp/nogh"
-no_gh_warning=$(PATH="$tmp/nogh" GH_TOKEN='' GITHUB_TOKEN=''   verify_release_provenance "$tmp/assets/easysftp_linux_x64" easysftp_linux_x64 v1.2.3)
+no_gh_warning=$(check_provenance "$tmp/nogh" '')
 case "$no_gh_warning" in
   '::warning::easySFTP action: could not verify the build provenance'*)
     echo 'PASS: an unavailable provenance check warns instead of failing'

--- a/scripts/test-action.sh
+++ b/scripts/test-action.sh
@@ -219,6 +219,63 @@ expect_failure 'missing checksum entry' verify_release_checksum "$tmp/assets/eas
 printf '%064d  easysftp_linux_x64\n' 0 > "$tmp/wrong-checksum"
 expect_failure 'wrong checksum' verify_release_checksum "$tmp/assets/easysftp_linux_x64" "$tmp/wrong-checksum" 'easysftp_linux_x64'
 
+# Build provenance (issue #146). The SHA-256 check alone proves transport
+# integrity only, because checksums.txt comes from the same mutable release as
+# the binary it describes. These cover the three answers the check can give,
+# with a mock gh: verified, ran and failed, and could not run.
+mkdir -p "$tmp/ghbin"
+cat > "$tmp/ghbin/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" != 'attestation' || "${2:-}" != 'verify' ]]; then
+  exit 2
+fi
+if [[ "${3:-}" == '--help' ]]; then
+  exit 0
+fi
+# The identity of the signer is the whole point: a run must not accept an
+# attestation from another repository or another workflow.
+saw_repo=0
+saw_workflow=0
+for arg in "$@"; do
+  case "$arg" in
+    eiserv/easySFTP) saw_repo=1 ;;
+    eiserv/easySFTP/.github/workflows/release-binaries.yml) saw_workflow=1 ;;
+  esac
+done
+if (( ! saw_repo || ! saw_workflow )); then
+  printf 'mock gh: verify_release_provenance must pin --repo and --signer-workflow\n' >&2
+  exit 1
+fi
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  printf 'mock gh: no token was passed through\n' >&2
+  exit 1
+fi
+exit "${MOCK_GH_EXIT:-0}"
+MOCK_GH
+chmod +x "$tmp/ghbin/gh"
+
+provenance_ok=$(
+  PATH="$tmp/ghbin:$PATH" GH_TOKEN=mock-token     verify_release_provenance "$tmp/assets/easysftp_linux_x64" easysftp_linux_x64 v1.2.3
+)
+expect_equal 'verified provenance is reported'   'Verified build provenance for easysftp_linux_x64 (v1.2.3, built by eiserv/easySFTP/.github/workflows/release-binaries.yml)'   "$provenance_ok"
+
+expect_failure 'a failed provenance check fails the run' env   PATH="$tmp/ghbin:$PATH" GH_TOKEN=mock-token MOCK_GH_EXIT=1   bash -c 'source "$0"; verify_release_provenance "$1" easysftp_linux_x64 v1.2.3'   "$repo_root/scripts/action-lib.sh" "$tmp/assets/easysftp_linux_x64"
+
+# A runner without the tooling keeps working on the checksum alone and says so.
+# Tampering fails closed; a missing prerequisite does not break a deploy.
+mkdir -p "$tmp/nogh"
+no_gh_warning=$(PATH="$tmp/nogh" GH_TOKEN='' GITHUB_TOKEN=''   verify_release_provenance "$tmp/assets/easysftp_linux_x64" easysftp_linux_x64 v1.2.3)
+case "$no_gh_warning" in
+  '::warning::easySFTP action: could not verify the build provenance'*)
+    echo 'PASS: an unavailable provenance check warns instead of failing'
+    ;;
+  *)
+    echo "FAIL: an unavailable provenance check should warn, got '$no_gh_warning'" >&2
+    failures=$((failures + 1))
+    ;;
+esac
+
 if (( failures != 0 )); then
   echo "$failures action test(s) failed" >&2
   exit 1


### PR DESCRIPTION
Closes #146. Also removes the sharpest edge of #241, which is noted there but not closed by this.

## The problem

`prepare-action.sh` downloaded two files from the **same** GitHub Release and verified one against the other:

```bash
download_release_file "$version" 'checksums.txt' "$checksums" 1048576
download_release_file "$version" "$asset" "$binary" 104857600
verify_release_checksum "$binary" "$checksums" "$asset"
```

Release assets are mutable here by design — `release-binaries.yml` uploads with `gh release upload ... --clobber`, and `repair-release.yml` exists specifically to re-run that upload for an already published tag. Anyone able to write release assets could replace the binary and `checksums.txt` together and the check would still pass. So it proved the download was not corrupted **in transit**, and nothing more.

The binary it guards reads the user's SSH private key and connects to their production server, which makes it the highest-value target in the project.

## What this changes

**At release time.** `release-binaries.yml`'s upload job now runs `actions/attest-build-provenance` (SHA-pinned, per the repo rule) over the six binaries. An attestation is not a release asset: it is signed with the workflow's OIDC identity and stored by GitHub, so it binds each digest to this repository, to `.github/workflows/release-binaries.yml` and to the release commit. A replaced binary has no attestation matching its digest. `release-please.yml` and `repair-release.yml` pass `id-token: write` and `attestations: write` through, since a called workflow cannot grant itself more than its caller has.

**At run time.** `verify_release_provenance` in `action-lib.sh` runs `gh attestation verify` before the binary is executed, pinning **both** `--repo` and `--signer-workflow`, so an attestation from another repository — or from another workflow in this one — is not accepted. `action.yml` passes `GH_TOKEN: ${{ github.token }}` for the read.

## The one judgement call

A check that **runs and fails** is fatal. A check that **cannot run at all** (no `gh` on the runner, no token, a `gh` predating the `attestation` command) warns and continues on the checksum — which is exactly what the run had before this existed.

Tampering therefore fails closed; a self-hosted runner without the tooling is not broken by a security improvement it cannot participate in. The warning names the escape hatch that gives a hard guarantee today: pin to a non-release commit and the action builds from source, which is fully covered by the pin and costs a Go build.

This follows CLAUDE.md's stated principle — prefer letting the user pick the tradeoff over hard-coded behaviour that removes the choice, and default to today's behaviour where the new one cannot apply.

## Option 1 from the issue, and why not

The issue's first suggestion is to commit the expected hashes into the tagged tree. As [noted on #241](https://github.com/eiserv/easySFTP/issues/241), that cannot be done by writing back after the fact: the binaries are built after release-please has created the tag, so committing the digest into that tree would mean moving a published tag, which makes the trust story worse rather than better. Doing it properly needs reproducible builds computed in the release PR and is a release-flow redesign of its own. Attestation is the standard answer, needs no such redesign, and additionally protects users pinned to the rolling `@v3` tag, which committed hashes alone would not.

## Docs

`docs/security.md` said "Exact version tags (`v3.0.0`) are immutable once published". That is true of the git tag and not of the release asset the launcher downloads. The supply-chain section now separates the two, says what each check actually proves, and gives the command a user can run themselves. `SECURITY.md` matches.

## Tests

`scripts/test-action.sh` gains a mock `gh` covering the three answers the check can give: verified (and the mock fails the test if `--repo` / `--signer-workflow` / the token are not passed), ran-and-failed (fatal), and could-not-run (warns, exit 0).

`go test ./...` and `bash scripts/test-action.sh` pass. The attestation half is exercised for real only by an actual release; the workflow changes are the standard shape for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)