### PR TITLE
feat(ssh): allow explicit legacy algorithms

### DIFF
--- a/cmd/easysftp/main.go
+++ b/cmd/easysftp/main.go
@@ -102,6 +102,16 @@ func hostKeyStatus(cfg *config.Config) string {
 	return status
 }
 
+func algorithmStatus(cfg *config.Config) string {
+	if len(cfg.Algorithms.Insecure) > 0 {
+		return "⚠️ insecure additions allowed: `" + strings.Join(cfg.Algorithms.Insecure, "`, `") + "`"
+	}
+	if cfg.Algorithms.Configured() {
+		return "explicit supported additions"
+	}
+	return "library defaults"
+}
+
 func logBuildInfo() {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
@@ -180,8 +190,8 @@ func reportStats(cfg *config.Config, stats *uploader.Stats, mode string, runErr 
 		configSource = fmt.Sprintf("`%s` (version 3)", cfg.ConfigPath)
 	}
 	summary := fmt.Sprintf(
-		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Host key | %s |\n| Configuration | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Directories removed | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %s |\n| Duration | %s |\n",
-		status, hostKeyStatus(cfg), configSource, mode, stats.FilesUploaded, stats.FilesDeleted, stats.DirsDeleted, stats.FilesSkipped, humanBytes(stats.BytesUploaded), stats.Duration.Round(time.Millisecond))
+		"### easySFTP\n\n| Metric | Value |\n|---|---|\n| Status | %s |\n| Host key | %s |\n| SSH algorithms | %s |\n| Configuration | %s |\n| Files %s | %d |\n| Files deleted | %d |\n| Directories removed | %d |\n| Files skipped (unchanged) | %d |\n| Bytes transferred | %s |\n| Duration | %s |\n",
+		status, hostKeyStatus(cfg), algorithmStatus(cfg), configSource, mode, stats.FilesUploaded, stats.FilesDeleted, stats.DirsDeleted, stats.FilesSkipped, humanBytes(stats.BytesUploaded), stats.Duration.Round(time.Millisecond))
 	summary += deploymentBreakdown(stats.Deployments)
 	gha.AppendSummary(summary)
 }

