### PR TITLE
fix(benchmark): stop repeats=2 from storing best-of-two as a median

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -516,9 +516,15 @@ faster or slower, and `comparison[].within_noise` says so directly.
 
 A single repeat has no measured spread, so `mad_ms` is then `null` (empty in the
 CSV) rather than 0, which would read as perfect precision. That is the normal
-case for a matrix run, whose `REPEATS` default is 1 because the grid is already
-hours: its deltas have no noise floor to compare against, and the canary above is
-what stands in for one. Results stored before this change carry 0 there.
+case for a manual matrix run, whose `REPEATS` default is 1 because the grid is
+already hours: its deltas have no noise floor to compare against, and the canary
+above is what stands in for one. Results stored before this change carry 0 there.
+
+Two repeats populate `mad_ms` but under the lower-middle median it is
+structurally 0 for every cell (the median is the faster sample, so one
+deviation is 0 and that 0 is the MAD). The release matrix therefore defaults to
+three repeats, the smallest count that can yield an informative MAD (issue
+#227).
 
 Before reading a delta at all, check the run's single-stream control against the
 scenario's own MiB/s. A scenario sitting at the control was limited by the path,

--- a/internal/benchmark/driver/driver.go
+++ b/internal/benchmark/driver/driver.go
@@ -99,9 +99,26 @@ type run struct {
 func logf(format string, args ...any)  { fmt.Printf(format+"\n", args...) }
 func warnf(format string, args ...any) { fmt.Printf("::warning::"+format+"\n", args...) }
 
+
+// informativeRepeats raises two to three. Under the lower-middle median in
+// internal/benchmark/stats, two samples always report mad_ms == 0 and
+// median_ms == min_ms (best-of-two labelled as a median). Three is the
+// smallest count that can yield an informative MAD (issue #227). One-repeat
+// quick grids and already-sufficient counts are left alone.
+func informativeRepeats(n int) int {
+	if n == 2 {
+		return 3
+	}
+	return n
+}
+
 func newRun(opts Options) (*run, error) {
 	if opts.Repeats < 1 {
 		return nil, fmt.Errorf("a run needs at least one repeat, got %d", opts.Repeats)
+	}
+	if raised := informativeRepeats(opts.Repeats); raised != opts.Repeats {
+		warnf("REPEATS=%d yields mad_ms=0 under the lower-middle median (issue #227); measuring %d times instead", opts.Repeats, raised)
+		opts.Repeats = raised
 	}
 	if err := checkRemoteBase(opts.RemoteBase); err != nil {
 		return nil, err

--- a/internal/benchmark/driver/repeats_test.go
+++ b/internal/benchmark/driver/repeats_test.go
@@ -1,0 +1,15 @@
+package driver
+
+import "testing"
+
+func TestInformativeRepeatsRaisesTwoToThree(t *testing.T) {
+	// Issue #227: two is the broken release-matrix default; leave 1 and 3+ alone.
+	if got := informativeRepeats(2); got != 3 {
+		t.Errorf("informativeRepeats(2) = %d, want 3", got)
+	}
+	for _, n := range []int{1, 3, 5} {
+		if got := informativeRepeats(n); got != n {
+			t.Errorf("informativeRepeats(%d) = %d, want unchanged", n, got)
+		}
+	}
+}

--- a/internal/benchmark/stats/stats.go
+++ b/internal/benchmark/stats/stats.go
@@ -6,13 +6,19 @@
 // a slightly different rule is not comparable to the ones already published
 // (issue #190).
 //
-// Three of those edge cases are load-bearing and are pinned by tests:
+// Four of those edge cases are load-bearing and are pinned by tests:
 //
 //   - The median is the *lower* middle value for an even sample count, which is
 //     why an odd number of repeats is the better choice.
 //   - The median absolute deviation is null below two samples rather than 0: a
 //     single repeat has no measured spread at all, and a 0 there reads as
 //     perfect precision (issue #184, phase 2).
+//   - At exactly two samples the MAD is structurally 0 under that lower-middle
+//     median (the median is the min, one deviation is 0, and the lower-middle
+//     of the deviations is that 0). Three is the smallest repeat count that
+//     can yield a non-zero MAD (issue #227). The field stays populated at two
+//     so stored results stay comparable; callers that need an informative
+//     spread must measure at least three times.
 //   - A value that was never reported is null, and null is not zero. jq sorts
 //     null below every number, treats it as the identity of addition, and
 //     propagates it out of min and max over an empty list. A median over a
@@ -67,7 +73,9 @@ func MedianOf(xs []float64) float64 {
 //
 // It is the spread metric to compare a delta against: a single slow repeat,
 // which is the normal failure mode of a shared host, moves it far less than it
-// moves a standard deviation.
+// moves a standard deviation. With the lower-middle median, two samples always
+// produce Mad == 0 (issue #227); three is the smallest count that can be
+// informative.
 func Mad(xs []float64) *float64 {
 	if len(xs) < 2 {
 		return nil

--- a/internal/benchmark/stats/stats_test.go
+++ b/internal/benchmark/stats/stats_test.go
@@ -57,6 +57,31 @@ func TestMadIsNullBelowTwoSamples(t *testing.T) {
 	}
 }
 
+func TestMadAtTwoSamplesIsStructurallyZero(t *testing.T) {
+	// Issue #227: with the lower-middle median, two samples collapse. The median
+	// is the min, one absolute deviation is therefore 0, and the lower-middle of
+	// the deviations is that 0. Every cell in a repeats:2 sweep reports mad_ms
+	// == 0 and median_ms == min_ms (best-of-two labelled as a median). The field
+	// stays populated so stored results stay comparable; three is the smallest
+	// informative repeat count.
+	got := stats.Mad([]float64{10, 40})
+	if got == nil || *got != 0 {
+		t.Errorf("mad of two samples = %v, want 0", got)
+	}
+	if got := stats.MedianOf([]float64{10, 40}); got != 10 {
+		t.Errorf("median of two samples = %v, want the min (10)", got)
+	}
+}
+
+func TestMadAtThreeSamplesCanBeNonZero(t *testing.T) {
+	// The release matrix default after #227: three samples, lower-middle median
+	// 20, deviations 10/0/10, MAD 10.
+	got := stats.Mad([]float64{10, 20, 30})
+	if got == nil || *got != 10 {
+		t.Errorf("mad of three samples = %v, want 10", got)
+	}
+}
+
 func TestMadIsTheMedianDeviation(t *testing.T) {
 	// Deviations from the median 20 are 10, 0, 10, 20; their lower-middle value
 	// is 10. A standard deviation would have been dragged up by the outlier,


### PR DESCRIPTION
## Summary

Fixes #227.

With `repeats: 2` and the lower-middle median in `internal/benchmark/stats`, every cell reports `mad_ms == 0` and `median_ms == min_ms` (best-of-two labelled as a median).

### Approach

1. **Measure-time guard** (`informativeRepeats` in `internal/benchmark/driver`): when `REPEATS=2`, raise to 3 and emit an Actions warning. One-repeat quick grids and already-sufficient counts stay unchanged. The harness is built from the workflow checkout, so once this is on `main`, a release matrix that still passes `REPEATS=2` cannot store another thin sweep.
2. **Document** the n=2 structural-zero edge in `stats.go` and `benchmarks/README.md`. MAD formula unchanged so stored results stay comparable (#190).
3. **Tests** pin two-sample MAD=0 / median=min, three-sample MAD can be non-zero, and `informativeRepeats`.

### Workflow YAML (blocked on OAuth `workflow` scope)

Ideal companion change to `.github/workflows/benchmark-matrix.yml` (could not push from this token):

- `workflow_call` `repeats` default: `"2"` → `"3"`
- Description: replace "Two is the smallest number that still yields a MAD" with "Three is the smallest count that yields a MAD that can be non-zero under the lower-middle median (issue #227)."
- Header comment: "measured twice" → "measured three times…"
- Optional: note on `workflow_dispatch` repeats that `3+` is needed for an informative MAD (default stays `1` for quick grids)

Happy to add that in a follow-up once `workflow` scope is available.

Out of scope: rewriting already-stored `repeats: 2` sweeps (store never rewrites).

## Test plan

- [x] `go test ./internal/benchmark/stats/ ./internal/benchmark/driver/`
- [ ] Next matrix run with `REPEATS=2` should warn and measure 3 times
- [ ] Optional workflow default bump once `workflow` scope is available