### PR TITLE
fix(uploader): harden pool retries and cleanup

### DIFF
--- a/internal/uploader/backoff.go
+++ b/internal/uploader/backoff.go
@@ -1,0 +1,17 @@
+package uploader
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// retryBackoff is exponential backoff with up to 25 percent positive jitter.
+// The retry number starts at one. Positive jitter keeps the established
+// minimum delay while ensuring workers and concurrent jobs which lost the
+// same server do not all retry on the same second boundary.
+func retryBackoff(retry int) time.Duration {
+	retry = max(retry, 1)
+	base := time.Duration(1<<(retry-1)) * time.Second
+	jitterWindow := base / 4
+	return base + time.Duration(rand.Int64N(int64(jitterWindow)+1))
+}

--- a/internal/uploader/cleanup_test.go
+++ b/internal/uploader/cleanup_test.go
@@ -1,0 +1,122 @@
+package uploader
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+)
+
+func TestRetryBackoffUsesExponentialRangeWithJitter(t *testing.T) {
+	for retry := 1; retry <= 5; retry++ {
+		base := time.Duration(1<<(retry-1)) * time.Second
+		for range 20 {
+			got := retryBackoff(retry)
+			if got < base || got > base+base/4 {
+				t.Fatalf("retry %d backoff %s is outside [%s, %s]", retry, got, base, base+base/4)
+			}
+		}
+	}
+}
+
+func TestUploadTempPathHasOneDefinition(t *testing.T) {
+	if got := uploadTempPath("/www/app.js", 42); got != "/www/app.js"+tmpSuffix+".42" {
+		t.Fatalf("upload temp path = %q", got)
+	}
+}
+
+func TestRetryKeepsItsAcquiredConnectionWhenSpreadChanges(t *testing.T) {
+	first := &conn{sftp: &sftp.Client{}}
+	second := &conn{sftp: &sftp.Client{}}
+	sess := &session{conns: []*conn{first, second}, spread: 2}
+
+	_, acquired, _ := sess.acquire(1)
+	if acquired != second {
+		t.Fatal("test setup did not acquire the second connection")
+	}
+	sess.setSpread(1)
+	client, _ := sess.connection(acquired)
+	if client != second.sftp {
+		t.Fatal("captured connection changed after the spread changed")
+	}
+	_, rerouted, _ := sess.acquire(1)
+	if rerouted != first {
+		t.Fatal("test setup did not demonstrate that re-acquiring by index reroutes")
+	}
+}
+
+type keepaliveProbe struct {
+	called  chan bool
+	release chan struct{}
+}
+
+func (p *keepaliveProbe) SendRequest(_ string, wantReply bool, _ []byte) (bool, []byte, error) {
+	p.called <- wantReply
+	if p.release != nil {
+		<-p.release
+	}
+	return false, nil, nil
+}
+
+func TestKeepaliveLoopBoundsBlockedRequestsWithoutDelayingHealthyConnections(t *testing.T) {
+	blocked := &keepaliveProbe{called: make(chan bool, 2), release: make(chan struct{})}
+	healthy := &keepaliveProbe{called: make(chan bool, 2)}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		keepaliveLoop(ctx, func() []keepaliveSender { return []keepaliveSender{blocked, healthy} }, 10*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case wantReply := <-healthy.called:
+		if wantReply {
+			t.Error("keepalive unnecessarily waited for a reply")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("healthy connection was blocked by another connection's keepalive")
+	}
+	if wantReply := <-blocked.called; wantReply {
+		t.Error("blocked keepalive unnecessarily waited for a reply")
+	}
+	select {
+	case <-blocked.called:
+		t.Error("a second keepalive started while the first was blocked")
+	case <-time.After(40 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("keepalive loop did not stop after cancellation")
+	}
+	close(blocked.release)
+}
+
+func TestWriteProgressTicksAfterThePreviousPacket(t *testing.T) {
+	watch := &stallWatchdog{}
+	reader := watch.writeProgress(strings.NewReader("abc"))
+	buf := make([]byte, 1)
+	if _, err := reader.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := watch.ticks.Load(); got != 0 {
+		t.Fatalf("first local read produced %d progress ticks, want none", got)
+	}
+	if _, err := reader.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := watch.ticks.Load(); got != 1 {
+		t.Fatalf("read after the previous write round produced %d ticks, want 1", got)
+	}
+}
+
+func TestSleepCtxStillCancelsJitteredWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := sleepCtx(ctx, retryBackoff(1)); err != context.Canceled {
+		t.Fatalf("cancelled backoff returned %v", err)
+	}
+}

--- a/internal/uploader/connection.go
+++ b/internal/uploader/connection.go
@@ -29,15 +29,48 @@ const keepaliveInterval = 30 * time.Second
 // opens later; interval is a parameter so tests can drive it with a short tick
 // instead of waiting 30s.
 func sendKeepalives(ctx context.Context, clients func() []*ssh.Client, interval time.Duration) {
+	keepaliveLoop(ctx, func() []keepaliveSender {
+		live := clients()
+		senders := make([]keepaliveSender, len(live))
+		for i, client := range live {
+			senders[i] = client
+		}
+		return senders
+	}, interval)
+}
+
+type keepaliveSender interface {
+	SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error)
+}
+
+// keepaliveLoop decouples every connection from every other one. A keepalive
+// is advisory and does not need a reply; sending concurrently means a wedged
+// transport cannot prevent healthy pool members from being pinged. At most one
+// request per connection may be in flight, which also bounds blocked workers.
+func keepaliveLoop(ctx context.Context, clients func() []keepaliveSender, interval time.Duration) {
 	t := time.NewTicker(interval)
 	defer t.Stop()
+	done := make(chan keepaliveSender)
+	inFlight := make(map[keepaliveSender]struct{})
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case client := <-done:
+			delete(inFlight, client)
 		case <-t.C:
-			for _, c := range clients() {
-				_, _, _ = c.SendRequest("keepalive@openssh.com", true, nil)
+			for _, client := range clients() {
+				if _, busy := inFlight[client]; busy {
+					continue
+				}
+				inFlight[client] = struct{}{}
+				go func(client keepaliveSender) {
+					_, _, _ = client.SendRequest("keepalive@openssh.com", false, nil)
+					select {
+					case done <- client:
+					case <-ctx.Done():
+					}
+				}(client)
 			}
 		}
 	}