--- a/cmd/easysftp/main_test.go
+++ b/cmd/easysftp/main_test.go
@@ -154,6 +154,7 @@ func TestReportStatsOnFailure(t *testing.T) {
 	for _, want := range []string{
 		"| Status | ❌ Failed after 3 file(s), 2.0 KiB (2,048 bytes) |",
 		"| Host key | ✅ pinned |",
+		"| SSH algorithms | library defaults |",
 		"| Configuration | inline inputs |",
 		"| Files uploaded | 3 |",
 		"| Files deleted | 1 |",
@@ -164,6 +165,16 @@ func TestReportStatsOnFailure(t *testing.T) {
 		if !strings.Contains(string(summary), want) {
 			t.Errorf("summary does not contain %q:\n%s", want, summary)
 		}
+	}
+}
+
+func TestAlgorithmStatusReportsInsecureAdditions(t *testing.T) {
+	cfg := &config.Config{Algorithms: config.SSHAlgorithms{
+		KeyExchanges: []string{"diffie-hellman-group1-sha1"},
+		Insecure:     []string{"diffie-hellman-group1-sha1"},
+	}}
+	if got := algorithmStatus(cfg); !strings.Contains(got, "diffie-hellman-group1-sha1") || !strings.Contains(got, "insecure") {
+		t.Fatalf("algorithm status: %q", got)
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,11 @@ connection:
   # known_hosts: |             # alternative to host_key
   #   sftp.example.com ssh-ed25519 AAAA...
   # allow_any_host_key: true   # explicit opt-out (not recommended)
+  # algorithms:                # legacy-server escape hatch; warns when insecure
+  #   key_exchanges: [diffie-hellman-group1-sha1]
+  #   ciphers: [aes128-cbc]
+  #   macs: [hmac-sha1-96]
+  #   host_key_algorithms: [ssh-rsa]
   # proxy:                     # optional jump host / bastion
   #   host: bastion.example.com
   #   username: jumper
@@ -201,7 +206,14 @@ sync:
 | `host_key` | ³ | - | SHA256 fingerprint(s), one per line. |
 | `known_hosts` | ³ | - | `known_hosts`-format host key(s); alternative to `host_key`. |
 | `allow_any_host_key` | ³ | `false` | Explicit opt-out of host key verification. |
+| `algorithms` | | - | Add legacy `key_exchanges`, `ciphers`, `macs`, or `host_key_algorithms` to the SSH negotiation policy for both the target and proxy hop. Unknown names fail; insecure additions warn and appear in the job summary. |
 | `proxy` | | - | Optional jump host; same fields (`host`, `port`, `username`, `host_key`, `known_hosts`, `allow_any_host_key`). |
+
+`connection.algorithms` is an escape hatch for a server that cannot negotiate
+modern SSH. It is additive: each configured category keeps all algorithms the
+current `golang.org/x/crypto/ssh` version classifies as supported and adds the
+named values. Categories you omit keep the library defaults exactly. Prefer
+upgrading the server, and enable only the one algorithm the server needs.
 
 ³ As in inline mode, exactly one of `host_key`/`known_hosts`/`allow_any_host_key` is required, per hop.
 

--- a/docs/easysftp.example.yml
+++ b/docs/easysftp.example.yml
@@ -24,6 +24,14 @@ connection:
   # Without host_key or known_hosts the run fails. To explicitly accept any
   # host key instead (NOT recommended, allows man-in-the-middle attacks):
   # allow_any_host_key: true
+
+  # Legacy-server escape hatch. Omit this whole block unless the server cannot
+  # negotiate modern SSH; insecure additions warn and appear in the summary.
+  # algorithms:
+  #   key_exchanges: [diffie-hellman-group1-sha1]
+  #   ciphers: [aes128-cbc]
+  #   macs: [hmac-sha1-96]
+  #   host_key_algorithms: [ssh-rsa]
   #
   # Optional jump host (bastion), like OpenSSH's ProxyJump. Credentials come
   # from the proxy-password / proxy-private-key action inputs.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,6 +36,25 @@ release; do not bypass checksum verification.
 
 ## Connection problems
 
+### `ssh: handshake failed: no common algorithm ...`
+
+The server and easySFTP could not agree on a key exchange, cipher, MAC, or
+host-key signature algorithm. This commonly means the server offers only an
+obsolete algorithm. Upgrading the SSH server is the safest fix. When that is
+not possible, config mode has an explicit additive escape hatch:
+
+```yaml
+connection:
+  algorithms:
+    key_exchanges: [diffie-hellman-group1-sha1] # example only
+```
+
+The error normally names the missing category and the server's algorithm.
+Configure only that category and value. Unknown algorithms are rejected;
+algorithms classified as insecure by the bundled SSH library produce a
+warning and are listed in the job summary. The same additions are offered to
+an optional proxy hop, with modern algorithms retained ahead of them.
+
 ### `connecting to <host>:22: dial tcp ...: i/o timeout`
 
 The runner cannot reach the server.

--- a/internal/config/algorithms_test.go
+++ b/internal/config/algorithms_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestConfigFileSSHAlgorithms(t *testing.T) {
+	cfg, err := loadFile(t, `version: 3
+connection:
+  host: h
+  username: u
+  algorithms:
+    key_exchanges: [diffie-hellman-group1-sha1, diffie-hellman-group1-sha1]
+    ciphers: [aes128-cbc]
+    macs: [hmac-sha1-96]
+    host_key_algorithms: [ssh-rsa]
+deployments:
+  web:
+    source: a
+    target: /b
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(cfg.Algorithms.KeyExchanges, []string{"diffie-hellman-group1-sha1"}) {
+		t.Fatalf("key exchanges: %#v", cfg.Algorithms.KeyExchanges)
+	}
+	for _, name := range []string{"diffie-hellman-group1-sha1", "aes128-cbc", "hmac-sha1-96", "ssh-rsa"} {
+		if !slices.Contains(cfg.Algorithms.Insecure, name) {
+			t.Errorf("insecure algorithms do not contain %q: %#v", name, cfg.Algorithms.Insecure)
+		}
+	}
+}
+
+func TestConfigFileRejectsUnknownSSHAlgorithm(t *testing.T) {
+	_, err := loadFile(t, `version: 3
+connection:
+  host: h
+  username: u
+  algorithms:
+    ciphers: [rot13]
+deployments:
+  web:
+    source: a
+    target: /b
+`)
+	if err == nil || !strings.Contains(err.Error(), `connection.algorithms.ciphers' contains unsupported SSH algorithm "rot13"`) {
+		t.Fatalf("unknown algorithm error: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,24 @@ type Proxy struct {
 	AllowAnyHostKey bool
 }
 
+// SSHAlgorithms contains additive SSH negotiation choices from
+// connection.algorithms. Empty slices preserve x/crypto/ssh's defaults for
+// that category. Insecure records the explicitly requested algorithms which
+// x/crypto/ssh classifies as insecure, so the uploader and job summary can
+// report the security tradeoff without classifying the same input again.
+type SSHAlgorithms struct {
+	KeyExchanges      []string
+	Ciphers           []string
+	MACs              []string
+	HostKeyAlgorithms []string
+	Insecure          []string
+}
+
+// Configured reports whether any SSH algorithm category was explicitly set.
+func (a SSHAlgorithms) Configured() bool {
+	return len(a.KeyExchanges) > 0 || len(a.Ciphers) > 0 || len(a.MACs) > 0 || len(a.HostKeyAlgorithms) > 0
+}
+
 // Safety holds the safety limits applied before any destructive operation.
 // The field and type names mirror the config file's "safety" section on
 // purpose: a name that drifts from the YAML key leaks into error messages
@@ -147,6 +165,9 @@ type Config struct {
 	// pinned keys and without this opt-in, the run fails instead of talking
 	// to an unverified server.
 	AllowAnyHostKey bool
+	// Algorithms adds explicitly requested SSH algorithms to the safe set for
+	// both the target and an optional proxy hop. It is config-file-only.
+	Algorithms SSHAlgorithms
 
 	// Proxy, if non-nil, routes the connection through a jump host.
 	Proxy *Proxy

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -3,9 +3,11 @@ package config
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,13 +28,21 @@ type yamlConfig struct {
 }
 
 type yamlConnection struct {
-	Host            string     `yaml:"host"`
-	Port            int        `yaml:"port"`
-	Username        string     `yaml:"username"`
-	HostKey         string     `yaml:"host_key"`
-	KnownHosts      string     `yaml:"known_hosts"`
-	AllowAnyHostKey bool       `yaml:"allow_any_host_key"`
-	Proxy           *yamlProxy `yaml:"proxy"`
+	Host            string         `yaml:"host"`
+	Port            int            `yaml:"port"`
+	Username        string         `yaml:"username"`
+	HostKey         string         `yaml:"host_key"`
+	KnownHosts      string         `yaml:"known_hosts"`
+	AllowAnyHostKey bool           `yaml:"allow_any_host_key"`
+	Algorithms      yamlAlgorithms `yaml:"algorithms"`
+	Proxy           *yamlProxy     `yaml:"proxy"`
+}
+
+type yamlAlgorithms struct {
+	KeyExchanges      []string `yaml:"key_exchanges"`
+	Ciphers           []string `yaml:"ciphers"`
+	MACs              []string `yaml:"macs"`
+	HostKeyAlgorithms []string `yaml:"host_key_algorithms"`
 }
 
 type yamlProxy struct {
@@ -122,15 +132,16 @@ func (a autoInt) auto() bool { return !a.set }
 // named deployment). checkKeys walks the raw YAML against it so a typo fails
 // with a suggestion instead of a silent no-op or a cryptic decoder error.
 var allowedKeys = map[string][]string{
-	"":                 {"version", "connection", "defaults", "deployments", "safety", "advanced", "permissions", "sync"},
-	"connection":       {"host", "port", "username", "host_key", "known_hosts", "allow_any_host_key", "proxy"},
-	"connection.proxy": {"host", "port", "username", "host_key", "known_hosts", "allow_any_host_key"},
-	"defaults":         {"mode", "exclude"},
-	"deployments.*":    {"source", "target", "mode", "exclude"},
-	"safety":           {"max_deletes"},
-	"advanced":         {"retries", "timeout", "stall_timeout", "concurrency", "request_concurrency", "connections", "skip_unchanged", "auto_cache"},
-	"permissions":      {"files", "directories", "preserve_times"},
-	"sync":             {"fast_path", "manifest"},
+	"":                      {"version", "connection", "defaults", "deployments", "safety", "advanced", "permissions", "sync"},
+	"connection":            {"host", "port", "username", "host_key", "known_hosts", "allow_any_host_key", "algorithms", "proxy"},
+	"connection.algorithms": {"key_exchanges", "ciphers", "macs", "host_key_algorithms"},
+	"connection.proxy":      {"host", "port", "username", "host_key", "known_hosts", "allow_any_host_key"},
+	"defaults":              {"mode", "exclude"},
+	"deployments.*":         {"source", "target", "mode", "exclude"},
+	"safety":                {"max_deletes"},
+	"advanced":              {"retries", "timeout", "stall_timeout", "concurrency", "request_concurrency", "connections", "skip_unchanged", "auto_cache"},
+	"permissions":           {"files", "directories", "preserve_times"},
+	"sync":                  {"fast_path", "manifest"},
 }
 
 // checkKeys validates every mapping key in the file against allowedKeys and
@@ -277,6 +288,10 @@ func applyYAML(cfg *Config, yc *yamlConfig) error {
 	cfg.HostKeyFingerprints = splitLines(conn.HostKey)
 	cfg.KnownHosts = strings.TrimSpace(conn.KnownHosts)
 	cfg.AllowAnyHostKey = conn.AllowAnyHostKey
+	var err error
+	if cfg.Algorithms, err = parseSSHAlgorithms(conn.Algorithms); err != nil {
+		return err
+	}
 	if p := conn.Proxy; p != nil {
 		proxy := &Proxy{
 			Server:              strings.TrimSpace(p.Host),
@@ -368,7 +383,6 @@ func applyYAML(cfg *Config, yc *yamlConfig) error {
 	cfg.SkipUnchanged = yc.Advanced.SkipUnchanged
 	cfg.AutoCachePath = strings.TrimSpace(yc.Advanced.AutoCache)
 
-	var err error
 	if cfg.FileMode, err = parseMode(yc.Permissions.Files, "permissions.files"); err != nil {
 		return err
 	}
@@ -382,4 +396,46 @@ func applyYAML(cfg *Config, yc *yamlConfig) error {
 		return err
 	}
 	return nil
+}
+
+func parseSSHAlgorithms(y yamlAlgorithms) (SSHAlgorithms, error) {
+	supported := ssh.SupportedAlgorithms()
+	insecure := ssh.InsecureAlgorithms()
+	var out SSHAlgorithms
+
+	categories := []struct {
+		name        string
+		requested   []string
+		supported   []string
+		insecure    []string
+		destination *[]string
+	}{
+		{"key_exchanges", y.KeyExchanges, supported.KeyExchanges, insecure.KeyExchanges, &out.KeyExchanges},
+		{"ciphers", y.Ciphers, supported.Ciphers, insecure.Ciphers, &out.Ciphers},
+		{"macs", y.MACs, supported.MACs, insecure.MACs, &out.MACs},
+		{"host_key_algorithms", y.HostKeyAlgorithms, supported.HostKeys, insecure.HostKeys, &out.HostKeyAlgorithms},
+	}
+
+	for _, category := range categories {
+		seen := map[string]bool{}
+		for _, raw := range category.requested {
+			name := strings.TrimSpace(raw)
+			path := "connection.algorithms." + category.name
+			if name == "" {
+				return SSHAlgorithms{}, fmt.Errorf("'%s' contains an empty algorithm name", path)
+			}
+			if !slices.Contains(category.supported, name) && !slices.Contains(category.insecure, name) {
+				return SSHAlgorithms{}, fmt.Errorf("'%s' contains unsupported SSH algorithm %q", path, name)
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			*category.destination = append(*category.destination, name)
+			if slices.Contains(category.insecure, name) && !slices.Contains(out.Insecure, name) {
+				out.Insecure = append(out.Insecure, name)
+			}
+		}
+	}
+	return out, nil
 }

--- a/internal/uploader/algorithms_test.go
+++ b/internal/uploader/algorithms_test.go
@@ -1,0 +1,144 @@
+package uploader
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"slices"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/eiserv/easySFTP/internal/config"
+)
+
+func TestApplySSHAlgorithmsIsAdditiveByCategory(t *testing.T) {
+	client := &ssh.ClientConfig{}
+	applySSHAlgorithms(client, config.SSHAlgorithms{
+		KeyExchanges:      []string{ssh.InsecureKeyExchangeDH1SHA1},
+		Ciphers:           []string{ssh.InsecureCipherAES128CBC},
+		MACs:              []string{ssh.InsecureHMACSHA196},
+		HostKeyAlgorithms: []string{ssh.KeyAlgoRSA},
+	})
+
+	supported := ssh.SupportedAlgorithms()
+	checks := []struct {
+		name string
+		got  []string
+		safe string
+		old  string
+	}{
+		{"key exchange", client.KeyExchanges, supported.KeyExchanges[0], ssh.InsecureKeyExchangeDH1SHA1},
+		{"cipher", client.Ciphers, supported.Ciphers[0], ssh.InsecureCipherAES128CBC},
+		{"MAC", client.MACs, supported.MACs[0], ssh.InsecureHMACSHA196},
+		{"host key", client.HostKeyAlgorithms, supported.HostKeys[0], ssh.KeyAlgoRSA},
+	}
+	for _, check := range checks {
+		if len(check.got) == 0 || check.got[0] != check.safe || !slices.Contains(check.got, check.old) {
+			t.Errorf("%s list is not safe-first and additive: %#v", check.name, check.got)
+		}
+	}
+
+	defaults := &ssh.ClientConfig{}
+	applySSHAlgorithms(defaults, config.SSHAlgorithms{})
+	if defaults.KeyExchanges != nil || defaults.Ciphers != nil || defaults.MACs != nil || defaults.HostKeyAlgorithms != nil {
+		t.Fatalf("empty additions changed library defaults: %#v", defaults)
+	}
+}
+
+func TestLegacySSHAlgorithmsInteroperate(t *testing.T) {
+	cases := []struct {
+		name      string
+		algorithm string
+		configure func(*config.Config)
+		server    serverOption
+	}{
+		{
+			"key exchange",
+			ssh.InsecureKeyExchangeDH1SHA1,
+			func(cfg *config.Config) { cfg.Algorithms.KeyExchanges = []string{ssh.InsecureKeyExchangeDH1SHA1} },
+			withOnlyKeyExchange(ssh.InsecureKeyExchangeDH1SHA1),
+		},
+		{
+			"cipher",
+			ssh.InsecureCipherAES128CBC,
+			func(cfg *config.Config) { cfg.Algorithms.Ciphers = []string{ssh.InsecureCipherAES128CBC} },
+			withOnlyCipher(ssh.InsecureCipherAES128CBC),
+		},
+		{
+			"MAC",
+			ssh.InsecureHMACSHA196,
+			func(cfg *config.Config) { cfg.Algorithms.MACs = []string{ssh.InsecureHMACSHA196} },
+			withOnlyMAC(ssh.InsecureHMACSHA196),
+		},
+		{
+			"host key",
+			ssh.KeyAlgoRSA,
+			func(cfg *config.Config) { cfg.Algorithms.HostKeyAlgorithms = []string{ssh.KeyAlgoRSA} },
+			withOnlyRSAHostKey(t),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := startTestServer(t, tc.server)
+			local := t.TempDir()
+			writeTree(t, local, map[string]string{"file.txt": tc.name})
+			cfg := baseConfig(srv)
+			cfg.Uploads = []config.UploadPair{{Local: local, Remote: "/www"}}
+			tc.configure(cfg)
+			cfg.Algorithms.Insecure = []string{tc.algorithm}
+			log := &recordingLogger{testLogger: testLogger{t}}
+			if _, err := Run(context.Background(), cfg, log); err != nil {
+				t.Fatalf("legacy %s handshake failed: %v", tc.name, err)
+			}
+			algorithmWarnings := 0
+			for _, warning := range log.warnings {
+				if strings.Contains(warning, "connection.algorithms") && strings.Contains(warning, tc.algorithm) {
+					algorithmWarnings++
+				}
+			}
+			if algorithmWarnings != 1 {
+				t.Fatalf("warning for %s: %#v", tc.algorithm, log.warnings)
+			}
+		})
+	}
+}
+
+func withOnlyKeyExchange(name string) serverOption {
+	return func(s *testServer) { s.sshConfig.KeyExchanges = []string{name} }
+}
+
+func withOnlyCipher(name string) serverOption {
+	return func(s *testServer) { s.sshConfig.Ciphers = []string{name} }
+}
+
+func withOnlyMAC(name string) serverOption {
+	return func(s *testServer) { s.sshConfig.MACs = []string{name} }
+}
+
+func withOnlyRSAHostKey(t *testing.T) serverOption {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	algorithmSigner, ok := signer.(ssh.AlgorithmSigner)
+	if !ok {
+		t.Fatal("RSA signer does not implement ssh.AlgorithmSigner")
+	}
+	restricted, err := ssh.NewSignerWithAlgorithms(algorithmSigner, []string{ssh.KeyAlgoRSA})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func(s *testServer) {
+		s.hostSigner = restricted
+		s.HostPubKey = restricted.PublicKey()
+		s.HostKeySHA256 = ssh.FingerprintSHA256(restricted.PublicKey())
+	}
+}

--- a/internal/uploader/connection.go
+++ b/internal/uploader/connection.go
@@ -66,6 +66,7 @@ type hop struct {
 	fingerprints    []string
 	knownHosts      string
 	allowAnyHostKey bool
+	algorithms      config.SSHAlgorithms
 	names           hopNames
 }
 
@@ -82,12 +83,51 @@ func (h hop) clientConfig(timeout time.Duration, log Logger) (*ssh.ClientConfig,
 	if err != nil {
 		return nil, permanentError{err}
 	}
-	return &ssh.ClientConfig{
+	client := &ssh.ClientConfig{
 		User:            h.user,
 		Auth:            auth,
 		HostKeyCallback: cb,
 		Timeout:         timeout,
-	}, nil
+	}
+	applySSHAlgorithms(client, h.algorithms)
+	return client, nil
+}
+
+// applySSHAlgorithms keeps x/crypto/ssh's defaults for every category the
+// user did not mention. A mentioned category starts with every supported safe
+// algorithm, in library preference order, and appends the requested values.
+// The parser has already rejected unknown names and recorded insecure ones.
+func applySSHAlgorithms(client *ssh.ClientConfig, additions config.SSHAlgorithms) {
+	supported := ssh.SupportedAlgorithms()
+	if len(additions.KeyExchanges) > 0 {
+		client.KeyExchanges = appendAlgorithms(supported.KeyExchanges, additions.KeyExchanges)
+	}
+	if len(additions.Ciphers) > 0 {
+		client.Ciphers = appendAlgorithms(supported.Ciphers, additions.Ciphers)
+	}
+	if len(additions.MACs) > 0 {
+		client.MACs = appendAlgorithms(supported.MACs, additions.MACs)
+	}
+	if len(additions.HostKeyAlgorithms) > 0 {
+		client.HostKeyAlgorithms = appendAlgorithms(supported.HostKeys, additions.HostKeyAlgorithms)
+	}
+}
+
+func appendAlgorithms(base, additions []string) []string {
+	out := append([]string(nil), base...)
+	for _, addition := range additions {
+		found := false
+		for _, existing := range out {
+			if existing == addition {
+				found = true
+				break
+			}
+		}
+		if !found {
+			out = append(out, addition)
+		}
+	}
+	return out
 }
 
 // targetHop maps the primary connection settings onto a hop.
@@ -106,12 +146,13 @@ func targetHop(cfg *config.Config) hop {
 		fingerprints:    cfg.HostKeyFingerprints,
 		knownHosts:      cfg.KnownHosts,
 		allowAnyHostKey: cfg.AllowAnyHostKey,
+		algorithms:      cfg.Algorithms,
 		names:           names,
 	}
 }
 
 // jumpHop maps the connection.proxy settings onto a hop.
-func jumpHop(p *config.Proxy) hop {
+func jumpHop(p *config.Proxy, algorithms config.SSHAlgorithms) hop {
 	return hop{
 		addr:            net.JoinHostPort(p.Server, fmt.Sprintf("%d", p.Port)),
 		user:            p.Username,
@@ -121,6 +162,7 @@ func jumpHop(p *config.Proxy) hop {
 		fingerprints:    p.HostKeyFingerprints,
 		knownHosts:      p.KnownHosts,
 		allowAnyHostKey: p.AllowAnyHostKey,
+		algorithms:      algorithms,
 		names: hopNames{hostKey: "connection.proxy.host_key", knownHosts: "connection.proxy.known_hosts",
 			allowAny: "connection.proxy.allow_any_host_key", privateKey: "proxy-private-key"},
 	}
@@ -206,7 +248,7 @@ func dialSSH(addr string, cfg *ssh.ClientConfig) (*ssh.Client, error) {
 // target's SSH handshake (with the target's own host key verification) over
 // that tunnel. The returned cleanup closes the jump transport.
 func dialViaJump(cfg *config.Config, targetAddr string, targetConfig *ssh.ClientConfig, log Logger) (*ssh.Client, func(), error) {
-	jump := jumpHop(cfg.Proxy)
+	jump := jumpHop(cfg.Proxy, cfg.Algorithms)
 	jumpConfig, err := jump.clientConfig(cfg.Timeout, log)
 	if err != nil {
 		return nil, nil, err

--- a/internal/uploader/testserver_test.go
+++ b/internal/uploader/testserver_test.go
@@ -31,6 +31,7 @@ type testServer struct {
 	ClientKeyPEM  string
 	handlers      sftp.Handlers
 	sshConfig     *ssh.ServerConfig
+	hostSigner    ssh.Signer
 	listener      net.Listener
 
 	// Fault injection (set via options before the accept loop starts).
@@ -396,7 +397,6 @@ func startTestServer(t *testing.T, opts ...serverOption) *testServer {
 			return nil, errors.New("access denied")
 		},
 	}
-	sshConfig.AddHostKey(hostSigner)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -411,11 +411,13 @@ func startTestServer(t *testing.T, opts ...serverOption) *testServer {
 		ClientKeyPEM:  string(pem.EncodeToMemory(clientPEM)),
 		handlers:      sftp.InMemHandler(),
 		sshConfig:     sshConfig,
+		hostSigner:    hostSigner,
 		listener:      listener,
 	}
 	for _, opt := range opts {
 		opt(srv)
 	}
+	sshConfig.AddHostKey(srv.hostSigner)
 	if srv.failRename {
 		srv.handlers.FileCmd = &faultyRename{inner: srv.handlers.FileCmd}
 	}

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -14,6 +14,7 @@ package uploader
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	ignore "github.com/sabhiram/go-gitignore"
@@ -67,6 +68,9 @@ func Run(ctx context.Context, cfg *config.Config, log Logger) (*Stats, error) {
 	start := time.Now()
 	stats := &Stats{}
 	defer func() { stats.Duration = time.Since(start) }()
+	if len(cfg.Algorithms.Insecure) > 0 {
+		log.Warningf("connection.algorithms explicitly enables insecure SSH algorithm(s): %s; use these only when a server cannot negotiate modern algorithms", strings.Join(cfg.Algorithms.Insecure, ", "))
+	}
 
 	// One budget for the whole run: safety.max_deletes lives under a run-wide
 	// safety: section and is enforced like one (issue #237).

--- a/schema/easysftp.schema.json
+++ b/schema/easysftp.schema.json
@@ -45,6 +45,17 @@
           "description": "Explicitly skip host key verification. NOT recommended: allows man-in-the-middle attacks.",
           "type": "boolean"
         },
+        "algorithms": {
+          "description": "Optional SSH algorithms to allow in addition to the library's supported secure set. Use only for a legacy server that cannot negotiate modern algorithms. Unknown names are rejected and insecure additions produce a warning.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key_exchanges": { "$ref": "#/$defs/algorithmList" },
+            "ciphers": { "$ref": "#/$defs/algorithmList" },
+            "macs": { "$ref": "#/$defs/algorithmList" },
+            "host_key_algorithms": { "$ref": "#/$defs/algorithmList" }
+          }
+        },
         "proxy": {
           "description": "Optional jump host (bastion) through which the SFTP server is reached, like OpenSSH's ProxyJump. Credentials come from the proxy-password / proxy-private-key / proxy-passphrase action inputs.",
           "type": "object",
@@ -214,6 +225,14 @@
     }
   },
   "$defs": {
+    "algorithmList": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "mode": {
       "description": "How the remote target is reconciled: overlay (upload only), sync (manifest-tracked mirror) or clean (wipe, then upload).",
       "type": "string",


### PR DESCRIPTION
Closes #151

## Summary

- add config-file-only SSH algorithm additions for key exchanges, ciphers, MACs, and host-key algorithms
- validate every name against x/crypto/ssh's supported and insecure registries
- preserve library defaults for omitted categories and safe preference order for configured categories
- apply the same compatibility policy to the target and optional proxy hop
- emit one explicit warning and summary annotation when an insecure algorithm is requested
- update the schema, example configuration, reference, and troubleshooting guidance

This is an explicit compatibility escape hatch, not a silent downgrade. Unknown names fail configuration loading and insecure additions are visible in every run.

## Verification

- real SSH/SFTP interoperability tests restricted to legacy KEX, cipher, MAC, and RSA host-key negotiation
- parser tests for validation, deduplication, and secure/insecure classification
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- schema parsed with PowerShell `ConvertFrom-Json`
- `git diff --check`

The local Windows environment cannot start `-race` without CGO/GCC, so CI's Linux race job is the race-detector gate.