### PR TITLE
fix(tuning): preserve cache evidence across concurrent runs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,7 +294,10 @@ number you wrote always wins. A missing, unreadable or outdated file costs at
 most a warning, never the deploy. [Transfer
 tuning](tuning.md#remembering-what-it-measured) explains what is stored, what
 is restored (a measurement, never a decision) and when a record stops being
-used.
+used. The path is trusted configuration and is not a filesystem sandbox;
+normally keep it under the workspace or the runner's temporary directory.
+Concurrent runs may share one path: write-back is serialized and merges the
+latest records instead of replacing another run's update.
 
 #### `permissions`
 

--- a/internal/autocache/store.go
+++ b/internal/autocache/store.go
@@ -6,12 +6,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // fileMode is what the cache file is created with. It holds no secrets (the
 // target is a fingerprint, see Record.Target), but it describes somebody's
 // deployment and there is no reason for it to be world readable.
 const fileMode = 0o600
+
+const (
+	lockWait  = 3 * time.Second
+	lockStale = 10 * time.Minute
+	lockPoll  = 25 * time.Millisecond
+)
 
 // ErrEmpty reports a path that holds no usable store yet: the file does not
 // exist, or it is empty. It is the normal state of a first run and the caller
@@ -64,6 +71,36 @@ func Save(path string, s *Store) error {
 	if path == "" || s == nil {
 		return nil
 	}
+	return withStoreLock(path, func() error { return saveUnlocked(path, s) })
+}
+
+// UpdateFile serializes one run's read-modify-write with every other process
+// using the same cache path. Reloading after the lock is acquired is the
+// important part: each writer merges its observation into the records the
+// previous writer just committed instead of replacing the whole document it
+// happened to read at startup.
+func UpdateFile(path string, obs Observation, at time.Time) (bool, error) {
+	if path == "" {
+		return false, nil
+	}
+	changed := false
+	err := withStoreLock(path, func() error {
+		store, loadErr := Load(path)
+		if loadErr != nil && !errors.Is(loadErr, ErrEmpty) {
+			// The caller already warned when it read this unusable file. A fresh
+			// valid store is the recoverable outcome at write-back time.
+			store = &Store{Version: FormatVersion}
+		}
+		changed = store.Update(obs, at)
+		if !changed {
+			return nil
+		}
+		return saveUnlocked(path, store)
+	})
+	return changed, err
+}
+
+func saveUnlocked(path string, s *Store) error {
 	if dir := filepath.Dir(path); dir != "" && dir != "." {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err
@@ -93,4 +130,48 @@ func Save(path string, s *Store) error {
 		return err
 	}
 	return os.Rename(name, path)
+}
+
+// withStoreLock is a small cross-platform lock built from O_EXCL. The lock is
+// held only around a tiny JSON read and atomic write. A killed process can
+// leave the sidecar behind, so an old lock is recoverable; a fresh lock that
+// does not clear within lockWait costs a cache warning, never the deploy.
+func withStoreLock(path string, fn func() error) error {
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	lockPath := path + ".lock"
+	deadline := time.Now().Add(lockWait)
+	for {
+		lock, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fileMode)
+		if err == nil {
+			name := lock.Name()
+			if _, writeErr := fmt.Fprintf(lock, "%d\n", os.Getpid()); writeErr != nil {
+				lock.Close()
+				os.Remove(name)
+				return writeErr
+			}
+			if closeErr := lock.Close(); closeErr != nil {
+				os.Remove(name)
+				return closeErr
+			}
+			defer os.Remove(name)
+			return fn()
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > lockStale {
+			if removeErr := os.Remove(lockPath); removeErr == nil || errors.Is(removeErr, os.ErrNotExist) {
+				continue
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for concurrent cache writer at %s", lockPath)
+		}
+		time.Sleep(lockPoll)
+	}
 }

--- a/internal/autocache/store_test.go
+++ b/internal/autocache/store_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -38,6 +39,57 @@ func TestRoundTrip(t *testing.T) {
 	b.MeasuredAt, b.LastUsed = time.Time{}, time.Time{}
 	if a != b {
 		t.Errorf("record changed on the way through the file:\n got %+v\nwant %+v", b, a)
+	}
+}
+
+func TestConcurrentUpdateFileMergesEveryWriter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auto.json")
+	const writers = 6
+	start := make(chan struct{})
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, err := UpdateFile(path, Observation{
+				Target:   string(rune('a' + i)),
+				Workload: mediumTree(),
+				Link:     measuredLink(),
+				Measured: true,
+			}, time.Date(2026, 8, 30, i, 0, 0, 0, time.UTC))
+			errs <- err
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	store, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(store.Records) != writers {
+		t.Fatalf("concurrent writers left %d records, want %d: %+v", len(store.Records), writers, store.Records)
+	}
+	seen := map[string]bool{}
+	for _, record := range store.Records {
+		seen[record.Target] = true
+	}
+	for i := 0; i < writers; i++ {
+		target := string(rune('a' + i))
+		if !seen[target] {
+			t.Errorf("record %q was lost", target)
+		}
+	}
+	if _, err := os.Stat(path + ".lock"); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("lock sidecar survived the writers: %v", err)
 	}
 }
 

--- a/internal/autotune/autotune.go
+++ b/internal/autotune/autotune.go
@@ -315,9 +315,8 @@ const (
 	// has been observed. It is what the whole policy starts from.
 	SourcePrior Source = iota
 	// SourceCached is an observation carried over from an earlier run with a
-	// similar workload and link (issue #212). easySFTP does not produce these
-	// yet; Link accepts them so the policy that consumes one is written and
-	// tested before the cache exists.
+	// similar workload and link (issue #212). It is validated against the
+	// current workload and freshly measured RTT before the policy consumes it.
 	SourceCached
 	// SourceRuntime is what this transfer is achieving right now, which is the
 	// only evidence that describes the run being tuned.

--- a/internal/autotune/controller.go
+++ b/internal/autotune/controller.go
@@ -458,7 +458,10 @@ func (c *Controller) remaining(p Progress) Workload {
 	}
 	largest := int64(0)
 	if uploads > 0 {
-		largest = bytes / int64(uploads)
+		// Progress does not identify which individual files remain. Preserve
+		// the plan's largest-file bound instead of silently replacing it with
+		// the mean, capped only by all bytes still left to upload.
+		largest = min(c.workload.LargestUpload, bytes)
 	}
 	// The shape carries over from the plan: which files are left is not known,
 	// but nothing observed so far suggests they are shaped differently from

--- a/internal/autotune/remaining_internal_test.go
+++ b/internal/autotune/remaining_internal_test.go
@@ -1,0 +1,21 @@
+package autotune
+
+import "testing"
+
+func TestRemainingPreservesLargestUploadInsteadOfMean(t *testing.T) {
+	const mib = int64(1024 * 1024)
+	c := &Controller{workload: Workload{
+		Uploads: 100, UploadBytes: 107 * mib,
+		LargestUpload: 8 * mib, P50Upload: mib, P90Upload: mib,
+	}}
+
+	remaining := c.remaining(Progress{Uploaded: 90, Remaining: 10, RemainingBytes: 17 * mib})
+	if remaining.LargestUpload != 8*mib {
+		t.Fatalf("LargestUpload = %d, want the planned maximum %d instead of the mean %d", remaining.LargestUpload, 8*mib, remaining.UploadBytes/int64(remaining.Uploads))
+	}
+
+	remaining = c.remaining(Progress{Uploaded: 99, Remaining: 1, RemainingBytes: 2 * mib})
+	if remaining.LargestUpload != 2*mib {
+		t.Fatalf("LargestUpload = %d, want it capped by the %d remaining bytes", remaining.LargestUpload, 2*mib)
+	}
+}

--- a/internal/uploader/autocache.go
+++ b/internal/uploader/autocache.go
@@ -143,14 +143,15 @@ func (c *autoCache) save(obs autocache.Observation, log Logger, debug bool) {
 	}
 	obs.Target = c.target
 	obs.Reused = c.decision.Hit
-	if !c.store.Update(obs, time.Now()) {
+	changed, err := autocache.UpdateFile(c.path, obs, time.Now())
+	if err != nil {
+		log.Warningf("could not write the auto-tuning cache at %s (%v); the next run plans from easySFTP's own assumptions", c.path, err)
+		return
+	}
+	if !changed {
 		if debug {
 			log.Infof("auto tuning: the cache at %s already says everything this run learned", c.path)
 		}
-		return
-	}
-	if err := autocache.Save(c.path, c.store); err != nil {
-		log.Warningf("could not write the auto-tuning cache at %s (%v); the next run plans from easySFTP's own assumptions", c.path, err)
 		return
 	}
 	if debug {

--- a/internal/uploader/autocache_test.go
+++ b/internal/uploader/autocache_test.go
@@ -250,6 +250,20 @@ func TestCacheObservationReadsTheServersAnswer(t *testing.T) {
 		}
 	})
 
+	t.Run("small deploy still carries an inherited ceiling", func(t *testing.T) {
+		tune := newTuning(adaptive())
+		tune.setLink(autotune.Link{RTT: 13 * time.Millisecond, Handshake: 360 * time.Millisecond})
+		tune.applyCache(autocache.Decision{Hit: true, ConnectionCeiling: 4})
+		// One small file plans one connection, so the inherited ceiling never
+		// has to clamp it. That makes the ceiling untested, not disproved.
+		tune.planFor(autotune.SummarizeUploads([]int64{4096}))
+
+		obs := tune.cacheObservation(work, 1, false)
+		if obs.ConnectionCeiling != 0 || !obs.CeilingUntested {
+			t.Errorf("obs = %+v, want the unused inherited ceiling carried as untested", obs)
+		}
+	})
+
 	t.Run("nothing pushed back", func(t *testing.T) {
 		tune := newTuning(adaptive())
 		obs := tune.cacheObservation(work, 4, false)

--- a/internal/uploader/tuning.go
+++ b/internal/uploader/tuning.go
@@ -64,12 +64,10 @@ type tuning struct {
 	// ceiling is an upper bound on the pool that came from an earlier run
 	// against this server: it refused a connection, or a growth step
 	// measurably did not pay. Zero is the normal case and means the policy is
-	// free up to its own maximum. capped latches when the bound actually held
-	// something back, which is what tells the write-back that this run did
-	// not put the limit to the test (issue #212, and see
-	// autocache.MaxCeilingCarry).
+	// free up to its own maximum. Every run that inherits the ceiling but sees
+	// no fresh pushback carries it as untested, even when a small deploy never
+	// asked enough of the pool for the ceiling to clamp a decision (issue #246).
 	ceiling int
-	capped  bool
 
 	// observed is what this run's own transfers measured about the link, per
 	// connection, and observedBytes the size of the transfer that produced it.
@@ -222,7 +220,6 @@ func (t *tuning) clampLocked(n int) int {
 	if t.fixed.Connections > 0 || t.ceiling <= 0 || n <= t.ceiling {
 		return n
 	}
-	t.capped = true
 	return t.ceiling
 }
 
@@ -270,7 +267,7 @@ func (t *tuning) cacheObservation(runWork autotune.Workload, granted int, refuse
 		obs.ConnectionCeiling = max(granted, 1)
 	case t.spreadDown > 0:
 		obs.ConnectionCeiling = max(t.finalSpread, 1)
-	case t.capped:
+	case t.ceiling > 0:
 		obs.CeilingUntested = true
 	}
 	return obs


### PR DESCRIPTION
Closes #246

## Summary

- preserve the remaining workload's largest-file bound instead of replacing it with the mean
- carry an inherited connection ceiling as untested whenever a run produces no new ceiling evidence, including small deployments that never reach it
- serialize cache read-modify-write across processes with a short-lived sidecar lock and atomic replacement
- reload under the lock so concurrent jobs merge observations rather than lose the earlier writer
- recover stale locks and keep cache failures non-fatal
- correct the stale cache-source comment and document that the configured cache path is trusted state

## Verification

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

The test suite includes concurrent writers with distinct targets, lock cleanup, remaining-workload bounds, and ceiling carry-through. The local Windows environment cannot start `-race` without CGO/GCC, so CI's Linux race job is the race-detector gate.