### PR TITLE
test(autotune): read the regret stored sweeps recorded, and stop snapping optimistically

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,15 +153,31 @@ range stays inside the 15% budget, so the number is not balanced on a knife
 edge. Carry the caveat with it: one host, one 13 ms path, `shaping.available`
 false in every stored result.
 
-`internal/autotune/regret_test.go` is the acceptance test issue #209 asks for:
-it replays the policy over every sweep committed under `benchmarks/matrix/`
-with at least three repeats and fails when the regret against the best measured
-cell goes over 15% (a gap under 300 ms passes on its absolute size, which is
-what the issue allows for sub-two-second runs). A sibling test asserts that the
-old fixed 1/4/16 would *fail* it, so the replay cannot quietly stop
-discriminating. **Changing a constant in `internal/autotune` means running that
-test**, and a new stored sweep that fails it means the policy needs refitting,
-not that the test needs relaxing.
+The acceptance test issue #209 asks for is in two files, because the policy can
+be scored two ways and both are worth having.
+
+`internal/autotune/regret_test.go` **replays** the policy over every sweep
+committed under `benchmarks/matrix/` with at least three repeats and fails when
+the regret against the best measured cell goes over 15% (a gap under 300 ms
+passes on its absolute size, which is what the issue allows for sub-two-second
+runs). A choice the grid did not measure is interpolated between the cells that
+bracket it, not snapped to the nearest one: snapping broke ties upward, which
+is usually the faster column, so it flattered the policy by construction
+(issue #228). A sibling test asserts that the old fixed 1/4/16 would *fail* the
+replay, so it cannot quietly stop discriminating.
+
+`internal/autotune/recorded_regret_test.go` **reads what a sweep recorded about
+itself**: the `auto[]` block holds the regret the policy actually achieved on
+that host that day, with no replay and no interpolation in it. Every row is
+printed; a row is also enforced once the sweep has at least three repeats (below
+that its "best cell" is a sample, see issue #227) and today's policy still
+chooses the settings that row measured. Until a release sweep is stored at three
+repeats this half reports rather than gates, which is why the replay still
+carries the acceptance budget.
+
+**Changing a constant in `internal/autotune` means running both**, and a stored
+sweep that fails one means the policy needs refitting, not that the test needs
+relaxing.
 
 ## Remembering a measurement between runs (`internal/autocache`)
 

--- a/internal/autotune/recorded_regret_test.go
+++ b/internal/autotune/recorded_regret_test.go
@@ -1,0 +1,241 @@
+package autotune_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eiserv/easySFTP/internal/autotune"
+	"github.com/eiserv/easySFTP/internal/benchmark/scenario"
+	"github.com/eiserv/easySFTP/internal/benchmark/schema"
+)
+
+// This file is the other half of the acceptance test in regret_test.go, and it
+// exists because that half could not see the only data that measured the
+// shipped policy end to end (issue #228).
+//
+// The replay next door reconstructs a decision and scores it against a grid.
+// This one reads what a sweep recorded about itself: every matrix run measures
+// `auto` once per scenario and profile and stores the regret it achieved in
+// that run's own auto[] block. That number needs no replay and no
+// interpolation. It is what the policy did, on that host, that day.
+//
+// Reading it was the gap. regret_test.go only reads sweeps with at least three
+// repeats, and the two release sweeps that ran the shipped policy end to end
+// (v3.6.0 and v3.7.0) were stored at two, so the flagship policy was accepted
+// against replayed pre-policy grids while its only live measurements sat in
+// the repository unexamined, two of nine scenarios over the budget. Every row
+// is now printed by the suite, whether or not it is enforced.
+//
+// Two conditions decide whether a row is also *enforced*, and both are about
+// what the number means rather than about how convenient it is:
+//
+//   - The sweep needs at least minRepeats repeats. A recorded regret is
+//     median/best-1, and its denominator is the fastest of the sweep's own
+//     cells: at two repeats that is the minimum of a few hundred best-of-two
+//     medians, which is biased low for the same reason regret_test.go will not
+//     read such a grid. The stored 'small' rows are what that looks like: at
+//     concurrency 64 the best connection count is 2 in one sweep (3,893 ms,
+//     with 4 at 4,455 ms) and 4 in the next (3,907 ms, with 2 at 4,148 ms),
+//     a flip inside the sweeps' own drift. Fixing the repeat count at the
+//     source is the companion issue #227, and doing so turns every row here
+//     into an enforced one.
+//   - Today's policy has to still choose what the row measured. A recorded
+//     regret describes the settings that run picked, and the policy has been
+//     refitted since (issue #230); holding today's policy to a number produced
+//     by a decision it would no longer make would be scoring the wrong thing.
+func TestRecordedAutoRegretOfStoredSweeps(t *testing.T) {
+	rows := storedAutoRows(t)
+	if len(rows) == 0 {
+		// The rows this test exists for all carry a workload block. Losing
+		// them to a schema change or a broken reader has to fail here rather
+		// than turn the test green by finding nothing.
+		t.Fatal("no sweep under benchmarks/matrix recorded an auto[] regret with the workload behind it; this test would pass vacuously")
+	}
+
+	enforced := 0
+	for _, row := range rows {
+		recorded, ok := row.chosenSettings()
+		if !ok {
+			t.Logf("%-34s %-14s no resolved settings recorded", row.sweep, row.auto.Scenario)
+			continue
+		}
+		w, link, err := row.replayInputs()
+		if err != nil {
+			t.Fatalf("%s/%s: rebuilding the recorded workload: %v", row.sweep, row.auto.Scenario, err)
+		}
+		today := autotune.Plan(w, link, autotune.Fixed{})
+		regret := *row.auto.RegretPercent / 100
+		gap := recordedGap(row.auto)
+
+		var why string
+		switch {
+		case row.repeats < minRepeats:
+			why = fmt.Sprintf("not enforced: %d repeats, the best cell it is measured against is a sample (issue #227)", row.repeats)
+		case today != recorded:
+			why = fmt.Sprintf("not enforced: today's policy chooses %s for this workload", settings(today))
+		default:
+			why = "enforced"
+			enforced++
+		}
+		t.Logf("%-34s %-14s measured %+6.1f%% (%8s) at %-9s  %s",
+			row.sweep, row.auto.Scenario, regret*100, gap.Round(time.Millisecond), settings(recorded), why)
+
+		if why != "enforced" {
+			continue
+		}
+		if regret > regretTarget && gap > trivialGap {
+			t.Errorf("%s/%s: the policy measured %.1f%% (%s) behind the best cell of that sweep, over the %.0f%% target. "+
+				"This is a measurement of the shipped policy at settings it still chooses, not a replay, so the policy needs refitting",
+				row.sweep, row.auto.Scenario, regret*100, gap.Round(time.Millisecond), regretTarget*100)
+		}
+	}
+	if enforced == 0 {
+		t.Logf("no stored row is enforceable yet: the %d rows above were measured either below %d repeats or at settings "+
+			"the policy no longer chooses. The first release sweep stored after issue #227 changes that.", len(rows), minRepeats)
+	}
+}
+
+// autoRow is one auto[] entry together with the sweep it came from.
+type autoRow struct {
+	sweep   string
+	repeats int
+	auto    schema.Auto
+}
+
+// storedAutoRows reads every auto[] row under benchmarks/matrix that carries
+// both a recorded regret and the workload the policy saw.
+//
+// Rows without a workload are the sweeps stored before the policy existed,
+// where "auto" was the fixed 1/4/16; there is nothing of today's policy in
+// them, and TestTheFixedDefaultsWouldFailThisTest already owns that
+// comparison. Unlike the replay next door this reader does not drop a sweep
+// for its repeat count: every row is worth printing, and whether it is also
+// enforced is decided per row, next to the reason.
+func storedAutoRows(t *testing.T) []autoRow {
+	t.Helper()
+	dir, err := filepath.Abs(filepath.Join("..", "..", "benchmarks", "matrix"))
+	if err != nil {
+		t.Fatalf("locating benchmarks/matrix: %v", err)
+	}
+	paths, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		t.Fatalf("listing benchmarks/matrix: %v", err)
+	}
+	var out []autoRow
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		var env schema.Envelope
+		if err := json.Unmarshal(data, &env); err != nil {
+			t.Fatalf("decoding %s: %v", path, err)
+		}
+		var m schema.Matrix
+		if err := json.Unmarshal(env.Benchmark, &m); err != nil {
+			t.Fatalf("decoding the measurement in %s: %v", path, err)
+		}
+		name := strings.TrimSuffix(filepath.Base(path), ".json")
+		for _, a := range m.Auto {
+			if a.Workload == nil || a.RegretPercent == nil || a.Best == nil {
+				continue
+			}
+			// The row's own repeat count, falling back to the sweep's: they
+			// are the same today, and the row is the more specific answer.
+			repeats := a.Repeats
+			if repeats == 0 {
+				repeats = m.Repeats
+			}
+			out = append(out, autoRow{sweep: name, repeats: repeats, auto: a})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].sweep != out[j].sweep {
+			return out[i].sweep < out[j].sweep
+		}
+		return out[i].auto.Scenario < out[j].auto.Scenario
+	})
+	return out
+}
+
+// chosenSettings is what the run resolved its three knobs to before the
+// runtime controller touched anything, which is what Plan returns and
+// therefore the only thing comparable to it. The plain fields are the
+// high-water mark including the controller's growth, so Initial* is preferred
+// where the run recorded it.
+func (r autoRow) chosenSettings() (autotune.Settings, bool) {
+	c := r.auto.Chosen
+	conns := firstOf(c.InitialConnections, c.Connections)
+	concs := firstOf(c.InitialConcurrency, c.Concurrency)
+	reqs := firstOf(c.InitialRequestConcurrency, c.RequestConcurrency)
+	if conns == nil || concs == nil || reqs == nil {
+		return autotune.Settings{}, false
+	}
+	return autotune.Settings{
+		Connections:        int(*conns),
+		Concurrency:        int(*concs),
+		RequestConcurrency: int(*reqs),
+	}, true
+}
+
+// replayInputs rebuilds what the policy was looking at when this row was
+// recorded. Every feature comes from the row's own workload block, so nothing
+// here is reconstructed from the scenario tables except Unknown, which the
+// block does not carry and which follows from the deployment's shape.
+func (r autoRow) replayInputs() (autotune.Workload, autotune.Link, error) {
+	w := r.auto.Workload
+	if w.RTTMS == nil || w.HandshakeMS == nil {
+		return autotune.Workload{}, autotune.Link{}, fmt.Errorf("the row recorded no link")
+	}
+	shape := scenario.ShapeOf(r.auto.Scenario)
+	out := autotune.Workload{
+		Uploads:       int(value(w.Files)),
+		UploadBytes:   int64(value(w.Bytes)),
+		LargestUpload: int64(value(w.LargestBytes)),
+		P50Upload:     int64(value(w.P50Bytes)),
+		P90Upload:     int64(value(w.P90Bytes)),
+		SmallUploads:  int(value(w.SmallFiles)),
+		Probes:        int(value(w.Probes)),
+		Unknown:       shape.Prepopulate && shape.Mode != "sync",
+	}
+	link := autotune.Link{
+		RTT:       millis(*w.RTTMS),
+		Handshake: millis(*w.HandshakeMS),
+	}
+	return out, link, nil
+}
+
+// recordedGap is the absolute distance to the best cell the run itself
+// measured, which is what the trivial-gap allowance is applied to.
+func recordedGap(a schema.Auto) time.Duration {
+	if a.RegretMS != nil {
+		return millis(*a.RegretMS)
+	}
+	return millis(a.MedianMS - a.Best.MedianMS)
+}
+
+func firstOf(values ...*float64) *float64 {
+	for _, v := range values {
+		if v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+func value(v *float64) float64 {
+	if v == nil {
+		return 0
+	}
+	return *v
+}
+
+func settings(s autotune.Settings) string {
+	return fmt.Sprintf("%d/%d/%d", s.Connections, s.Concurrency, s.RequestConcurrency)
+}

--- a/internal/autotune/regret_test.go
+++ b/internal/autotune/regret_test.go
@@ -43,11 +43,17 @@ import (
 // the runtime controller to react to; what the controller adds is on top of
 // the numbers below, not in them.
 //
-// It also cannot score a coordinate the grid does not contain. nearest snaps to
-// the closest measured neighbour, ties going up, so a choice between two swept
-// values is credited with one of them; snapNote prints the bracket, and where
-// that bracket is wide the percentage next to it is not a measurement of the
-// policy (issue #217).
+// It also cannot score a coordinate the grid does not contain. scoreOf
+// interpolates between the measured cells that bracket the choice, so a choice
+// between two swept values is estimated from both rather than credited with
+// the better one; snapNote prints the span, and where that span is wide the
+// percentage next to it is an estimate and not a measurement of the policy
+// (issues #217 and #228).
+//
+// What it cannot see at all is a sweep's own recorded auto[] regret, which is
+// a measurement rather than a replay. TestRecordedAutoRegretOfStoredSweeps in
+// recorded_regret_test.go reads those, including from the sweeps this file
+// skips.
 //
 // When this fails after a policy change, read the per-scenario table it
 // prints: it names the cell the policy chose, the cell that won, and the two
@@ -83,7 +89,7 @@ func TestPolicyRegretAgainstStoredSweeps(t *testing.T) {
 					t.Fatalf("%s: %v", group.scenario, err)
 				}
 				chosen := autotune.Plan(w, link, autotune.Fixed{})
-				at, ok := group.nearest(chosen)
+				at, ok := group.scoreOf(chosen)
 				if !ok {
 					// The policy picked coordinates this grid did not measure
 					// at all. Nothing to score, and silently dropping it would
@@ -92,13 +98,13 @@ func TestPolicyRegretAgainstStoredSweeps(t *testing.T) {
 					continue
 				}
 				best := group.best()
-				gap := time.Duration(at.MedianMS-best.MedianMS) * time.Millisecond
-				regret := at.MedianMS/best.MedianMS - 1
+				gap := time.Duration(at-best.MedianMS) * time.Millisecond
+				regret := at/best.MedianMS - 1
 
 				t.Logf("%-16s chose %d/%d/%s -> %s, best %d/%d/%s -> %s, regret %+.1f%%%s",
 					group.scenario, chosen.Connections, chosen.Concurrency, request(chosen.RequestConcurrency),
-					ms(at.MedianMS), best.Connections, best.Concurrency, requestOf(best.RequestConcurrency),
-					ms(best.MedianMS), regret*100, group.snapNote(chosen, at))
+					ms(at), best.Connections, best.Concurrency, requestOf(best.RequestConcurrency),
+					ms(best.MedianMS), regret*100, group.snapNote(chosen))
 
 				if regret > regretTarget && gap > trivialGap {
 					t.Errorf("%s: the policy is %.1f%% (%s) behind the fastest cell, over the %.0f%% target",
@@ -118,11 +124,11 @@ func TestTheFixedDefaultsWouldFailThisTest(t *testing.T) {
 	worst := 0.0
 	for _, sweep := range storedSweeps(t) {
 		for _, group := range sweep.groups() {
-			at, ok := group.nearest(old)
+			at, ok := group.scoreOf(old)
 			if !ok {
 				continue
 			}
-			worst = math.Max(worst, at.MedianMS/group.best().MedianMS-1)
+			worst = math.Max(worst, at/group.best().MedianMS-1)
 		}
 	}
 	if worst <= regretTarget {
@@ -293,42 +299,52 @@ func (g cellGroup) best() schema.Cell {
 	return best
 }
 
-// nearest is the measured cell closest to what the policy chose, per axis,
-// ties going to the larger value. A grid is a handful of powers of two, so the
-// exact choice usually is not on it; the nearest measured neighbour is the
-// closest this replay can get to what the run would have done.
-func (g cellGroup) nearest(s autotune.Settings) (schema.Cell, bool) {
-	conns := axis(g.cells, func(c schema.Cell) int { return c.Connections })
-	return g.cellAt(snap(conns, s.Connections), s)
-}
-
-// snapNote says what a scored row is hiding when the policy's connection count
-// is not on the grid: which cell it was actually scored at, and what the cell
-// below the choice measured.
+// scoreOf is the duration a choice is scored at. A grid is a handful of powers
+// of two, so the exact choice usually is not on it and the replay has to
+// estimate.
 //
-// It is a log line rather than a rule because the replay has no better answer
-// available, but a reader has to know it is reading one. The stored 'mixed'
-// sweep is why: 6 connections on a grid of 1/2/4/8 snapped up to the 8 column
-// and came out 1.3% behind the best cell, while the run really measured at
-// those settings was 30% behind it (issue #217). The bracket makes that gap
-// visible without inventing a number for a coordinate nobody swept.
-func (g cellGroup) snapNote(s autotune.Settings, at schema.Cell) string {
-	conns := axis(g.cells, func(c schema.Cell) int { return c.Connections })
-	if slices.Contains(conns, s.Connections) {
-		return ""
+// It interpolates between the measured cells that bracket the choice, weighted
+// per axis, instead of snapping to the closest measured neighbour. Snapping
+// was optimistic in the one direction that matters for an acceptance test,
+// because ties went up and up is usually the faster column: for the stored
+// "mixed" sweep the policy chose 6 connections, whose measured brackets are 8
+// (12,995 ms) and 4 (17,447 ms), and rounding to 8 scored it at +1.3% where the
+// run really measured at those settings came out +24.8% (issue #228).
+// Interpolating puts it at 15,221 ms, +17%, which is an estimate rather than a
+// measurement but is not one that flatters the policy by construction.
+//
+// A choice that is on the grid is unaffected: it is scored at its own cell.
+// Where a corner of the bracket was not measured, the weights of the corners
+// that were are renormalized, which is the same approximation one axis at a
+// time.
+func (g cellGroup) scoreOf(s autotune.Settings) (float64, bool) {
+	corners := g.bracketCells(s)
+	if len(corners) == 0 {
+		return 0, false
 	}
-	note := fmt.Sprintf("  [%d connections were not swept; scored at %d", s.Connections, at.Connections)
-	if lower, ok := largestBelow(conns, s.Connections); ok {
-		if cell, found := g.cellAt(lower, s); found {
-			note += fmt.Sprintf(", %d took %s", lower, ms(cell.MedianMS))
-		}
+	var sum, weight float64
+	for _, c := range corners {
+		sum += c.weight * c.cell.MedianMS
+		weight += c.weight
 	}
-	return note + "]"
+	if weight == 0 {
+		return 0, false
+	}
+	return sum / weight, true
 }
 
-// cellAt is the measured cell at one connection count, with the other two axes
-// snapped to values the grid has.
-func (g cellGroup) cellAt(connections int, s autotune.Settings) (schema.Cell, bool) {
+// corner is one measured cell of a bracket, with the weight interpolation
+// gives it.
+type corner struct {
+	cell   schema.Cell
+	weight float64
+}
+
+// bracketCells is every measured cell whose coordinates bracket the choice: on
+// each axis either the chosen value itself, when the grid measured it, or the
+// neighbours immediately below and above.
+func (g cellGroup) bracketCells(s autotune.Settings) []corner {
+	conns := axis(g.cells, func(c schema.Cell) int { return c.Connections })
 	concs := axis(g.cells, func(c schema.Cell) int { return c.Concurrency })
 	var requests []int
 	for _, c := range g.cells {
@@ -338,20 +354,86 @@ func (g cellGroup) cellAt(connections int, s autotune.Settings) (schema.Cell, bo
 	}
 	requests = dedup(requests)
 
-	wantConn, wantConc := connections, snap(concs, s.Concurrency)
-	var wantRequest *int
-	if len(requests) > 0 {
-		r := snap(requests, s.RequestConcurrency)
-		wantRequest = &r
+	// A grid pass that set nothing is "default", which is not the same as any
+	// measured number; where the grid swept the axis at all, only its measured
+	// values are candidates.
+	wantRequests := map[*int]float64{}
+	if len(requests) == 0 {
+		wantRequests[nil] = 1
+	} else {
+		for value, w := range bracket(requests, s.RequestConcurrency) {
+			v := value
+			wantRequests[&v] = w
+		}
 	}
+
+	var out []corner
+	for wantConn, wConn := range bracket(conns, s.Connections) {
+		for wantConc, wConc := range bracket(concs, s.Concurrency) {
+			for wantRequest, wRequest := range wantRequests {
+				if c, ok := g.cellExact(wantConn, wantConc, wantRequest); ok {
+					out = append(out, corner{cell: c, weight: wConn * wConc * wRequest})
+				}
+			}
+		}
+	}
+	return out
+}
+
+// bracket is the measured values on one axis that a choice sits between, each
+// with its interpolation weight: the value itself at weight 1 when the grid has
+// it, otherwise the neighbours below and above weighted by how close the
+// choice is to each. A choice outside the swept range has only one neighbour
+// and is scored at it.
+func bracket(values []int, want int) map[int]float64 {
+	if slices.Contains(values, want) {
+		return map[int]float64{want: 1}
+	}
+	lo, hasLo := largestBelow(values, want)
+	hi, hasHi := smallestAbove(values, want)
+	switch {
+	case hasLo && hasHi:
+		span := float64(hi - lo)
+		return map[int]float64{lo: float64(hi-want) / span, hi: float64(want-lo) / span}
+	case hasLo:
+		return map[int]float64{lo: 1}
+	case hasHi:
+		return map[int]float64{hi: 1}
+	default:
+		return map[int]float64{snap(values, want): 1}
+	}
+}
+
+// snapNote says what a scored row is standing in for when the choice is not on
+// the grid: how many measured cells bracket it and how far apart they are. A
+// reader has to be able to see that the number next to it is a bound rather
+// than a measurement of that coordinate.
+func (g cellGroup) snapNote(s autotune.Settings) string {
+	corners := g.bracketCells(s)
+	if len(corners) < 2 {
+		return ""
+	}
+	lo, hi := corners[0].cell.MedianMS, corners[0].cell.MedianMS
+	for _, c := range corners[1:] {
+		lo = math.Min(lo, c.cell.MedianMS)
+		hi = math.Max(hi, c.cell.MedianMS)
+	}
+	return fmt.Sprintf("  [%d/%d/%s was not swept; interpolated between %d measured cells spanning %s to %s]",
+		s.Connections, s.Concurrency, request(s.RequestConcurrency), len(corners), ms(lo), ms(hi))
+}
+
+// cellExact is the measured cell at exactly these coordinates, if the grid has
+// one. A nil request concurrency is the grid pass that set nothing, which is
+// not the same as any measured number.
+func (g cellGroup) cellExact(connections, concurrency int, requestConcurrency *int) (schema.Cell, bool) {
 	for _, c := range g.cells {
-		if c.Connections != wantConn || c.Concurrency != wantConc {
+		if c.Connections != connections || c.Concurrency != concurrency {
 			continue
 		}
-		if (c.RequestConcurrency == nil) != (wantRequest == nil) {
+		if (c.RequestConcurrency == nil) != (requestConcurrency == nil) {
 			continue
 		}
-		if wantRequest != nil && *c.RequestConcurrency != *wantRequest {
+		if requestConcurrency != nil && *c.RequestConcurrency != *requestConcurrency {
 			continue
 		}
 		return c, true
@@ -380,12 +462,23 @@ func dedup(values []int) []int {
 	return out
 }
 
-// largestBelow is the largest measured value strictly under want, which is the
-// neighbour a choice cannot claim the benefit of.
+// largestBelow is the largest measured value strictly under want, and
+// smallestAbove its counterpart: together they are the two neighbours an
+// off-grid choice sits between.
 func largestBelow(values []int, want int) (int, bool) {
 	best, found := 0, false
 	for _, v := range values {
 		if v < want && (!found || v > best) {
+			best, found = v, true
+		}
+	}
+	return best, found
+}
+
+func smallestAbove(values []int, want int) (int, bool) {
+	best, found := 0, false
+	for _, v := range values {
+		if v > want && (!found || v < best) {
 			best, found = v, true
 		}
 	}


### PR DESCRIPTION
Closes #228.

## The problem

`internal/autotune/regret_test.go` reads only sweeps with `repeats >= 3`. The two release sweeps that ran the shipped `auto` policy end to end (`20260821-v3.6.0`, `20260825-v3.7.0`) were stored at 2. So the flagship adaptive policy was being accepted against replayed **pre-policy** grids, while its only live measurements sat in the repo showing `mixed` at 24.77% and `sync` at 22.25%, unexamined.

The second, smaller effect pointed the same way: `nearest` snapped an off-grid connection count to the closest measured column with ties going up, and up is usually the faster column.

## What this changes

**1. A new `recorded_regret_test.go` reads what a sweep recorded about itself.** Every `auto[]` row is printed with the regret that run achieved — a measurement, no replay and no interpolation in it. Sample output:

```
matrix-...-v3.7.0   mixed    measured  +24.8% (  3.132s) at 5/56/64   not enforced: 2 repeats, ...
matrix-...-v3.7.0   sync     measured  +22.2% (   229ms) at 1/3/16    not enforced: 2 repeats, ...
```

A row is also **enforced** when two conditions hold, both about what the number means rather than what is convenient:

- **At least `minRepeats` repeats.** A recorded regret is `median/best - 1`, and its denominator is the fastest of that sweep's own cells. At 2 repeats that is the minimum of ~267 best-of-two medians, biased low — the same reason the replay refuses such a grid. The stored `small` rows are the counter-example that settles it: at concurrency 64 the best connection count is **2** in v3.6.0 (3,893 ms, with 4 at 4,455 ms) and **4** in v3.7.0 (3,907 ms, with 2 at 4,148 ms). That flip is inside the sweeps' own drift, and it is what produces v3.6.0's `small` "27.7% regret". Fixing the repeat count is the companion issue #227; when it lands, every row here becomes enforced with no further change.
- **Today's policy still chooses what the row measured.** A recorded regret describes the settings *that run* picked, and the policy has been refitted since (#230/#258). Holding today's policy to a decision it would no longer make scores the wrong thing. Each row is replayed against the workload and link the row itself recorded, and the comparison is printed either way.

**2. The replay stops snapping optimistically.** `scoreOf` interpolates between the measured cells bracketing the choice, per axis, instead of rounding to the nearest with ties going up. For `mixed`, 6 connections bracket 8 (12,995 ms) and 4 (17,447 ms): the old snap scored +1.3% where the run measured +24.8%; interpolation puts it at +17%. Still an estimate — `snapNote` now prints the span it was estimated across — but not one that flatters the policy by construction.

This is not cosmetic. It moved real numbers in the existing replay, e.g. `sync` on the 3-repeat sweeps from +5.5%/+14.0% to +18.5%/+17.8% (both still passing on the documented 300 ms absolute-gap allowance, on 1.3 s runs).

I also tried the issue's other option, scoring at the **worse** bracket. It is a strict upper bound rather than an estimate, it charges the policy for a coordinate it did not choose, and it fails the existing replay on `small` and `sync`. Interpolation is the honest middle and is what the issue lists first as an alternative.

## Point 4 of the issue: refit or model limit?

The issue asks this to be decided once the test can see the data. From the numbers now printed:

- **`small` — noise, not a defect.** The best connection count flips between adjacent columns across two sweeps of the same scenario on the same host, within the documented ~9% canary spread. v3.6.0's 27.7% is the low-repeat bias, and v3.7.0 measured the same scenario at 3.5%.
- **`sync` — real and consistent.** ~11–22% behind on both the replay (3-repeat grids) and both live sweeps, at settings today's policy still chooses. It passes only because the absolute gap is 130–250 ms on a 1.3 s run, which the documented `trivialGap` rule exempts. Worth a look, but it is not a budget breach by the test's own terms.
- **`mixed` — needs a new measurement, not a verdict.** 29.7% and 24.8% were measured at 6/56/18 and 5/56/64. The refitted prior makes today's policy choose 8/56/16 and 8/56/64 for those same recorded workloads, and 8 is the column the grid says is fastest. Whether that lands is the next release sweep's job to say.

None of that is a constant change, so this PR touches no policy code.

## Also

`CLAUDE.md`'s paragraph on the acceptance test described one file and the old snapping rule; it now describes both halves, the interpolation, and why the second half reports before it gates.

`go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)