### PR TITLE
feat(auth): support keyboard-interactive passwords

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,10 @@ inputs:
     required: false
   password:
     description: >-
-      Password used for authentication. Provide this or private-key (or both).
-      Always store this in a GitHub Actions secret. As a credential, this
-      input is used in both inline and config mode.
+      Password used for password or single-prompt keyboard-interactive
+      authentication. Provide this or private-key (or both). Always store this
+      in a GitHub Actions secret. As a credential, this input is used in both
+      inline and config mode.
     required: false
   private-key:
     description: >-
@@ -124,8 +125,9 @@ inputs:
     required: false
   proxy-password:
     description: >-
-      Password for the jump host defined as connection.proxy in the config
-      file. Always store this in a GitHub Actions secret.
+      Password for password or single-prompt keyboard-interactive
+      authentication to the jump host defined as connection.proxy in the
+      config file. Always store this in a GitHub Actions secret.
     required: false
   proxy-private-key:
     description: >-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ Everything else has a sensible default.
 | `host` | ✅ | - | Hostname or IP of the SFTP server. |
 | `port` | | `22` | SSH port. |
 | `username` | ✅ | - | Username for authentication. |
-| `password` | ¹ | - | Password. **Use a secret.** |
+| `password` | ¹ | - | Password, offered through SSH password and single-prompt keyboard-interactive authentication. **Use a secret.** |
 | `private-key` | ¹ | - | SSH private key (OpenSSH/PEM format). **Use a secret.** |
 | `passphrase` | | - | Passphrase of the private key, if encrypted. |
 | `host-key` | ² | - | Expected SHA256 host key fingerprint(s), one per line (`SHA256:...`). See [Security](security.md). |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -81,8 +81,10 @@ The server rejected the credentials.
 
 - Verify the secret names in your workflow match the configured secrets
   (a missing secret silently expands to an empty string).
-- Password auth: some servers disable it entirely (`PasswordAuthentication no`);
-  use a key instead.
+- A configured password is offered through both SSH password authentication
+  and a single hidden keyboard-interactive prompt. Servers that require an
+  additional interactive secret such as a TOTP code cannot be used from an
+  unattended job; use a deploy key or a dedicated CI account instead.
 - Key auth: the key must be in OpenSSH or PEM format. If it is encrypted, set
   `passphrase`. Check that the *public* key is in the server's
   `authorized_keys`.

--- a/internal/uploader/connection.go
+++ b/internal/uploader/connection.go
@@ -250,6 +250,43 @@ func authMethods(h hop) ([]ssh.AuthMethod, error) {
 	}
 	if h.password != "" {
 		methods = append(methods, ssh.Password(h.password))
+		methods = append(methods, ssh.KeyboardInteractive(passwordChallenge(h.password)))
 	}
 	return methods, nil
+}
+
+// passwordChallenge covers servers that disable the SSH "password" method
+// but ask for the same password through keyboard-interactive. A single round
+// may include visible informational questions; those receive an empty answer
+// so a secret is never echoed. A second secret round is genuine interactive
+// authentication (commonly a TOTP prompt), which an unattended action cannot
+// satisfy safely.
+func passwordChallenge(password string) ssh.KeyboardInteractiveChallenge {
+	answeredSecret := false
+	return func(_ string, _ string, questions []string, echos []bool) ([]string, error) {
+		if len(questions) != len(echos) {
+			return nil, fmt.Errorf("keyboard-interactive authentication returned %d questions and %d echo flags", len(questions), len(echos))
+		}
+
+		answers := make([]string, len(questions))
+		secretQuestions := 0
+		for _, echo := range echos {
+			if !echo {
+				secretQuestions++
+			}
+		}
+		if secretQuestions == 0 {
+			return answers, nil
+		}
+		if answeredSecret || secretQuestions > 1 {
+			return nil, fmt.Errorf("server requested additional keyboard-interactive secrets; unattended easySFTP supports one password prompt only")
+		}
+		for i, echo := range echos {
+			if !echo {
+				answers[i] = password
+			}
+		}
+		answeredSecret = true
+		return answers, nil
+	}
 }