--- a/internal/uploader/retry.go
+++ b/internal/uploader/retry.go
@@ -32,22 +32,23 @@ func uploadFileWithRetry(ctx context.Context, env *transferEnv, f fileItem, inde
 	doneFile := metrics.Op("file_upload")
 	defer func() { doneFile(err) }()
 	var lastErr error
+	client, c, gen := sess.acquire(index)
 	for attempt := 0; attempt <= retries; attempt++ {
 		if attempt > 0 {
 			metrics.Count("retries", 1)
 			env.progress.failed()
-			backoff := time.Duration(1<<(attempt-1)) * time.Second
+			backoff := retryBackoff(attempt)
 			log.Warningf("retrying upload of %s in %s (attempt %d/%d): %v", f.localPath, backoff, attempt+1, retries+1, lastErr)
 			if err := sleepCtx(ctx, backoff); err != nil {
 				return 0, err
 			}
+			client, gen = sess.connection(c)
 		}
-		client, c, gen := sess.acquire(index)
 		if attempt > 0 {
 			// A previous attempt may have left its temp file behind (a dead
 			// connection cannot run the normal cleanup). Clear it so the
 			// fresh attempt starts from a clean slate; harmless when absent.
-			_ = client.Remove(fmt.Sprintf("%s%s.%d", f.remotePath, tmpSuffix, index))
+			_ = client.Remove(uploadTempPath(f.remotePath, index))
 		}
 		n, err := uploadFile(ctx, env, f, index, mode, client)
 		if err == nil {

--- a/internal/uploader/session.go
+++ b/internal/uploader/session.go
@@ -93,7 +93,7 @@ func newSession(ctx context.Context, cfg *config.Config, tune *tuning, log Logge
 	var lastErr error
 	for attempt := 0; attempt <= cfg.Retries; attempt++ {
 		if attempt > 0 {
-			backoff := time.Duration(1<<(attempt-1)) * time.Second
+			backoff := retryBackoff(attempt)
 			log.Warningf("could not connect; retrying in %s (attempt %d/%d): %v", backoff, attempt+1, cfg.Retries+1, lastErr)
 			if err := sleepCtx(ctx, backoff); err != nil {
 				return nil, err
@@ -320,6 +320,16 @@ func (s *session) acquire(index int) (*sftp.Client, *conn, int) {
 	}
 }
 
+// connection snapshots the current client and generation of the connection a
+// file already acquired. Retries use this instead of routing the file index
+// through a possibly changed spread again, so runtime tuning cannot move a
+// retry away from the connection it just reconnected.
+func (s *session) connection(c *conn) (*sftp.Client, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return c.sftp, c.gen
+}
+
 // dialPooled opens one additional pooled connection with s.mu released, but
 // with at most one handshake in flight for the whole session. That second half
 // is what holding s.mu across the dial used to give and is worth keeping: a
@@ -472,7 +482,7 @@ func (s *session) reconnect(ctx context.Context, c *conn, gen int) (*sftp.Client
 		// The op spans the backoff too: from the run's point of view that wait
 		// is exactly what a dropped connection costs.
 		doneReconnect := metrics.Op("reconnect")
-		backoff := time.Duration(1<<(attempt-1)) * time.Second
+		backoff := retryBackoff(attempt)
 		s.log.Warningf("connection to the server was lost; reconnecting in %s (reconnect %d/%d)", backoff, attempt, s.cfg.Retries)
 		fresh, err := s.redial(ctx, backoff, &dead)
 		doneReconnect(err)

--- a/internal/uploader/sessionlock_test.go
+++ b/internal/uploader/sessionlock_test.go
@@ -70,6 +70,42 @@ func TestCloseSSHRunsDuringAnInFlightReconnect(t *testing.T) {
 	sess.close()
 }
 
+func TestSessionReadsRunDuringAnInFlightPooledDial(t *testing.T) {
+	srv := startTestServer(t, withHangHandshakeAfter(1))
+	cfg := baseConfig(srv)
+	cfg.Connections = 2
+	cfg.Concurrency = 2
+
+	sess, err := newSession(context.Background(), cfg, newTuning(cfg), testLogger{t})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.setSpread(2)
+	acquired := make(chan struct{})
+	go func() {
+		_, _, _ = sess.acquire(1)
+		close(acquired)
+	}()
+	waitFor(t, "the pooled dial to reach the server", func() bool {
+		return atomic.LoadInt32(&srv.accepted) > 1
+	})
+
+	read := make(chan struct{})
+	go func() {
+		_ = sess.liveSSH()
+		close(read)
+	}()
+	select {
+	case <-read:
+	case <-time.After(time.Second):
+		t.Fatal("a session read blocked behind an in-flight pooled handshake")
+	}
+
+	srv.closeLiveConns()
+	<-acquired
+	sess.close()
+}
+
 // TestConcurrentReconnectsCollapseIntoOne pins the behaviour session.do
 // documents and that used to fall out of holding the mutex across the redial:
 // workers that all fail on the same connection cost one reconnect between

--- a/internal/uploader/staletemp_test.go
+++ b/internal/uploader/staletemp_test.go
@@ -310,6 +310,32 @@ func TestSweepRunsForSyncUploads(t *testing.T) {
 	}
 }
 
+func TestSweepReachesPlannedDirectoryWithNoChangedFiles(t *testing.T) {
+	shrinkStaleTempMaxAge(t)
+
+	srv := startTestServer(t)
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{
+		"index.html":       "1",
+		"assets/deep/a.js": "unchanged",
+	})
+	cfg := syncConfig(srv, local)
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+
+	orphan := "/www/assets/deep/old.js" + tmpSuffix + ".42"
+	writeRemoteFile(t, srv.verifyClient(t), orphan, "partial")
+	// No local file changed. The upload subset is empty, but the deployment's
+	// full planned directory set still reaches assets/deep.
+	if _, err := Run(context.Background(), cfg, testLogger{t}); err != nil {
+		t.Fatal(err)
+	}
+	if remoteExists(t, srv, orphan) {
+		t.Error("stale temp file survived in a planned directory with no changed files")
+	}
+}
+
 // Dry runs must not delete anything, orphaned temp files included.
 func TestSweepSkippedInDryRun(t *testing.T) {
 	shrinkStaleTempMaxAge(t)

--- a/internal/uploader/stall.go
+++ b/internal/uploader/stall.go
@@ -10,7 +10,7 @@ import (
 
 // stallWatchdog fails a run fast when its active transfers stop making
 // progress. Transfers mark themselves active for the duration of each upload
-// attempt and tick the watchdog on every read that moved bytes. A monitor
+// attempt and tick the watchdog after a remote write round completes. A monitor
 // goroutine fires when transfers are active but no tick arrived for the
 // configured timeout; firing closes the run's SSH connections, which unblocks
 // every SFTP operation stuck on the stalled server with an error, so the run
@@ -90,18 +90,26 @@ func (w *stallWatchdog) monitor() {
 	}
 }
 
-// reader wraps r so that every read that moved bytes counts as progress.
-func (w *stallWatchdog) reader(r io.Reader) io.Reader { return &tickReader{w: w, r: r} }
-
-type tickReader struct {
-	w *stallWatchdog
-	r io.Reader
+// writeProgress wraps the source with a one-read lag. uploadFile deliberately
+// passes a reader without Size/Len/Stat to pkg/sftp, which keeps its ReadFrom
+// loop sequential: it asks for the next packet only after the previous remote
+// write completed. Ticking before that next read therefore records server-side
+// progress, while ticking on the first local read would not.
+func (w *stallWatchdog) writeProgress(r io.Reader) io.Reader {
+	return &writeProgressReader{w: w, r: r}
 }
 
-func (t *tickReader) Read(p []byte) (int, error) {
-	n, err := t.r.Read(p)
-	if n > 0 {
-		t.w.ticks.Add(1)
+type writeProgressReader struct {
+	w       *stallWatchdog
+	r       io.Reader
+	pending bool
+}
+
+func (r *writeProgressReader) Read(p []byte) (int, error) {
+	if r.pending {
+		r.w.tick()
 	}
+	n, err := r.r.Read(p)
+	r.pending = n > 0
 	return n, err
 }

--- a/internal/uploader/sync.go
+++ b/internal/uploader/sync.go
@@ -157,7 +157,7 @@ func executeSync(ctx context.Context, cfg *config.Config, sess *session, p plan,
 	// goes along with the changed subset because the stale-temp sweep must not
 	// remove an unchanged planned target that happens to be named like a temp
 	// file; see uploadFiles and issue #186.
-	completed, err := uploadFiles(ctx, cfg, sess, upload, p.files, dirs, base, stats, verb, watch, false, log)
+	completed, err := uploadFiles(ctx, cfg, sess, upload, p.files, dirs, p.remoteDirs, base, stats, verb, watch, false, log)
 	if err != nil {
 		writeRecoveryManifest(ctx, cfg, sess, watch, base, mergedManifest(old, upload, completed, nil), log)
 		return err

--- a/internal/uploader/transfer.go
+++ b/internal/uploader/transfer.go
@@ -25,6 +25,10 @@ import (
 // rename stays on one filesystem and is atomic.
 const tmpSuffix = ".easysftp-tmp"
 
+func uploadTempPath(remotePath string, index int) string {
+	return fmt.Sprintf("%s%s.%d", remotePath, tmpSuffix, index)
+}
+
 // bakSuffix names the short-lived copy of the live file that the non-atomic
 // publish path parks the target under while it renames the upload into place.
 // It sits inside the tmpSuffix family on purpose, so isTempFileName recognises
@@ -70,13 +74,14 @@ type transferEnv struct {
 // planned is the deployment's full plan, which is the same slice as files for
 // overlay and clean but a superset of it for sync (which narrows the upload to
 // the changed files). Only the stale-temp sweep needs the difference: the
-// directories it visits follow what is being uploaded, but the targets it must
-// not remove are every planned one. See sweepStaleTemps and issue #186.
+// directories it visits are the deployment's full planned directory set, and
+// the targets it must not remove are every planned one. See sweepStaleTemps
+// and issues #186 and #244.
 //
 // It returns which files completed, indexed like files, so that on a partial
 // failure the caller knows what actually made it to the server (the sync
 // strategy uses this to persist a recovery manifest).
-func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, planned []fileItem, dirs []string, base string, stats *Stats, verb string, watch *stallWatchdog, skipUnchanged bool, log Logger) ([]bool, error) {
+func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, planned []fileItem, dirs, sweepDirs []string, base string, stats *Stats, verb string, watch *stallWatchdog, skipUnchanged bool, log Logger) ([]bool, error) {
 	// Declared before the first failure point: callers index the returned
 	// slice by file, so it must be sized even when nothing was uploaded.
 	completed := make([]bool, len(files))
@@ -93,10 +98,10 @@ func uploadFiles(ctx context.Context, cfg *config.Config, sess *session, files, 
 		}
 
 		// Before any upload starts, remove temp files that an earlier killed
-		// run left in the directories this run uploads into; see
+		// run left anywhere in the deployment's planned directory tree; see
 		// sweepStaleTemps.
 		endSweep := metrics.Phase("sweep_stale_temps")
-		sweepStaleTemps(ctx, sess, watch, base, files, planned, log)
+		sweepStaleTemps(ctx, sess, watch, base, sweepDirs, planned, log)
 		endSweep()
 	}
 
@@ -232,7 +237,7 @@ func uploadFile(ctx context.Context, env *transferEnv, f fileItem, index int, mo
 	// The four round-trips below (open, write, chmod, rename) are sampled
 	// separately: in the small-file scenario the payload is a rounding error
 	// and the question is which of them the run is really spending its time in.
-	tmpPath := fmt.Sprintf("%s%s.%d", f.remotePath, tmpSuffix, index)
+	tmpPath := uploadTempPath(f.remotePath, index)
 	doneOpen := metrics.Op("sftp_open")
 	dst, err := client.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
 	doneOpen(err)
@@ -244,7 +249,7 @@ func uploadFile(ctx context.Context, env *transferEnv, f fileItem, index int, mo
 	// instead of streaming a whole large file first.
 	var reader io.Reader = &ctxReader{ctx: ctx, r: src}
 	if watch != nil {
-		reader = watch.reader(reader)
+		reader = watch.writeProgress(reader)
 	}
 	doneWrite := metrics.Op("sftp_write")
 	n, err := io.Copy(dst, reader)
@@ -463,13 +468,13 @@ func isTempFileName(name string) bool {
 // deletes a file it did not just write, so the orphans would otherwise sit in
 // the target forever, publicly served when the target is a web root.
 //
-// The swept set is exactly the directories that receive files this run (the
-// parent directory of every uploaded remote path) plus the deployment's remote
-// base, where the sync manifest's temp file lives even when no changed file
-// does. Nothing above the base is ever listed or touched: a deploy to
-// /var/www/html/blog has no business reading /var. That keeps the added
-// round-trips proportional to the run and the sweep's reach inside the
-// deployment.
+// The swept set is the deployment's full planned directory tree plus its
+// remote base, where the sync manifest's temp file lives even when no changed
+// file does. This deliberately reaches a directory whose files are unchanged:
+// otherwise debris from an interrupted run stays there forever. Nothing above
+// the base is ever listed or touched: a deploy to /var/www/html/blog has no
+// business reading /var. The extra listings buy complete cleanup inside the
+// tree and remain bounded by the plan.
 //
 // Three guards bound what the sweep may remove: the name must match the temp
 // pattern (isTempFileName), the entry must be older than staleTempMaxAge (a
@@ -498,20 +503,24 @@ func isTempFileName(name string) bool {
 // connection redials. A listing or removal failure only warns and never fails
 // the deploy. Removals are logged, so a user who wondered what those files were
 // gets an answer.
-func sweepStaleTemps(ctx context.Context, sess *session, watch *stallWatchdog, base string, files, planned []fileItem, log Logger) {
+func sweepStaleTemps(ctx context.Context, sess *session, watch *stallWatchdog, base string, plannedDirs []string, planned []fileItem, log Logger) {
 	keep := make(map[string]struct{}, len(planned))
 	for _, f := range planned {
 		keep[f.remotePath] = struct{}{}
 	}
-	touched := make(map[string]struct{}, len(files)+1)
+	touched := make(map[string]struct{}, len(plannedDirs)+1)
 	// A single-file overlay deploy without a trailing slash resolves base to
 	// the planned file itself, not a directory; its parent joins the set via
 	// path.Dir below, so the file path is skipped here.
-	if _, isPlannedFile := keep[base]; !isPlannedFile {
-		touched[base] = struct{}{}
+	sweepBase := base
+	if _, isPlannedFile := keep[base]; isPlannedFile {
+		sweepBase = path.Dir(base)
 	}
-	for _, f := range files {
-		touched[path.Dir(f.remotePath)] = struct{}{}
+	touched[sweepBase] = struct{}{}
+	for _, dir := range plannedDirs {
+		if dir == sweepBase || strings.HasPrefix(dir, strings.TrimSuffix(sweepBase, "/")+"/") {
+			touched[dir] = struct{}{}
+		}
 	}
 	dirs := make([]string, 0, len(touched))
 	for dir := range touched {

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -243,7 +243,6 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 		if err := checkRemoteRoot(p.pair.Remote); err != nil {
 			return err
 		}
-		var files, dirs []string
 		endRemoteScan := metrics.Phase("remote_scan")
 		files, dirs, err := listRemoteContents(ctx, sess, base, watch, log)
 		endRemoteScan()
@@ -272,7 +271,7 @@ func executeOverlayOrClean(ctx context.Context, cfg *config.Config, sess *sessio
 	skipUnchanged := cfg.SkipUnchanged && p.strategy == config.StrategyOverlay
 	// Overlay and clean upload the whole plan, so the uploaded set and the
 	// planned set are the same slice.
-	_, err := uploadFiles(ctx, cfg, sess, p.files, p.files, p.remoteDirs, base, stats, verb, watch, skipUnchanged, log)
+	_, err := uploadFiles(ctx, cfg, sess, p.files, p.files, p.remoteDirs, p.remoteDirs, base, stats, verb, watch, skipUnchanged, log)
 	return err
 }
 


### PR DESCRIPTION
Closes #244

## Summary

- retain the pooled-dial liveness behavior already present on the current base and add a regression test proving session reads continue during an in-flight handshake
- use one exponential backoff implementation with positive jitter for connect, reconnect, and upload retries
- keep a file retry on its originally acquired connection even if runtime tuning changes the pool spread
- sweep stale temp files throughout the full planned deployment tree while remaining confined to the deployment base
- send reply-free keepalives independently, with at most one in-flight request per connection
- make watchdog progress represent completion of the preceding SFTP write round
- centralize temp-path construction and remove the shadowed clean-mode declarations

## Verification

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

New tests cover pooled-dial liveness, jitter bounds, stable retry routing, bounded keepalives, write-progress timing, cancellation, and stale cleanup in unchanged planned directories. The local Windows environment cannot start `-race` without CGO/GCC, so CI's Linux race job is the race-detector gate.