--- a/internal/uploader/keyboardinteractive_test.go
+++ b/internal/uploader/keyboardinteractive_test.go
@@ -1,0 +1,50 @@
+package uploader
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+func TestKeyboardInteractivePasswordUpload(t *testing.T) {
+	srv := startTestServer(t, withKeyboardInteractiveOnly())
+	local := t.TempDir()
+	writeTree(t, local, map[string]string{"index.html": "keyboard interactive"})
+
+	cfg := baseConfig(srv)
+	cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+	stats, err := Run(context.Background(), cfg, testLogger{t})
+	if err != nil {
+		t.Fatalf("upload through keyboard-interactive authentication failed: %v", err)
+	}
+	if stats.FilesUploaded != 1 {
+		t.Fatalf("uploaded files: got %d, want 1", stats.FilesUploaded)
+	}
+}
+
+func TestPasswordChallengeDoesNotLeakOrReusePassword(t *testing.T) {
+	challenge := passwordChallenge("correct horse battery staple")
+
+	answers, err := challenge("server", "", []string{"Password: ", "Account: "}, []bool{false, true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(answers) != 2 || answers[0] != "correct horse battery staple" || answers[1] != "" {
+		t.Fatalf("unexpected answers: %#v", answers)
+	}
+
+	_, err = challenge("server", "", []string{"Verification code: "}, []bool{false})
+	if err == nil || !strings.Contains(err.Error(), "one password prompt only") {
+		t.Fatalf("additional secret prompt error: got %v", err)
+	}
+}
+
+func TestPasswordChallengeRejectsMultipleSecretQuestions(t *testing.T) {
+	challenge := passwordChallenge("secret")
+	_, err := challenge("server", "", []string{"Password: ", "Token: "}, []bool{false, false})
+	if err == nil || !strings.Contains(err.Error(), "one password prompt only") {
+		t.Fatalf("multiple secret prompt error: got %v", err)
+	}
+}

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -67,6 +67,29 @@ func (s *testServer) closeLiveConns() {
 // serverOption tweaks a testServer before it starts serving.
 type serverOption func(*testServer)
 
+// withKeyboardInteractiveOnly models the common sshd configuration with
+// PasswordAuthentication disabled and KbdInteractiveAuthentication enabled.
+// The server accepts exactly one hidden password prompt.
+func withKeyboardInteractiveOnly() serverOption {
+	return func(s *testServer) {
+		s.sshConfig.PasswordCallback = nil
+		s.sshConfig.PublicKeyCallback = nil
+		s.sshConfig.KeyboardInteractiveCallback = func(conn ssh.ConnMetadata, challenge ssh.KeyboardInteractiveChallenge) (*ssh.Permissions, error) {
+			if conn.User() != testUser {
+				return nil, errors.New("access denied")
+			}
+			answers, err := challenge("easySFTP test", "Password authentication", []string{"Password: "}, []bool{false})
+			if err != nil {
+				return nil, err
+			}
+			if len(answers) != 1 || answers[0] != testPassword {
+				return nil, errors.New("access denied")
+			}
+			return nil, nil
+		}
+	}
+}
+
 // faultyOpen rejects reads of one exact path while delegating every other
 // request to the in-memory handler.
 type faultyOpen struct {


### PR DESCRIPTION
Closes #150

## Summary

- offer keyboard-interactive alongside SSH password authentication whenever a password is configured
- answer exactly one non-echoed secret prompt with that password
- leave echoed informational prompts empty so secrets are not reflected
- fail safely when a server asks for multiple secrets or a later OTP/TOTP round
- document the unattended single-password boundary in action metadata and troubleshooting guidance

## Verification

- actual upload against a test SSH server that only permits keyboard-interactive authentication
- callback tests for echoed prompts, repeated secret rounds, and multiple secret questions
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `scripts/test-action.sh` under Git Bash
- `git diff --check`

The local Windows environment cannot start `-race` without CGO/GCC, so CI's Linux race job is the race-detector gate.